### PR TITLE
Update task schedules for the two jobs to avoid conflicts

### DIFF
--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -15,6 +15,7 @@ data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
 master_log   kadi_cmds.log             # Composite master log (created in log_dir)
+heartbeat    task_sched_heartbeat_cmds
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
@@ -39,7 +40,6 @@ alert       aca@head.cfa.harvard.edu
 
 <task kadi_cmds>
       cron       * * * * *
-      check_cron * * * * *
       exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
       <check>
         <error>

--- a/task_schedule_events.cfg
+++ b/task_schedule_events.cfg
@@ -15,6 +15,7 @@ data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
 master_log   kadi_events.log             # Composite master log (created in log_dir)
+heartbeat    task_sched_heartbeat_events
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).

--- a/task_schedule_occ_cmds.cfg
+++ b/task_schedule_occ_cmds.cfg
@@ -15,6 +15,7 @@ data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
 master_log   kadi_cmds.log             # Composite master log (created in log_dir)
+heartbeat    task_sched_heartbeat_cmds
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
@@ -39,7 +40,6 @@ alert       SOT
 
 <task kadi_cmds>
       cron       * * * * *
-      check_cron * * * * *
       exec update_cmds --occ --ftp --data-root=$ENV{SKA_DATA}/kadi
       <check>
         <error>

--- a/task_schedule_occ_events.cfg
+++ b/task_schedule_occ_events.cfg
@@ -15,6 +15,7 @@ data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
 log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
 bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
 master_log   kadi_events.log             # Composite master log (created in log_dir)
+heartbeat    task_sched_heartbeat_events
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).


### PR DESCRIPTION
This removes check_cron from the more frequent job with the hope that
only the check_cront called in the "daily" events job will call watch_cron_logs and move
and check the logs.  You do run into the issue that the cmds logs will also
only be checked once a day (though a fatal error should still go to aca).

These edits also give each task a unique heartbeat file name to avoid collision.