### PR TITLE
Migrate settings for Django 1.6

### DIFF
--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -74,13 +74,14 @@ APPEND_SLASH = True
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+# TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 
 USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Note: SECRET_KEY here won't be used in production!
