### PR TITLE
Py3 compatibility for occweb

### DIFF
--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 14, 0, False)
+VERSION = (3, 14, 1, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Was kadi ever passing occweb tests on Py3?  I'm confused because I thought ska_testr was OK on Ska3, but that isn't what I'm now seeing.

Anyway I noticed these test failures and so fixed the code to pass on Py3.

Closes #101