### PR TITLE
Fix ingest of non-load commands during a load stoppage (anomaly)

### DIFF
--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -142,15 +142,15 @@ def get_cmds(start, stop, mp_dir='/data/mpcrit1/mplogs'):
         # Get non-load commands (from autonomous or ground SCS107, NSM, etc) in the
         # time range that the timelines span.
         tl_datestart = min(timeline_loads['datestart'])
-        tl_datestop = max(timeline_loads['datestop'])
         nl_cmds = db.fetchall('SELECT * from cmds where timeline_id IS NULL and '
                               'date >= "{}" and date <= "{}"'
-                              .format(tl_datestart, tl_datestop))
+                              .format(tl_datestart, stop.date))
 
         # Private method from cmd_states.py fetches the actual int/float param values
         # and returns list of dict.
         nl_cmds = _tl_to_bs_cmds(nl_cmds, None, db)
         nl_cmds = fix_nonload_cmds(nl_cmds)
+        logger.info(f'Found {len(nl_cmds)} non-load commands between {tl_datestart} : {stop.date}')
 
     logger.info('Found {} timelines included within {} to {}'
                 .format(len(timeline_loads), start.date, stop.date))


### PR DESCRIPTION
This is a simple change to the ingest of non-load commands.  It makes the applicable date range for commands go out to the ingest `stop` date instead of the end of the last timeline.  The previous logic was incorrect since during an anomaly the last timeline is clipped so you don't get non-load commands in the kadi cmds archive.

## Testing

This works, as demonstrated in these two notebooks:

- https://nbviewer.jupyter.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/ipynb/kadi/test-nonload-update-cmds-dev.ipynb
- https://nbviewer.jupyter.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/ipynb/kadi/test-nonload-update-cmds-4.18.1.ipynb