### PR TITLE
Fix task_schedule user and add an OCC version

### DIFF
--- a/task_schedule_occ.cfg
+++ b/task_schedule_occ.cfg
@@ -20,7 +20,7 @@ master_log   kadi.log             # Composite master log (created in log_dir)
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
-alert       aca@head.cfa.harvard.edu
+alert       SOT
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab


### PR DESCRIPTION
Note that having the `--ftp` flag is OK even though the currently installed OCC version does not.