### PR TITLE
Add StarAcq event type and infrastructure for emailed alerts

### DIFF
--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -173,7 +173,7 @@ def send_alerts_mail(alerts):
 
     for alert in alerts:
         sender = os.environ['USER'] + '@head.cfa.harvard.edu'
-        recipients = ['taldcroft@cfa.harvard.edu']
+        recipients = ['aca_alert@cfa.harvard.edu']
         msg = MIMEText(alert['message'])
         msg['Subject'] = alert['subject']
         msg['From'] = sender

--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -10,6 +10,7 @@ import six
 from . import occweb
 import pyyaks.logger
 from Chandra.Time import DateTime
+from Ska.engarchive import fetch_eng as fetch
 
 logger = None  # for pyflakes
 
@@ -42,6 +43,9 @@ def get_opt(args=None):
     parser.add_argument("--data-root",
                         default=".",
                         help="Root data directory (default='.')")
+    parser.add_argument("--data-source",
+                        default="cxc",
+                        help="Telemetry data source (cxc|maude) (default='cxc')")
     parser.add_argument("--occ",
                         default=OCC_SOT_ACCOUNT,
                         action='store_true',
@@ -99,7 +103,7 @@ def update(EventModel, date_stop):
             delete_date = DateTime(update.date) - EventModel.lookback_delete
             delete_from_date(EventModel, delete_date, set_update_date=False)
 
-    if duration < 0.5:
+    if duration < -0.5:
         logger.info('Skipping {} events because update duration={:.1f} is < 0.5 day'
                     .format(cls_name, duration))
         return
@@ -132,6 +136,10 @@ def update(EventModel, date_stop):
                 logger.verbose('Skipping {} at {}: already in database ({})'
                                .format(cls_name, event['start'], err))
                 continue
+            else:
+                alerts = event.get('event-alerts')  # List of alert dicts
+                if alerts:
+                    send_alerts_mail(alerts)
 
             logger.info('Added {} {}'.format(cls_name, event_model))
             if 'dur' in event and event['dur'] < 0:
@@ -155,6 +163,29 @@ def update(EventModel, date_stop):
     update.save()
 
 
+def send_alerts_mail(alerts):
+    """
+    Send an email for each alert in the list.  An alert is a dict with
+    keys for ``subject`` and ``message``.
+    """
+    import smtplib
+    from email.mime.text import MIMEText
+
+    for alert in alerts:
+        sender = os.environ['USER'] + '@head.cfa.harvard.edu'
+        recipients = ['taldcroft@cfa.harvard.edu']
+        msg = MIMEText(alert['message'])
+        msg['Subject'] = alert['subject']
+        msg['From'] = sender
+        msg['To'] = ','.join(recipients)
+        if False:
+            s = smtplib.SMTP('localhost')
+            s.sendmail(sender, recipients, msg.as_string())
+            s.quit()
+        else:
+            print(msg.as_string())
+
+
 def main():
     global logger
 
@@ -173,10 +204,13 @@ def main():
     logger.info('Kadi version   : {}'.format(version.__version__))
     logger.info('Kadi path      : {}'.format(os.path.dirname(os.path.abspath(version.__file__))))
     logger.info('Event database : {}'.format(EVENTS_DB_PATH()))
+    logger.info('Telemetry source: {}'.format(opt.data_source.upper()))
     logger.info('')
     logger.info('Options:')
     for line in pformat(vars(opt)).splitlines():
         logger.info('  {}'.format(line))
+
+    fetch.data_source.set(opt.data_source)
 
     if opt.occ:
         # Get events database file from HEAD via lucky ftp

--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -103,7 +103,7 @@ def update(EventModel, date_stop):
             delete_date = DateTime(update.date) - EventModel.lookback_delete
             delete_from_date(EventModel, delete_date, set_update_date=False)
 
-    if duration < -0.5:
+    if duration < 0.5:
         logger.info('Skipping {} events because update duration={:.1f} is < 0.5 day'
                     .format(cls_name, duration))
         return
@@ -178,12 +178,9 @@ def send_alerts_mail(alerts):
         msg['Subject'] = alert['subject']
         msg['From'] = sender
         msg['To'] = ','.join(recipients)
-        if False:
-            s = smtplib.SMTP('localhost')
-            s.sendmail(sender, recipients, msg.as_string())
-            s.quit()
-        else:
-            print(msg.as_string())
+        s = smtplib.SMTP('localhost')
+        s.sendmail(sender, recipients, msg.as_string())
+        s.quit()
 
 
 def main():

--- a/kadi/update_events.py
+++ b/kadi/update_events.py
@@ -103,7 +103,7 @@ def update(EventModel, date_stop):
             delete_date = DateTime(update.date) - EventModel.lookback_delete
             delete_from_date(EventModel, delete_date, set_update_date=False)
 
-    if duration < 0.5:
+    if duration < 0.0:
         logger.info('Skipping {} events because update duration={:.1f} is < 0.5 day'
                     .format(cls_name, duration))
         return

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 13, 0, False)
+VERSION = (3, 14, None, False)
 
 
 class SemanticVersion(object):

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 14, None, False)
+VERSION = (3, 14, None, True)
 
 
 class SemanticVersion(object):

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -40,8 +40,7 @@ alert       aca@head.cfa.harvard.edu
 <task kadi>
       cron       * * * * *
       check_cron * * * * *
-      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi
-      exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
+      exec update_events --data-root=$ENV{SKA_DATA}/kadi --model=StarAcq --data-source=maude
       <check>
         <error>
           #    File           Expression

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -20,7 +20,7 @@ master_log   kadi.log             # Composite master log (created in log_dir)
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
-alert       aca@head.cfa.harvard.edu
+alert       taldcroft@cfa.harvard.edu
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab


### PR DESCRIPTION
This adds a new kadi event that has the number of acq stars ID'd and which ones, along with the size of one-shots.  This is slightly messy and might not end up being merged.  However, it will be run in the short term on the side at 2 hour intervals to provide visibility into metrics related to gyro bias variations and mitigation.  This might belong elsewhere (like attitude_error_mon), but decided the existing infrastructure in kadi was useful for this.

Note also the new flag to use MAUDE instead of CXC as the telemetry data source.

To do:

- [ ] Fix docstring
- [ ] Change email address
- [x] Update task_schedule to only update this model and use MAUDE
- [x] Install and run on the side

@jeanconn - any opinion on the difference between using `localhost` vs. `head.cfa.harvard.edu` for the SMTP server?