### PR TITLE
Update_cmds fixes for py3

### DIFF
--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -14,6 +14,7 @@ from Chandra.Time import DateTime
 from Chandra.cmd_states.cmd_states import _tl_to_bs_cmds
 from . import occweb
 from .paths import IDX_CMDS_PATH, PARS_DICT_PATH
+from . import __version__
 
 MIN_MATCHING_BLOCK_SIZE = 500
 BACKSTOP_CACHE = {}
@@ -68,6 +69,8 @@ def get_opt(args=None):
                         default=False,
                         action='store_true',
                         help="Store or get files via ftp (implied for --occ)")
+    parser.add_argument('--version', action='version',
+                        version='%(prog)s {version}'.format(version=__version__))
 
     args = parser.parse_args(args)
     return args

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -2,11 +2,10 @@
 import os
 import argparse
 import difflib
+import pickle
 
 import numpy as np
 import tables
-from six.moves import cPickle as pickle
-import six
 
 import pyyaks.logger
 import Ska.DBI
@@ -105,18 +104,15 @@ def fix_nonload_cmds(nl_cmds):
         if cmd['msid'] is not None:
             new_cmd['params']['msid'] = str(cmd['msid'])
 
-        # De-unicode and de-numpy (otherwise unpickling on PY3 has problems).
+        # De-numpy (otherwise unpickling on PY3 has problems).
         if 'params' in cmd:
             params = new_cmd['params']
             for key, val in cmd['params'].items():
                 key = str(key)
-                if isinstance(val, six.string_types):
-                    val = str(val)
-                else:
-                    try:
-                        val = val.item()
-                    except Exception:
-                        pass
+                try:
+                    val = val.item()
+                except AttributeError:
+                    pass
                 params[key] = val
 
         new_cmds.append(new_cmd)
@@ -316,7 +312,10 @@ def add_h5_cmds(h5file, idx_cmds):
         # Define the column names that specify a complete and unique row
         key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'timeline_id', 'vcdu')
 
-        h5d_recent_vals = [tuple(str(row[x]) for x in key_names) for row in h5d_recent]
+        h5d_recent_vals = [tuple(
+            row[x].decode('ascii') if isinstance(row[x], bytes) else str(row[x])
+            for x in key_names)
+            for row in h5d_recent]
         idx_cmds_vals = [tuple(str(x) for x in row[1:]) for row in idx_cmds]
 
         diff = difflib.SequenceMatcher(a=h5d_recent_vals, b=idx_cmds_vals, autojunk=False)

--- a/kadi/version.py
+++ b/kadi/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 18, 1, False)
+VERSION = (4, 19, None, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Fixes for kadi update_cmds to run correctly on Py3.  Also includes minor flake8 fixes.  Just one non-trivial fix related to the diffing and a bytes/unicode issue.  (str() of a bytestring gives `b'blah'` not `blah`.)

## Testing

### On HEAD (kady) in ska3/flight

```
ska  # LEGACY ska
cd ~/tmp/kadi-test
python /proj/sot/ska/share/update_cmds.py --start=2015:001 --stop=2015:030
# Creates local cmds.h5 and cmds.pkl for the date range using the Ska2-flight kadi.
```

### On local machine (MacOS) in py3-compat branch

```
ska3  # Activate ska3 environment
cd ~/git/kadi
git checkout py3-compat
cp ~/git/ska_testr/packages/kadi/write_events_cmds.py write_cmds.py
```
- Edit `write_cmds.py` to comment out writing the events and fix a Py3-compatibility
  problem (os.path cannot take None in Py3)

```
rm cmds.*
./update_cmds.py --start=2015:001 --stop=2015:030 --mp-dir ~/ska/data/mpcrit1/mplogs
python write_cmds.py  --start=2014:001 --stop=2016:001
# Creates cmds.txt which is a plain-text version of the commands

mkdir cmds-ska2
cd cmds-ska2
scp 'kady:tmp/kadi-test/cmds.*' ./
python ../write_cmds.py --start=2014:001 --stop=2016:001

diff cmds.txt ../cmds.txt
# Compare cmds from local branch to ska2-flight version
#  ** NO DIFF **
```
