### PR TITLE
Add inclusive_stop kwarg to get_cmds

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -188,22 +188,20 @@ def _find(start=None, stop=None, inclusive_stop=False, **kwargs):
 
     :returns: astropy Table of commands
     """
-    date = kwargs.pop('date', None)
-    if date:
-        start = DateTime(date).date  # clip resolution to nearest msec
-        stop = DateTime(start) + 0.001 / 86400  # exactly 1 msec later
-        inclusive_stop = False
-
     ok = np.ones(len(idx_cmds), dtype=bool)
     par_ok = np.zeros(len(idx_cmds), dtype=bool)
 
-    if start:
-        ok &= idx_cmds['date'] >= DateTime(start).date
-    if stop:
-        if inclusive_stop:
-            ok &= idx_cmds['date'] <= DateTime(stop).date
-        else:
-            ok &= idx_cmds['date'] < DateTime(stop).date
+    date = kwargs.pop('date', None)
+    if date:
+        ok &= idx_cmds['date'] == DateTime(date).date
+    else:
+        if start:
+            ok &= idx_cmds['date'] >= DateTime(start).date
+        if stop:
+            if inclusive_stop:
+                ok &= idx_cmds['date'] <= DateTime(stop).date
+            else:
+                ok &= idx_cmds['date'] < DateTime(stop).date
 
     for key, val in kwargs.items():
         key = key.lower()

--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -74,8 +74,10 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
     the command parameters such as TLMSID, MSID, SCS, STEP, or POS, the ``key``
     can be:
 
-    type Command type e.g. COMMAND_SW, COMMAND_HW, ACISPKT, SIMTRANS date Exact
-      date of command e.g. '2013:003:22:11:45.530'
+    type
+      Command type e.g. COMMAND_SW, COMMAND_HW, ACISPKT, SIMTRANS
+    date
+      Exact date of command e.g. '2013:003:22:11:45.530'
 
     If ``date`` is provided then ``start`` and ``stop`` values are ignored.
 

--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -62,38 +62,39 @@ pars_dict = LazyVal(load_pars_dict)
 rev_pars_dict = LazyVal(lambda: {v: k for k, v in pars_dict.items()})
 
 
-def get_cmds(start=None, stop=None, **kwargs):
+def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
     """
-    Get commands with ``start`` <= date < ``stop``.  Additional ``key=val`` pairs
-    can be supplied to further filter the results.  Both ``key`` and ``val``
-    are case insensitive.  In addition to the any of the command parameters
-    such as TLMSID, MSID, SCS, STEP, or POS, the ``key`` can be:
+    Get commands beteween ``start`` and ``stop``.
 
-    type
-      Command type e.g. COMMAND_SW, COMMAND_HW, ACISPKT, SIMTRANS
-    date
-      Exact date of command e.g. '2013:003:22:11:45.530'
+    By default the interval is ``start`` <= date < ``stop``, but if
+    ``inclusive_stop=True`` then the interval is ``start`` <= date <= ``stop``.
+
+    Additional ``key=val`` pairs can be supplied to further filter the results.
+    Both ``key`` and ``val`` are case insensitive.  In addition to the any of
+    the command parameters such as TLMSID, MSID, SCS, STEP, or POS, the ``key``
+    can be:
+
+    type Command type e.g. COMMAND_SW, COMMAND_HW, ACISPKT, SIMTRANS date Exact
+      date of command e.g. '2013:003:22:11:45.530'
 
     If ``date`` is provided then ``start`` and ``stop`` values are ignored.
 
     Examples::
 
-      >>> from kadi import commands
-      >>> cmds = commands.get_cmds('2012:001', '2012:030')
-      >>> cmds = commands.get_cmds('2012:001', '2012:030', type='simtrans')
-      >>> cmds = commands.get_cmds(type='acispkt', tlmsid='wsvidalldn')
-      >>> cmds = commands.get_cmds(msid='aflcrset')
+      >>> from kadi import commands cmds = commands.get_cmds('2012:001',
+      >>> '2012:030') cmds = commands.get_cmds('2012:001', '2012:030',
+      >>> type='simtrans') cmds = commands.get_cmds(type='acispkt',
+      >>> tlmsid='wsvidalldn') cmds = commands.get_cmds(msid='aflcrset')
       >>> print(cmds)
 
-    :param start: DateTime format (optional)
-        Start time, defaults to beginning of available commands (2002:001)
-    :param stop: DateTime format (optional)
-        Stop time, defaults to end of available commands
-    :param kwargs: key=val keyword argument pairs
+    :param start: DateTime format (optional) Start time, defaults to beginning
+        of available commands (2002:001) :param stop: DateTime format (optional)
+        Stop time, defaults to end of available commands :param kwargs: key=val
+        keyword argument pairs
 
     :returns: :class:`~kadi.commands.commands.CommandTable` of commands
     """
-    cmds = _find(start, stop, **kwargs)
+    cmds = _find(start, stop, inclusive_stop, **kwargs)
     out = CommandTable(cmds)
     out['params'] = None if len(out) > 0 else Column([], dtype=object)
 
@@ -154,12 +155,17 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
     return CommandTable(out)
 
 
-def _find(start=None, stop=None, **kwargs):
+def _find(start=None, stop=None, inclusive_stop=False, **kwargs):
     """
-    Get commands ``start`` <= date < ``stop``.  Additional ``key=val`` pairs
-    can be supplied to further filter the results.  Both ``key`` and ``val``
-    are case insensitive.  In addition to the any of the command parameters
-    such as TLMSID, MSID, SCS, STEP, or POS, the ``key`` can be:
+    Get commands beteween ``start`` and ``stop``.
+
+    By default the interval is ``start`` <= date < ``stop``, but if
+    ``inclusive_stop=True`` then the interval is ``start`` <= date <= ``stop``.
+
+    Additional ``key=val`` pairs can be supplied to further filter the results.
+    Both ``key`` and ``val`` are case insensitive.  In addition to the any of
+    the command parameters such as TLMSID, MSID, SCS, STEP, or POS, the ``key``
+    can be:
 
     date : Exact date of command e.g. '2013:003:22:11:45.530'
     type : Command type e.g. COMMAND_SW, COMMAND_HW, ACISPKT, SIMTRANS
@@ -184,6 +190,7 @@ def _find(start=None, stop=None, **kwargs):
     if date:
         start = DateTime(date).date  # clip resolution to nearest msec
         stop = DateTime(start) + 0.001 / 86400  # exactly 1 msec later
+        inclusive_stop = False
 
     ok = np.ones(len(idx_cmds), dtype=bool)
     par_ok = np.zeros(len(idx_cmds), dtype=bool)
@@ -191,7 +198,11 @@ def _find(start=None, stop=None, **kwargs):
     if start:
         ok &= idx_cmds['date'] >= DateTime(start).date
     if stop:
-        ok &= idx_cmds['date'] < DateTime(stop).date
+        if inclusive_stop:
+            ok &= idx_cmds['date'] <= DateTime(stop).date
+        else:
+            ok &= idx_cmds['date'] < DateTime(stop).date
+
     for key, val in kwargs.items():
         key = key.lower()
         if isinstance(val, str):

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -67,6 +67,19 @@ def test_get_cmds_zero_length_result():
                              'step', 'timeline_id', 'vcdu', 'params']
 
 
+def test_get_cmds_inclusive_stop():
+    """get_cmds returns start <= date < stop for inclusive_stop=False (default)
+    or start <= date <= stop for inclusive_stop=True.
+    """
+    # Query over a range that includes two commands at exactly start and stop.
+    start, stop = '2020:001:15:50:00.000', '2020:001:15:50:00.257'
+    cmds = commands.get_cmds(start, stop)
+    assert np.all(cmds['date'] == [start])
+
+    cmds = commands.get_cmds(start, stop, inclusive_stop=True)
+    assert np.all(cmds['date'] == [start, stop])
+
+
 def test_get_cmds_from_backstop_and_add_cmds():
     bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
     bs_cmds = commands.get_cmds_from_backstop(bs_file)


### PR DESCRIPTION
## Description

This will make code related to RLTT a bit cleaner because in that case one needs to get commands up to and *including* the RLTT stop time.

This should be used in https://github.com/sot/starcheck/pull/341/.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing
  - Added new unit test
