### PR TITLE
Migrate update_cmds task_schedule to ska3 idiom

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from distutils.core import setup
+import os
+import sys
 
 # from this_package.version import package_version object
 from kadi.version import package_version
@@ -23,13 +25,21 @@ try:
 except ImportError:
     cmdclass = {}
 
-entry_points = {'console_scripts': 'get_chandra_states = kadi.commands.states:get_chandra_states'}
+if "--user" not in sys.argv:
+    share_path = os.path.join(sys.prefix, "share", "kadi")
+    data_files = [(share_path, ['task_schedule.cfg'])]
+else:
+    data_files = None
+
+entry_points = {'console_scripts': [
+    'get_chandra_states = kadi.commands.states:get_chandra_states',
+    'kadi_update_cmds = kadi.update_cmds:main']}
 
 setup(name='kadi',
       version=package_version.version,
       description='Kadi events archive',
       author='Tom Aldcroft',
-      author_email='aldcroft@head.cfa.harvard.edu',
+      author_email='taldcroft@cfa.harvard.edu',
       url='http://cxc.harvard.edu/mta/ASPECT/tool_doc/kadi/',
       packages=['kadi', 'kadi.events', 'kadi.cmds', 'kadi.tests',
                 'kadi.commands', 'kadi.commands.tests'],
@@ -39,6 +49,7 @@ setup(name='kadi',
                                                 'static/images/*', 'static/*.css',
                                                 'GIT_VERSION']},
       tests_require=['pytest'],
+      data_files=data_files,
       cmdclass=cmdclass,
       entry_points=entry_points,
       )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ except ImportError:
 
 if "--user" not in sys.argv:
     share_path = os.path.join(sys.prefix, "share", "kadi")
-    data_files = [(share_path, ['task_schedule.cfg'])]
+    data_files = [(share_path, ['task_schedule_cmds.cfg',
+                                'task_schedule_events.cfg'])]
 else:
     data_files = None
 

--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -13,7 +13,6 @@ loud              0                 # Run loudly or quietly (production mode)
 
 data_dir     $ENV{SKA}/data/kadi       # Data file directory
 log_dir      $ENV{SKA}/data/kadi/logs  # Log file directory
-bin_dir      $ENV{SKA}/bin      # Bin dir (optional, see task def'n)
 master_log   kadi_cmds.log             # Composite master log (created in log_dir)
 heartbeat    task_sched_heartbeat_cmds
 

--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -11,9 +11,9 @@ loud              0                 # Run loudly or quietly (production mode)
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/kadi       # Data file directory
-log_dir      $ENV{SKA_DATA}/kadi/logs  # Log file directory
-bin_dir      $ENV{SKA_SHARE}/kadi      # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data/kadi       # Data file directory
+log_dir      $ENV{SKA}/data/kadi/logs  # Log file directory
+bin_dir      $ENV{SKA}/bin      # Bin dir (optional, see task def'n)
 master_log   kadi_cmds.log             # Composite master log (created in log_dir)
 heartbeat    task_sched_heartbeat_cmds
 
@@ -40,5 +40,5 @@ alert       aca@head.cfa.harvard.edu
 
 <task kadi_cmds>
       cron       * * * * *
-      exec update_cmds --data-root=$ENV{SKA_DATA}/kadi
+      exec kadi_update_cmds --data-root=$ENV{SKA}/data/kadi
 </task>


### PR DESCRIPTION
The main changes are:
- Allow for mission planning dirs to be in $SKA/data/mpcrit1/mplogs
- Install cfg files into $CONDA_PREFIX/share/kadi

This should be included in a 4.19 release.

## Testing

### Unit testing

Passes unit tests on MacOS and linux.

### Integration testing

See https://github.com/sot/task_schedule/pull/15 for testing details on linux and MacOS in an integrated env with dev versions of kadi, task_schedule, and watch_cron_logs.
