### PR TITLE
Break events and commands processing into separate task_schedules

### DIFF
--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -1,7 +1,7 @@
 # Configuration file for task_schedule.pl to run astromon jobs
 
-subject           Kadi events database
-timeout           10000             # Default tool timeout
+subject           Kadi commands database
+timeout           1000              # Default tool timeout
 heartbeat_timeout 10                # Maximum age of heartbeat file (seconds)
 iterations        1                 # Run once then shut down task_schedule
 print_error       1                 # Print full log of errors
@@ -14,13 +14,13 @@ loud              0                 # Run loudly or quietly (production mode)
 data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
-master_log   kadi.log             # Composite master log (created in log_dir)
+master_log   kadi_cmds.log             # Composite master log (created in log_dir)
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
-alert       SOT
+alert       aca@head.cfa.harvard.edu
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab
@@ -37,10 +37,9 @@ alert       SOT
 # executed only once for each <number> of times the task is executed.  In the
 # example below, the commands are done once each 1, 2, and 4 minutes, respectively.
 
-<task kadi>
+<task kadi_cmds>
       cron       * * * * *
       check_cron * * * * *
-      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi
       exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
       <check>
         <error>

--- a/task_schedule_events.cfg
+++ b/task_schedule_events.cfg
@@ -1,0 +1,53 @@
+# Configuration file for task_schedule.pl to run astromon jobs
+
+subject           Kadi events database
+timeout           10000             # Default tool timeout
+heartbeat_timeout 10                # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
+log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
+bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
+master_log   kadi_events.log             # Composite master log (created in log_dir)
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+alert       aca@head.cfa.harvard.edu
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+# This has multiple jobs which get run in specified order
+# Note the syntax 'exec <number> : cmd', which means that the given command is
+# executed only once for each <number> of times the task is executed.  In the
+# example below, the commands are done once each 1, 2, and 4 minutes, respectively.
+
+<task kadi_events>
+      cron       * * * * *
+      check_cron * * * * *
+      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi
+      <check>
+        <error>
+          #    File           Expression
+          #  ----------      ---------------------------
+             kadi.log     error
+             kadi.log     warning
+             kadi.log     fatal
+        </error>
+      </check>
+</task>

--- a/task_schedule_occ_cmds.cfg
+++ b/task_schedule_occ_cmds.cfg
@@ -1,0 +1,53 @@
+# Configuration file for task_schedule.pl to run astromon jobs
+
+subject           Kadi events database
+timeout           10000             # Default tool timeout
+heartbeat_timeout 10                # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
+log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
+bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
+master_log   kadi_cmds.log             # Composite master log (created in log_dir)
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+alert       SOT
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+# This has multiple jobs which get run in specified order
+# Note the syntax 'exec <number> : cmd', which means that the given command is
+# executed only once for each <number> of times the task is executed.  In the
+# example below, the commands are done once each 1, 2, and 4 minutes, respectively.
+
+<task kadi_cmds>
+      cron       * * * * *
+      check_cron * * * * *
+      exec update_cmds --occ --ftp --data-root=$ENV{SKA_DATA}/kadi
+      <check>
+        <error>
+          #    File           Expression
+          #  ----------      ---------------------------
+             kadi.log     error
+             kadi.log     warning
+             kadi.log     fatal
+        </error>
+      </check>
+</task>

--- a/task_schedule_occ_events.cfg
+++ b/task_schedule_occ_events.cfg
@@ -14,13 +14,13 @@ loud              0                 # Run loudly or quietly (production mode)
 data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
-master_log   kadi.log             # Composite master log (created in log_dir)
+master_log   kadi_events.log             # Composite master log (created in log_dir)
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
-alert       aca@head.cfa.harvard.edu
+alert       SOT
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab
@@ -37,11 +37,10 @@ alert       aca@head.cfa.harvard.edu
 # executed only once for each <number> of times the task is executed.  In the
 # example below, the commands are done once each 1, 2, and 4 minutes, respectively.
 
-<task kadi>
+<task kadi_events>
       cron       * * * * *
       check_cron * * * * *
-      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi
-      exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
+      exec update_events --occ --ftp --data-root=$ENV{SKA_DATA}/kadi
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
This is to allow commands processing and ftp to GRETA to happen more frequently, say once per hour.

The only non-obvious content change is adding the `--occ` flag to the command for the OCC config files.  This flag has a default of True if the user is SOT, but better to just be explicit.