### PR TITLE
 Only set XDG_CONFIG_HOME in production web-server environment

### DIFF
--- a/NOTES.web-test-install.rst
+++ b/NOTES.web-test-install.rst
@@ -31,6 +31,9 @@ Test install
   # Install into TEST_PREFIX with flat kadi/ dir (without using egg)
   python setup.py install --prefix=$TEST_PREFIX --old-and-unmanageable
 
+  # Run self tests (in particular note that the xdg_config test gives expected results)
+  python setup.py test --args='-k test_events -s -v'
+
 Install other packages (e.g. mica) to TEST_PREFIX if necessary
 
 Run server and test
@@ -66,6 +69,9 @@ Production installation
   python setup.py install --prefix=$WEB_KADI --old-and-unmanageable
 
   ls -ld $PYTHONPATH/kadi*
+
+  # Run self tests (in particular note that the xdg_config test gives expected results)
+  python setup.py test --args='-k test_events -s -v'
 
 Restart::
 

--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -11,12 +11,29 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 from __future__ import print_function
 
 # Build paths inside the project like this: join(BASE_DIR, ...)
+import sys
 import os
 from os.path import join, dirname, realpath
 os.environ.setdefault('SKA', '/proj/sot/ska')
-os.environ.setdefault('XDG_CONFIG_HOME',
-                      join(os.environ['SKA'], 'data', 'config'))
-os.environ.setdefault('XDG_CACHE_HOME', os.environ['XDG_CONFIG_HOME'])
+
+# Check if this instance is running in the production Apache kadi web server.
+# If so set XDG_CONFIG_HOME and friend to make sure that the astropy config is
+# stable for production and is not coming from the config in the user home dir.
+# This will put the config file in $SKA/data/kadi/config.
+#
+# This code relies on the fact that currently in this case (production) kadi is
+# installed into /proj/web-kadi and conf/httpd.conf contains: WSGIPythonPath
+# /proj/web-kadi/lib/python2.7/site-packages.
+#
+# See also
+# https://stackoverflow.com/questions/26979579/django-mod-wsgi-set-os-environment-variable-from-apaches-setenv
+# for useful commentary on problems just using SetEnv in the conf file.  Also
+# search email for XDG_CONFIG_HOME for more discussion and motivation.
+
+if any(pth.startswith('/proj/web-kadi') for pth in sys.path):
+    os.environ.setdefault('XDG_CONFIG_HOME',
+                          join(os.environ['SKA'], 'data', 'config'))
+    os.environ.setdefault('XDG_CACHE_HOME', os.environ['XDG_CONFIG_HOME'])
 
 BASE_DIR = dirname(dirname(realpath(__file__)))
 

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 15, 3, False)
+VERSION = (3, 15, 4, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
**Rationale**

This bug-fix patch eliminates the issue of accidentally creating or depending on config files in `$SKA/data/config`.

**Interface impact**

No change in user interface.

**Testing**

This PR passes relevant unit tests in Ska and Ska3.  It also passes a new test script that can only be run as a standalone script; it can't work as a pytest script (as far as I can tell) because it relies on updating the Python path prior to import kadi.

There is a new *unrelated* fail in `test_occweb.py` which is also now occurring in the installed version in Ska.  This is due to some issue with the lucky configuration, but since the relevant code `occweb.py` is unchanged, this unit test fail is OK.

**Review**

This has been reviewed by Jean Connelly and John Zuhone.

**Deployment**

This will be installed to HEAD Ska / Ska3 flight and GRETA Ska test / Ska3 flight once approved.

This will eventually get installed to the production kadi web server (which provides the configured `find_attitude` functionality), but this has not been tested and must not be done without proper test, review, and FD approval.  Note that the currently installed version for the web server is 3.12.2 and that is very old.

**Backout**

The previous version can be re-installed with no trouble if a problem arises.

cc: @jzuhone 