### PR TITLE
Do event updates on a local copy and mv back

### DIFF
--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 16, 2, False)
+VERSION = (3, 16, 3, False)
 
 
 class SemanticVersion(object):

--- a/task_schedule_events.cfg
+++ b/task_schedule_events.cfg
@@ -41,7 +41,10 @@ alert       aca@head.cfa.harvard.edu
 <task kadi_events>
       cron       * * * * *
       check_cron * * * * *
-      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi
+      exec /bin/mkdir -p $ENV{SKA_DATA}/kadi/update_events
+      exec /bin/cp $ENV{SKA_DATA}/kadi/events.db3 $ENV{SKA_DATA}/kadi/ltt_bads.dat  $ENV{SKA_DATA}/kadi/update_events/
+      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi/update_events
+      exec /bin/mv $ENV{SKA_DATA}/kadi/update_events/events.db3  $ENV{SKA_DATA}/kadi/events.db3
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
@jeanconn - I did some testing locally on the implications of the `events.db3` file going missing or changing during an active session.

Testing:
- Copy $ska/data/kadi/events.db3 to a local version
- Truncate the local version in time to generate diffs that are obvious in query results
- Open a window with KADI=$PWD to point to local events.db3
- Open ipython and do queries to confirm truncated events
- In another window, cp $ska/data/events.db3 back to the local events.db3
- Confirm that in the original ipython, subsequent event queries still produce expected truncated results, including queries for models that I didn't do before.
- Quit ipython and restart, and confirm that the full (non-truncated) events.db3 is now being used.

As far as I can tell the file system does the right thing, which is to say that the active process holds on to the file handle and so queries continue working, using a phantom database that only exists in the internal file system but not visible to user.

cc: @linamaria11 