### PR TITLE
Stop pushing to ftp in regular processing

### DIFF
--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -40,5 +40,5 @@ alert       aca@head.cfa.harvard.edu
 
 <task kadi_cmds>
       cron       * * * * *
-      exec update_cmds --ftp --data-root=$ENV{SKA_DATA}/kadi
+      exec update_cmds --data-root=$ENV{SKA_DATA}/kadi
 </task>

--- a/task_schedule_events.cfg
+++ b/task_schedule_events.cfg
@@ -43,7 +43,7 @@ alert       aca@head.cfa.harvard.edu
       check_cron * * * * *
       exec /bin/mkdir -p $ENV{SKA_DATA}/kadi/update_events
       exec /bin/cp $ENV{SKA_DATA}/kadi/events.db3 $ENV{SKA_DATA}/kadi/ltt_bads.dat  $ENV{SKA_DATA}/kadi/update_events/
-      exec update_events --ftp --data-root=$ENV{SKA_DATA}/kadi/update_events
+      exec update_events --data-root=$ENV{SKA_DATA}/kadi/update_events
       exec /bin/mv $ENV{SKA_DATA}/kadi/update_events/events.db3  $ENV{SKA_DATA}/kadi/events.db3
       <check>
         <error>


### PR DESCRIPTION
Using `lucky` as a gateway to push commands and events to the GRETA network has been overtaken by pulling from GRETA via rsync.  This is more reliable and simpler.

Note that `task_schedule_occ_{cmds,events}.cfg` are no longer running on GRETA since moving to Wayside.