### PR TITLE
Handle events where input changes post-ingest or exists into future

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1761,6 +1761,11 @@ class LoadSegment(IFotEvent):
     ifot_type_desc = 'LOADSEG'
     ifot_props = ['NAME', 'SCS', 'LOAD_NAME', 'COMMENT']
 
+    lookback = 40  # days of lookback
+    lookback_delete = 20  # Remove load segments in database prior to 20 days ago
+                          # to account for potential load changes.
+    lookforward = 90  # Accept load segments planned up to 90 days in advance
+
     def __unicode__(self):
         return ('{}: {} {} scs={}'
                 .format(self.name, self.start[:17], self.load_name, self.scs))
@@ -1806,6 +1811,11 @@ class DsnComm(IFotEvent):
     ifot_type_desc = 'DSN_COMM'
     ifot_props = ['bot', 'eot', 'activity', 'config', 'data_rate', 'site', 'soe', 'station']
     ifot_types = {'DSN_COMM.bot': 'str', 'DSN_COMM.eot': 'str'}
+
+    lookback = 21  # days of lookback
+    lookback_delete = 7  # Remove all comms in database prior to 7 days ago to account
+                         # for potential schedule changes.
+    lookforward = 90  # Accept comms scheduled up to 90 days in advance
 
     def __unicode__(self):
         return ('{}: {} {}-{} {}'


### PR DESCRIPTION
The events `DsnComm` and `LoadSegment` contain data that can (and does) change in the iFOT database after having been ingested into Kadi.  The normal process never re-ingests the same event and doesn't allow for events changing or disappearing.  This PR adds two new class-level attributes:
- `lookback_delete`: delete all events after `NOW - lookback_delete` prior to doing daily ingest
- `lookforward`: ingest events out to `NOW + lookforward`
