### PR TITLE
Work around issues with sqlite3 database being locked during updates

### DIFF
--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 15, 1, False)
+VERSION = (3, 15, 2, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
This is a workaround for problems like:
```
2017-07-19 10:01:09,238 Updating Scs107 events from 2017:178:14:01:05 to 2017:200:14:01:04
2017-07-19 10:01:19,455 Deleting 34 LoadSegment events after 2017:180:14:01:04.585
Traceback (most recent call last):
  File "/proj/sot/ska/share/kadi/update_events", line 12, in <module>
    update_events.main()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/kadi/update_events.py", line 221, in main
    update(EventModel, date_stop)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/kadi/update_events.py", line 100, in update
    delete_from_date(EventModel, delete_date, set_update_date=False)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/kadi/update_events.py", line 72, in delete_from_date
    events.delete()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/models/query.py", line 465, in delete
    collector.delete()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/models/deletion.py", line 282, in delete
    sender=model, instance=obj, using=self.using
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/transaction.py", line 305, in __exit__
    connection.commit()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/backends/__init__.py", line 168, in commit
    self._commit()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/backends/__init__.py", line 136, in _commit
    return self.connection.commit()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/utils.py", line 99, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/django/db/backends/__init__.py", line 136, in _commit
    return self.connection.commit()
django.db.utils.OperationalError: database is locked
```
This PR has been tested by running the `ska_testr/packages/kadi/test_regression_long.sh` test, once via ska_testr in Ska flight and once by hand in the repo for this PR.  Outputs were diffed and no diffs were seen.

I have been unable to reproduce the databased locked problem.  I tried locally starting the process to update the database over a 30 day period, then in a separate window repeatedly query the events database.  No problem, no joy.  So most of this code is not tested and just needs to be looked at carefully.

Plan B was to make a local copy of the events database, update that, and then copy back.  But even then it would be better to not have the whole update process stop cold.  My feeling is to try this and see if it works.  We'll still see warnings pop up if the database was locked.