### PR TITLE
stop time is before start time

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1845,8 +1845,8 @@ class IFotEvent(BaseEvent):
                     DateTime(event[st]).date
                 except:
                     # Fail, roll back to the tstart/tstop version
-                    logger.info('WARNING: Bad value of ifot_evt[{}.{}] = {}'
-                                .format(cls.ifot_type_desc, st, event[st]))
+                    logger.info('WARNING: Bad value of ifot_evt[{}.{}] = "{}" at {}'
+                                .format(cls.ifot_type_desc, st, event[st], ifot_evt['tstart']))
                     event[st] = ifot_evt[tst]
 
             event['ifot_id'] = ifot_evt['id']

--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -134,6 +134,9 @@ def update(EventModel, date_stop):
                 continue
 
             logger.info('Added {} {}'.format(cls_name, event_model))
+            if 'dur' in event and event['dur'] < 0:
+                logger.info('WARNING: negative event duration for {} {}'
+                            .format(cls_name, event_model))
 
             # Add any foreign rows (many to one)
             for foreign_cls_name, rows in event.get('foreign', {}).items():

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 12, None, False)
+VERSION = (0, 12, 1, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
After importing Kadi, I grab all the CAPS run from 2015:001 to 2015:

In [1]: from kadi import events

In [2]: capsrun = events.caps.filter('2015:001', '2015:026').table

Looking at the 14th row I see this:

In [3]: capsrun[13]
Out[3]: 
<Row 13 of table
 values=(448701, '2015:008:00:43:24', '2015:007:23:40:03.303', 537065071.184, 537061270.487, -3800.697000026703, '1339', 'Command ACIS I CTI measurement via RTS', '', '', 'http://occweb.occ.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/')
 dtype=[('ifot_id', '<i8'), ('start', '|S21'), ('stop', '|S21'), ('tstart', '<f8'), ('tstop', '<f8'), ('dur', '<f8'), ('num', '|S10'), ('title', '|S60'), ('descr', '|S1'), ('notes', '|S1'), ('link', '|S108')]>

Notice that start is after stop:

In [4]: capsrun[13]['start']
Out[4]: '2015:008:00:43:24'

In [5]: capsrun[13]['stop']
Out[5]: '2015:007:23:40:03.303'

This doesn't happen with all the rows.


