### PR TITLE
Fix lefthand side spacing

### DIFF
--- a/kadi/events/templates/events/index.html
+++ b/kadi/events/templates/events/index.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
 
-{% block content %}
-
+{% block moreheader %}
 <h2> Kadi Events  </h2>
+{% endblock %}
+
+{% block content %}
 <ul>
   {% for event_model in event_models %}
   <li> <a href="{{ event_model.name }}/list">{{ event_model.description }}</a> </li>
   {% endfor %}
 </ul>
-
 {% endblock %}
 
 {% block navbuttons %}

--- a/kadi/templates/base.html
+++ b/kadi/templates/base.html
@@ -15,7 +15,8 @@
  {% block body %}
 <body>
  {% endblock %}
-<div id="header">
+<div class="row" id="header">
+
   {% block titlebar %}
   <nav class="top-bar" data-topbar role="navigation">
     <ul class="title-area">
@@ -40,26 +41,34 @@
 
     </section>
   </nav>
-    {% endblock %}
-
-  {% block moreheader %}
-  {% endblock %}
-
-  {% block navbuttons %}
   {% endblock %}
 </div>
 
-  {% block content %}
-  {% endblock %}
+<div class="row" id="header">
+  <div class="small-12 large-12 columns">
+    {% block moreheader %}
+    {% endblock %}
+  </div>
+</div>
+
+<div class="row" id="navinput">
+  <div class="small-12 large-12 columns">
+    {% block navbuttons %}
+    {% endblock %}
+  </div>
+</div>
+
+<div class="row" id="maincontent">
+  <div class="small-12 large-12 columns">
+    {% block content %}
+    {% endblock %}
+  </div>
+</div>
 
 <footer class="row">
   <div class="large-12 columns">
     <hr/>
-    <div class="row">
-      <div class="large-12 columns">
-        <p> Kadi version {{kadi_version}}</p>
-      </div>
-    </div>
+    <p> Kadi version {{kadi_version}}</p>
   </div>
 </footer>
 


### PR DESCRIPTION
This is a very small update that wraps the main html content, via the base template, in a `<div class="small-12 large-12 columns">` tag, increasing the spacing on the lefthand side to be more aesthetically pleasing (along with defining the grid structure for this row). This class definition within the above `<div>` tag is a common part of the row/column definition used by the foundation web framework. I tested this using the method previously suggested so it is ready for review.
