### PR TITLE
Make IntegrityError message handling be case-insensitive

### DIFF
--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -127,7 +127,7 @@ def update(EventModel, date_stop):
                 event_model = EventModel.from_dict(event, logger)
                 event_model.save(force_insert=True)
             except django.db.utils.IntegrityError as err:
-                if 'unique' not in str(err):
+                if not re.search('unique', str(err), re.IGNORECASE):
                     raise
                 logger.verbose('Skipping {} at {}: already in database ({})'
                                .format(cls_name, event['start'], err))

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 12, 1, False)
+VERSION = (0, 12, 2, False)
 
 
 class SemanticVersion(object):

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -67,14 +67,17 @@ class SemanticVersion(object):
 
         except:
             from subprocess import Popen, PIPE
-            p = Popen(['git', 'rev-list', 'HEAD'], cwd=self.version_dir,
-                      stdout=PIPE, stderr=PIPE, stdin=PIPE)
-            stdout, stderr = p.communicate()
+            try:
+                p = Popen(['git', 'rev-list', 'HEAD'], cwd=self.version_dir,
+                          stdout=PIPE, stderr=PIPE, stdin=PIPE)
+                stdout, stderr = p.communicate()
 
-            if p.returncode == 0:
-                revs = stdout.split('\n')
-                git_revs, git_sha = len(revs), revs[0][:7]
-            else:
+                if p.returncode == 0:
+                    revs = stdout.split('\n')
+                    git_revs, git_sha = len(revs), revs[0][:7]
+                else:
+                    git_revs, git_sha = None, None
+            except:
                 git_revs, git_sha = None, None
 
         return git_revs, git_sha


### PR DESCRIPTION
The `update_archive.py` process was failing because the SQLite3 error message for a non-unique key changed between ActivePython sqlite3 and Anaconda Python sqlite3.  the word `unique` became upper case.

As a somewhat unrelated patch, fix `version.py` to not fail hard if there is no git executable.