### PR TITLE
Add acisfp_setpoint state

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -509,8 +509,8 @@ classes which affect the keys.
 
 .. Run kadi.commands.states.print_state_keys_transition_classes_docs() to generate this list.
 
-``acisfp_temp``
-  - :class:`~kadi.commands.states.ACISFP_TempTransition`
+``acisfp_setpoint``
+  - :class:`~kadi.commands.states.ACISFP_SetPointTransition`
 
 ``aoephem1``, ``aoephem2``, ``aoratio``, ``aoargper``, ``aoeccent``, ``ao1minus``, ``ao1plus``, ``aomotion``, ``aoiterat``, ``aoorbang``, ``aoperige``, ``aoascend``, ``aosini``, ``aoslr``, ``aosqrtmu``
   - :class:`~kadi.commands.states.EphemerisTransition`

--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -509,6 +509,9 @@ classes which affect the keys.
 
 .. Run kadi.commands.states.print_state_keys_transition_classes_docs() to generate this list.
 
+``acisfp_temp``
+  - :class:`~kadi.commands.states.ACISFP_TempTransition`
+
 ``aoephem1``, ``aoephem2``, ``aoratio``, ``aoargper``, ``aoeccent``, ``ao1minus``, ``ao1plus``, ``aomotion``, ``aoiterat``, ``aoorbang``, ``aoperige``, ``aoascend``, ``aosini``, ``aoslr``, ``aosqrtmu``
   - :class:`~kadi.commands.states.EphemerisTransition`
 

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -4,6 +4,7 @@ based entirely on known history of commands.
 """
 from __future__ import division, print_function, absolute_import
 
+import re
 import collections
 import itertools
 import inspect
@@ -977,6 +978,38 @@ class ACISTransition(BaseTransition):
 
             elif tlmsid.startswith('WT'):
                 transitions[date].update(si_mode='TE_' + tlmsid[2:7])
+
+
+class ACISFP_TempTransition(BaseTransition):
+    """
+    Implement transitions for ACIS focal plane temperature states.
+    """
+    command_attributes = {'type': 'ACISPKT'}
+    state_keys = ['acisfp_temp']
+    default_value = -121.0
+
+    @classmethod
+    def set_transitions(cls, transitions, cmds, start, stop):
+        """
+        Set transitions for a Table of commands ``cmds``.
+
+        :param transitions_dict: global dict of transitions (updated in-place)
+        :param cmds: commands (CmdList)
+        :param start: start time for states
+        :param stop: stop time for states
+
+        :returns: None
+        """
+        state_cmds = cls.get_state_changing_commands(cmds)
+        for cmd in state_cmds:
+            tlmsid = cmd['tlmsid']
+            date = cmd['date']
+
+            if tlmsid.startswith('WSFTNEG'):
+                match = re.search(r'(\d+)$', tlmsid)
+                if not match:
+                    raise ValueError(f'unable to parse command {tlmsid}')
+                transitions[date].update(acisfp_temp=-float(match.group(1)))
 
 
 ###################################################################

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -980,12 +980,12 @@ class ACISTransition(BaseTransition):
                 transitions[date].update(si_mode='TE_' + tlmsid[2:7])
 
 
-class ACISFP_TempTransition(BaseTransition):
+class ACISFP_SetPointTransition(BaseTransition):
     """
-    Implement transitions for ACIS focal plane temperature states.
+    Implement transitions for ACIS focal plane temperature setpoint state.
     """
     command_attributes = {'type': 'ACISPKT'}
-    state_keys = ['acisfp_temp']
+    state_keys = ['acisfp_setpoint']
     default_value = -121.0
 
     @classmethod
@@ -1009,7 +1009,7 @@ class ACISFP_TempTransition(BaseTransition):
                 match = re.search(r'(\d+)$', tlmsid)
                 if not match:
                     raise ValueError(f'unable to parse command {tlmsid}')
-                transitions[date].update(acisfp_temp=-float(match.group(1)))
+                transitions[date].update(acisfp_setpoint=-float(match.group(1)))
 
 
 ###################################################################
@@ -1445,6 +1445,18 @@ def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000)):
         continuity['__transitions__'] = continuity_transitions
 
     return continuity
+
+
+def interpolate_states(states, times):
+    """Interpolate ``states`` table at given times.
+
+    :param states: states (np.recarray)
+    :param times: times (np.array or list)
+
+    :returns: ``states`` view at ``times``
+    """
+    indexes = np.searchsorted(states['tstop'], times)
+    return states[indexes]
 
 
 def _unique(seq):

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -983,6 +983,9 @@ class ACISTransition(BaseTransition):
 class ACISFP_SetPointTransition(BaseTransition):
     """
     Implement transitions for ACIS focal plane temperature setpoint state.
+
+    Looks for ACISPKT commands with TLMSID like ``WSFTNEG<number>``, where the
+    ACIS FP setpoint temperature is ``-<number>``.
     """
     command_attributes = {'type': 'ACISPKT'}
     state_keys = ['acisfp_setpoint']

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1246,3 +1246,30 @@ def test_get_pitch_from_mid_maneuver():
     assert np.all(exp['datestop'] == sts['datestop'])
     assert np.all(exp['pcad_mode'] == sts['pcad_mode'])
     assert np.all(np.isclose(exp['pitch'], sts['pitch'], rtol=0, atol=1e-8))
+
+
+def test_acisfp_temp_state():
+    sts = states.get_states('1999-01-01', '2004-01-01', state_keys='acisfp_temp')
+    assert repr(sts).splitlines() == [
+        '<Table length=5>',
+        '      datestart              datestop       acisfp_temp  trans_keys',
+        '        str21                 str21           float64      object  ',
+        '--------------------- --------------------- ----------- -----------',
+        '1999:001:12:00:00.000 2003:130:05:07:28.341      -121.0            ',
+        '2003:130:05:07:28.341 2003:130:19:09:28.930      -130.0 acisfp_temp',
+        '2003:130:19:09:28.930 2003:132:14:22:33.782      -121.0 acisfp_temp',
+        '2003:132:14:22:33.782 2003:133:22:04:22.425      -130.0 acisfp_temp',
+        '2003:133:22:04:22.425 2004:001:12:00:00.000      -121.0 acisfp_temp']
+
+    sts = states.get_states('2018-01-01', '2020-03-01', state_keys='acisfp_temp')
+    assert repr(sts).splitlines() == [
+        '<Table length=6>',
+        '      datestart              datestop       acisfp_temp  trans_keys',
+        '        str21                 str21           float64      object  ',
+        '--------------------- --------------------- ----------- -----------',
+        '2018:001:12:00:00.000 2018:249:20:16:04.603      -121.0            ',
+        '2018:249:20:16:04.603 2018:250:07:19:51.657      -126.0 acisfp_temp',
+        '2018:250:07:19:51.657 2018:294:22:29:00.000      -121.0 acisfp_temp',
+        '2018:294:22:29:00.000 2020:048:20:59:22.304      -121.0 acisfp_temp',
+        '2020:048:20:59:22.304 2020:049:13:05:52.537      -126.0 acisfp_temp',
+        '2020:049:13:05:52.537 2020:061:12:00:00.000      -121.0 acisfp_temp']

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1248,28 +1248,28 @@ def test_get_pitch_from_mid_maneuver():
     assert np.all(np.isclose(exp['pitch'], sts['pitch'], rtol=0, atol=1e-8))
 
 
-def test_acisfp_temp_state():
-    sts = states.get_states('1999-01-01', '2004-01-01', state_keys='acisfp_temp')
+def test_acisfp_setpoint_state():
+    sts = states.get_states('1999-01-01', '2004-01-01', state_keys='acisfp_setpoint')
     assert repr(sts).splitlines() == [
         '<Table length=5>',
-        '      datestart              datestop       acisfp_temp  trans_keys',
-        '        str21                 str21           float64      object  ',
-        '--------------------- --------------------- ----------- -----------',
-        '1999:001:12:00:00.000 2003:130:05:07:28.341      -121.0            ',
-        '2003:130:05:07:28.341 2003:130:19:09:28.930      -130.0 acisfp_temp',
-        '2003:130:19:09:28.930 2003:132:14:22:33.782      -121.0 acisfp_temp',
-        '2003:132:14:22:33.782 2003:133:22:04:22.425      -130.0 acisfp_temp',
-        '2003:133:22:04:22.425 2004:001:12:00:00.000      -121.0 acisfp_temp']
+        '      datestart              datestop       acisfp_setpoint    trans_keys  ',
+        '        str21                 str21             float64          object    ',
+        '--------------------- --------------------- --------------- ---------------',
+        '1999:001:12:00:00.000 2003:130:05:07:28.341          -121.0                ',
+        '2003:130:05:07:28.341 2003:130:19:09:28.930          -130.0 acisfp_setpoint',
+        '2003:130:19:09:28.930 2003:132:14:22:33.782          -121.0 acisfp_setpoint',
+        '2003:132:14:22:33.782 2003:133:22:04:22.425          -130.0 acisfp_setpoint',
+        '2003:133:22:04:22.425 2004:001:12:00:00.000          -121.0 acisfp_setpoint']
 
-    sts = states.get_states('2018-01-01', '2020-03-01', state_keys='acisfp_temp')
+    sts = states.get_states('2018-01-01', '2020-03-01', state_keys='acisfp_setpoint')
     assert repr(sts).splitlines() == [
         '<Table length=6>',
-        '      datestart              datestop       acisfp_temp  trans_keys',
-        '        str21                 str21           float64      object  ',
-        '--------------------- --------------------- ----------- -----------',
-        '2018:001:12:00:00.000 2018:249:20:16:04.603      -121.0            ',
-        '2018:249:20:16:04.603 2018:250:07:19:51.657      -126.0 acisfp_temp',
-        '2018:250:07:19:51.657 2018:294:22:29:00.000      -121.0 acisfp_temp',
-        '2018:294:22:29:00.000 2020:048:20:59:22.304      -121.0 acisfp_temp',
-        '2020:048:20:59:22.304 2020:049:13:05:52.537      -126.0 acisfp_temp',
-        '2020:049:13:05:52.537 2020:061:12:00:00.000      -121.0 acisfp_temp']
+        '      datestart              datestop       acisfp_setpoint    trans_keys  ',
+        '        str21                 str21             float64          object    ',
+        '--------------------- --------------------- --------------- ---------------',
+        '2018:001:12:00:00.000 2018:249:20:16:04.603          -121.0                ',
+        '2018:249:20:16:04.603 2018:250:07:19:51.657          -126.0 acisfp_setpoint',
+        '2018:250:07:19:51.657 2018:294:22:29:00.000          -121.0 acisfp_setpoint',
+        '2018:294:22:29:00.000 2020:048:20:59:22.304          -121.0 acisfp_setpoint',
+        '2020:048:20:59:22.304 2020:049:13:05:52.537          -126.0 acisfp_setpoint',
+        '2020:049:13:05:52.537 2020:061:12:00:00.000          -121.0 acisfp_setpoint']


### PR DESCRIPTION
## Description

This adds a new state to track the ACIS FP temperature based on commands of the form `WSFTNEG*`.

This could have been done with far less new code by just adding a new `elif` block to the existing `ACISTransition` class.  However, the first `WSFTNEG` command in the commands table is in 2003, so querying states before then was crashing.  The current implementation puts in place a default of -121.0.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing: new unit test
