### PR TITLE
Change quaternion division to delta quaternion

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1438,7 +1438,7 @@ class Manvr(TlmEvent):
             out[label + '_dec'] = float(quat.dec)
             out[label + '_roll'] = float(quat.roll)
 
-        dq = quats['stop'] / quats['start']  # = (wx * sa2, wy * sa2, wz * sa2, ca2)
+        dq = quats['start'].dq(quats['stop'])  # = (wx * sa2, wy * sa2, wz * sa2, ca2)
         q3 = np.abs(dq.q[3])
         if q3 >= 1.0:  # Floating point error possible
             out['angle'] = 0.0


### PR DESCRIPTION
Original quaternion division expression gives correct maneuver angle but wrong delta quaternion.  Quaternion 0.4 issues a warning about this incorrect usage.

To do:
- [ ] Update version
- [ ] Test by copying flight events database, dropping some rows, reprocess, confirm same maneuvers.