### PR TITLE
Allow start and stop in get_states() with cmds

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1184,10 +1184,8 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
         start = DateTime(start).date
         stop = DateTime(stop or cmds[-1]['date']).date  # User-supplied stop or last command
     else:
-        if start is not None or stop is not None:
-            raise ValueError("cannot supply both 'cmds' and 'start' / 'stop' arguments")
-        start = cmds[0]['date']
-        stop = cmds[-1]['date']
+        start = cmds[0]['date'] if start is None else DateTime(start).date
+        stop = cmds[-1]['date'] if stop is None else DateTime(stop).date
 
     # Get initial state at start of commands
     if continuity is None:

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -381,6 +381,28 @@ def test_get_continuity_vs_states():
             assert np.isclose(sts0[key], val, rtol=0, atol=1e-7)
 
 
+def test_get_states_with_cmds_and_start_stop():
+    """Test using get_states with supplied commands along with start and
+    stop."""
+    # Get 6 commands from 2020:001:02:55:00.000 to 2020:001:02:55:01.285
+    # (just comm setup commanding)
+    cmds = commands.get_cmds('2020:001:02:00:00', '2020:001:03:00:00')
+
+    sts = states.get_states(cmds=cmds, state_keys=['fep_count'])
+    assert len(sts) == 1
+    assert sts['datestart'][0] == '2020:001:02:55:00.000'
+    assert sts['datestop'][-1] == '2020:001:02:55:01.285'
+    assert np.all(sts['fep_count'] == 4)
+
+    sts = states.get_states(cmds=cmds, state_keys=['fep_count'],
+                            start='2020:001:00:00:00',
+                            stop='2020:002:00:00:00')
+    assert len(sts) == 1
+    assert sts['datestart'][0] == '2020:001:00:00:00.000'
+    assert sts['datestop'][-1] == '2020:002:00:00:00.000'
+    assert np.all(sts['fep_count'] == 4)
+
+
 def test_get_continuity_keys():
     """Test that output has only the desired state keys. Also test that one can
     provide a string instead of list of state keys"""


### PR DESCRIPTION
## Description

It turns out to be a good thing to supply `cmds` and `start` and `stop` in `get_states()` (https://github.com/sot/starcheck/pull/344).

To do:
- [x] Add unit test

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing
  - https://github.com/sot/starcheck/pull/344

