### PR TITLE
Remove unused 'check' blocks in cmds task_schedules

### DIFF
--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -41,13 +41,4 @@ alert       aca@head.cfa.harvard.edu
 <task kadi_cmds>
       cron       * * * * *
       exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
-      <check>
-        <error>
-          #    File           Expression
-          #  ----------      ---------------------------
-             kadi.log     error
-             kadi.log     warning
-             kadi.log     fatal
-        </error>
-      </check>
 </task>

--- a/task_schedule_occ_cmds.cfg
+++ b/task_schedule_occ_cmds.cfg
@@ -41,13 +41,4 @@ alert       SOT
 <task kadi_cmds>
       cron       * * * * *
       exec update_cmds --occ --ftp --data-root=$ENV{SKA_DATA}/kadi
-      <check>
-        <error>
-          #    File           Expression
-          #  ----------      ---------------------------
-             kadi.log     error
-             kadi.log     warning
-             kadi.log     fatal
-        </error>
-      </check>
 </task>


### PR DESCRIPTION
Remove unused 'check' blocks in cmds task_schedules

These were orphaned when we removed 'check_cron' from the cmds jobs.