### PR TITLE
 Add VCDU to commands archive and Py3 update capability

### DIFF
--- a/kadi/cmds/tests/test_commands.py
+++ b/kadi/cmds/tests/test_commands.py
@@ -53,9 +53,9 @@ def test_filter():
     cmd = cs[1]
 
     assert repr(cmd).startswith('<Cmd 2012:030:08:27:02.000 SIMTRANS')
-    assert repr(cmd).endswith('scs=133 step=161 timeline_id=426098449 pos=73176>')
+    assert repr(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176>')
     assert str(cmd).startswith('2012:030:08:27:02.000 SIMTRANS')
-    assert str(cmd).endswith('scs=133 step=161 timeline_id=426098449 pos=73176')
+    assert str(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176')
 
     assert cmd['pos'] == 73176
     assert cmd['step'] == 161

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -46,9 +46,9 @@ def test_get_cmds():
     cmd = cs[1]
 
     assert repr(cmd).startswith('<Cmd 2012:030:08:27:02.000 SIMTRANS')
-    assert repr(cmd).endswith('scs=133 step=161 timeline_id=426098449 pos=73176>')
+    assert repr(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176>')
     assert str(cmd).startswith('2012:030:08:27:02.000 SIMTRANS')
-    assert str(cmd).endswith('scs=133 step=161 timeline_id=426098449 pos=73176')
+    assert str(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176')
 
     assert cmd['pos'] == 73176
     assert cmd['step'] == 161
@@ -58,4 +58,4 @@ def test_get_cmds_zero_length_result():
     cmds = commands.get_cmds(date='2017:001')
     assert len(cmds) == 0
     assert cmds.colnames == ['idx', 'date', 'type', 'tlmsid', 'scs',
-                             'step', 'timeline_id', 'params']
+                             'step', 'timeline_id', 'vcdu', 'params']

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -5,6 +5,7 @@ import difflib
 
 import numpy as np
 import tables
+import tables3_api
 from six.moves import cPickle as pickle
 import six
 
@@ -106,7 +107,7 @@ def fix_nonload_cmds(nl_cmds):
             new_cmd['params']['msid'] = str(cmd['msid'])
 
         # De-unicode and de-numpy (otherwise unpickling on PY3 has problems).
-        if six.PY2 and 'params' in cmd:
+        if 'params' in cmd:
             params = new_cmd['params']
             for key, val in cmd['params'].items():
                 key = str(key)
@@ -291,7 +292,7 @@ def add_h5_cmds(h5file, idx_cmds):
     """
     # Note: reading this file uncompressed is about 5 times faster, so sacrifice file size
     # for read speed and do not use compression.
-    h5 = tables.openFile(h5file, mode='a')
+    h5 = tables.open_file(h5file, mode='a')
 
     # Convert cmds (list of tuples) to numpy structured array.  This also works for an
     # existing structured array.
@@ -303,7 +304,7 @@ def add_h5_cmds(h5file, idx_cmds):
         h5d = h5.root.data
         logger.info('Opened h5 cmds table {}'.format(h5file))
     except tables.NoSuchNodeError:
-        h5.createTable(h5.root, 'data', cmds, "cmds", expectedrows=2e6)
+        h5.create_table(h5.root, 'data', cmds, "cmds", expectedrows=2e6)
         logger.info('Created h5 cmds table {}'.format(h5file))
     else:
         date0 = min(idx_cmd[1] for idx_cmd in idx_cmds)

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -24,7 +24,8 @@ CMDS_DTYPE = [('idx', np.uint16),
               ('tlmsid', '|S10'),
               ('scs', np.uint8),
               ('step', np.uint16),
-              ('timeline_id', np.uint32)]
+              ('timeline_id', np.uint32),
+              ('vcdu', np.int32)]
 
 logger = None  # This is set as a global in main.  Define here for pyflakes.
 
@@ -87,7 +88,7 @@ def fix_nonload_cmds(nl_cmds):
     'time': 605233531.20899999,        # Ignored
     'timeline_id': None,               # Set to 0
     'tlmsid': None,                    # 'None' if None
-    'vcdu': None},                     # Ignored
+    'vcdu': None},                     # Set to -1
     """
     new_cmds = []
     for cmd in nl_cmds:
@@ -97,6 +98,7 @@ def fix_nonload_cmds(nl_cmds):
         new_cmd['tlmsid'] = str(cmd['tlmsid'])
         for key in ('scs', 'step', 'timeline_id'):
             new_cmd[key] = 0
+        new_cmd['vcdu'] = -1
 
         new_cmd['params'] = {}
         new_cmd['params']['nonload_id'] = int(cmd['id'])
@@ -108,7 +110,7 @@ def fix_nonload_cmds(nl_cmds):
             params = new_cmd['params']
             for key, val in cmd['params'].items():
                 key = str(key)
-                if isinstance(val, (str, unicode)):
+                if isinstance(val, six.string_types):
                     val = str(val)
                 else:
                     try:
@@ -252,7 +254,7 @@ def get_idx_cmds(cmds, pars_dict):
     values.
 
     Returns `idx_cmds` as a list of tuples:
-       (par_idx, date, time, cmd, tlmsid, scs, step)
+       (par_idx, date, time, cmd, tlmsid, scs, step, timeline_id, vcdu)
     """
     idx_cmds = []
 
@@ -277,7 +279,7 @@ def get_idx_cmds(cmds, pars_dict):
             pars_dict[pars_tup] = par_idx
 
         idx_cmds.append((par_idx, cmd['date'], cmd['type'], cmd.get('tlmsid'),
-                         cmd['scs'], cmd['step'], cmd['timeline_id']))
+                         cmd['scs'], cmd['step'], cmd['timeline_id'], cmd['vcdu']))
 
     return idx_cmds
 
@@ -312,7 +314,7 @@ def add_h5_cmds(h5file, idx_cmds):
         h5d_recent = h5d[idx_recent:]  # recent h5d entries
 
         # Define the column names that specify a complete and unique row
-        key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'timeline_id')
+        key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'timeline_id', 'vcdu')
 
         h5d_recent_vals = [tuple(str(row[x]) for x in key_names) for row in h5d_recent]
         idx_cmds_vals = [tuple(str(x) for x in row[1:]) for row in idx_cmds]
@@ -460,6 +462,7 @@ def read_backstop(filename):
     for bs_line in open(filename):
         bs_line = bs_line.replace(' ', '')
         date, vcdu, cmd_type, paramstr = [x for x in bs_line.split('|')]
+        vcdu = int(vcdu[:-1])  # Get rid of final '0' from '8023268 0' (where space was stripped)
         params = parse_params(paramstr)
         bs.append({'date': date,
                    'type': cmd_type,
@@ -467,6 +470,7 @@ def read_backstop(filename):
                    'tlmsid': params.get('TLMSID'),
                    'scs': params.get('SCS'),
                    'step': params.get('STEP'),
+                   'vcdu': vcdu
                    })
     return bs
 

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -402,7 +402,7 @@ def main(args=None):
 
     if pars_dict.n_updated > 0:
         with open(pars_dict_path, 'wb') as fh:
-            pickle.dump(pars_dict, fh, protocol=-1)
+            pickle.dump(pars_dict, fh, protocol=2)
             logger.info('Wrote {} pars_dict values ({} new) to {}'
                         .format(len(pars_dict), pars_dict.n_updated, pars_dict_path))
     else:

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 15, 5, False)
+VERSION = (3, 16, None, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
This also includes tweaks to `update_cmds.py` so that it generates cmds files using Ska3 (current /proj/sot/ska3/test 2018.08.02-a5c0a36) which pass tests.

### Testing

**Update_cmds with /proj/sot/ska3/test**
- [x] Pass tests using /proj/sot/ska3/test
- [x] Pass tests using /proj/sot/ska

**Update_cmds with /proj/sot/ska/flight**
- [x] Pass tests using /proj/sot/ska3/test
- [x] Pass tests using /proj/sot/ska

### Deployment

- Wait for subsequent PR to make updates hourly.