### PR TITLE
Improve get_cmds_from_backstop

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -106,7 +106,7 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
     be a string file name or a backstop table from ``parse_cm.read_backstop``.
 
     :param backstop: str or Table
-    :param remove_starcat: remove star catalog commands (default=True)
+    :param remove_starcat: remove star catalog command parameters (default=True)
     :returns: :class:`~kadi.commands.commands.CommandTable` of commands
     """
     if isinstance(backstop, Path):
@@ -121,10 +121,6 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
         raise ValueError(f'`backstop` arg must be a string filename or '
                          f'a backstop Table')
 
-    if remove_starcat:
-        ok = bs['type'] != 'MP_STARCAT'
-        bs = bs[ok]
-
     n_bs = len(bs)
     out = {}
     # Set idx to max (2**16 -1) so it does not match any real idx
@@ -138,6 +134,11 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
     out['timeline_id'] = np.zeros(n_bs, dtype=np.uint32)
     out['vcdu'] = bs['vcdu'].astype(np.int32)
     out['params'] = bs['params']
+
+    if remove_starcat:
+        # Remove the lengthy parameters in star catalog but leave the command
+        for idx in np.flatnonzero(bs['type'] == 'MP_STARCAT'):
+            out['params'][idx] = {}
 
     # Backstop has redundant param keys, get rid of them here
     for params in out['params']:

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -74,7 +74,7 @@ def test_get_cmds_from_backstop_and_add_cmds():
     cmds = commands.get_cmds(start='2018:182:00:00:00',
                              stop='2018:182:08:00:00')
 
-    assert len(bs_cmds) == 659
+    assert len(bs_cmds) == 674
     assert len(cmds) == 56
 
     assert bs_cmds.colnames == cmds.colnames
@@ -84,9 +84,13 @@ def test_get_cmds_from_backstop_and_add_cmds():
     new_cmds = cmds.add_cmds(bs_cmds)
     assert len(new_cmds) == len(cmds) + len(bs_cmds)
 
-    # No MP_STARCAT commands by default
-    assert not np.any(bs_cmds['type'] == 'MP_STARCAT')
+    # No MP_STARCAT command parameters by default
+    ok = bs_cmds['type'] == 'MP_STARCAT'
+    assert np.count_nonzero(ok) == 15
+    assert np.all(bs_cmds['params'][ok] == {})
 
     # Accept MP_STARCAT commands
     bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=False)
-    assert np.count_nonzero(bs_cmds['type'] == 'MP_STARCAT') == 15
+    ok = bs_cmds['type'] == 'MP_STARCAT'
+    assert np.count_nonzero(ok) == 15
+    assert np.all(bs_cmds['params'][ok] != {})


### PR DESCRIPTION

## Description

Don't entirely throw away starcat cmds  when `remove_starcat=True`, just toss the parameters.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (updated unit tests)

