### PR TITLE
Make web-only apps optional

### DIFF
--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -62,9 +62,17 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'kadi.events',
-    'mica.web',
-    'find_attitude.web',
 )
+
+OPTIONAL_APPS = ('mica.web', 'find_attitude.web')
+for app in OPTIONAL_APPS:
+    try:
+        __import__(app)
+    except ImportError:
+        pass
+    else:
+        INSTALLED_APPS += (app,)
+
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Something like this should work:
```
OPTIONAL_APPS = ('mica.web', 'find_attitude')
for app in OPTIONAL_APPS:
    try:
        __import__(app)
    except ImportError:
        pass
    else:
        INSTALLED_APPS += app
```
@jeanconn - we discussed this before, don't remember if it ever got to the point of some code.  