### PR TITLE
Fix a couple of issues in continuity

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1225,6 +1225,8 @@ def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000)):
 
     for lookback in lookbacks:
         cmds = commands.get_cmds(stop - lookback, stop)
+        if len(cmds) == 0:
+            continue
 
         for state_key in state_keys:
             # Don't bother if we already have a value for this key.

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1078,7 +1078,7 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
 
         # Some transition classes (e.g. Maneuver) might put in transitions that
         # extend past the stop time.  Break out of loop on the first one.
-        if date >= stop:
+        if date > stop:
             break
 
         # If transition is at a new date from current state then break the current state

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -914,3 +914,16 @@ def test_continuity_just_after_command():
     # 1 msec later
     cont = states.get_continuity('2018:001:11:52:10.176', 'targ_q1')
     assert cont['__dates__']['targ_q1'] == '2018:001:11:52:10.175'
+
+
+def test_continuity_far_future():
+    """
+    Test that using a continuity date in the future (well past commamds)
+    works.
+    """
+    # Now + 150 days.  Don't know the answer but just make sure this
+    # runs to completion.  The lookbacks of 7 and 30 days should fail
+    # but 180 days will get something.
+    cont = states.get_continuity(DateTime() + 150, 'obsid')
+    assert 'obsid' in cont
+    assert 'obsid' in cont['__dates__']

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -901,3 +901,16 @@ def test_regress_eclipse():
 2018:005:05:12:26.278 2018:006:12:00:00.000      DAY    eclipse
 """
     compare_regress_output(regress, 'eclipse')
+
+
+def test_continuity_just_after_command():
+    """
+    Fix issue where continuity required having at least one other
+    command after the relevant continuity command.
+    """
+    cont = states.get_continuity('2018:001:12:00:00', 'targ_q1')
+    assert cont['__dates__']['targ_q1'] == '2018:001:11:52:10.175'
+
+    # 1 msec later
+    cont = states.get_continuity('2018:001:11:52:10.176', 'targ_q1')
+    assert cont['__dates__']['targ_q1'] == '2018:001:11:52:10.175'

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 15, 2, False)
+VERSION = (3, 15, 3, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
- If the state-changing command was the last command, then that state got dropped and continuity got the wrong answer
- Query for continuity crashed for times far in the future (where the first 7-day lookback got no commands

@jeanconn - when you have a chance next week please review and (hopefully) merge and install to Ska HEAD flight, test, ska3 flight and GRETA test and ska3.

Ran self tests in ska and ska3 on kadi.