### PR TITLE
SHINY: update dates for Chandra.Time 4.0+

### DIFF
--- a/kadi/cmds/tests/test_commands.py
+++ b/kadi/cmds/tests/test_commands.py
@@ -6,7 +6,7 @@ from .. import cmds
 
 
 def test_find():
-    cs = cmds._find('2012:029', '2012:030')
+    cs = cmds._find('2012:029:12:00:00', '2012:030:12:00:00')
     assert isinstance(cs, Table)
     assert len(cs) == 147
     assert np.all(cs['timeline_id'][:10] == 426098447)
@@ -15,21 +15,21 @@ def test_find():
     assert cs['date'][-1] == '2012:030:11:00:01.285'
     assert cs['tlmsid'][-1] == 'CTXBON'
 
-    cs = cmds._find('2012:029', '2012:030', type='simtrans')
+    cs = cmds._find('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans')
     assert len(cs) == 2
     assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
 
-    cs = cmds._find('2012:015', '2012:030', type='acispkt', tlmsid='wsvidalldn')
+    cs = cmds._find('2012:015:12:00:00', '2012:030:12:00:00', type='acispkt', tlmsid='wsvidalldn')
     assert len(cs) == 3
     assert np.all(cs['date'] == ['2012:018:01:16:15.798', '2012:020:16:51:17.713',
                                  '2012:026:05:28:09.000'])
 
-    cs = cmds._find('2011:001', '2014:001', msid='aflcrset')
+    cs = cmds._find('2011:001:12:00:00', '2014:001:12:00:00', msid='aflcrset')
     assert len(cs) == 2494
 
 
 def test_filter():
-    cs = cmds.filter('2012:029', '2012:030')
+    cs = cmds.filter('2012:029:12:00:00', '2012:030:12:00:00')
     assert isinstance(cs, cmds.CmdList)
     assert len(cs) == 147
     assert np.all(cs['timeline_id'][:10] == 426098447)
@@ -38,7 +38,7 @@ def test_filter():
     assert cs['date'][-1] == '2012:030:11:00:01.285'
     assert cs['tlmsid'][-1] == 'CTXBON'
 
-    cs = cmds.filter('2012:029', '2012:030', type='simtrans')
+    cs = cmds.filter('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans')
     assert len(cs) == 2
     assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
     assert np.all(cs['pos'] == [75624, 73176])  # from params

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -12,7 +12,7 @@ from .. import commands
 
 
 def test_find():
-    cs = commands._find('2012:029', '2012:030')
+    cs = commands._find('2012:029:12:00:00', '2012:030:12:00:00')
     assert isinstance(cs, Table)
     assert len(cs) == 147
     assert np.all(cs['timeline_id'][:10] == 426098447)
@@ -21,21 +21,22 @@ def test_find():
     assert cs['date'][-1] == '2012:030:11:00:01.285'
     assert cs['tlmsid'][-1] == 'CTXBON'
 
-    cs = commands._find('2012:029', '2012:030', type='simtrans')
+    cs = commands._find('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans')
     assert len(cs) == 2
     assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
 
-    cs = commands._find('2012:015', '2012:030', type='acispkt', tlmsid='wsvidalldn')
+    cs = commands._find('2012:015:12:00:00', '2012:030:12:00:00',
+                        type='acispkt', tlmsid='wsvidalldn')
     assert len(cs) == 3
     assert np.all(cs['date'] == ['2012:018:01:16:15.798', '2012:020:16:51:17.713',
                                  '2012:026:05:28:09.000'])
 
-    cs = commands._find('2011:001', '2014:001', msid='aflcrset')
+    cs = commands._find('2011:001:12:00:00', '2014:001:12:00:00', msid='aflcrset')
     assert len(cs) == 2494
 
 
 def test_get_cmds():
-    cs = commands.get_cmds('2012:029', '2012:030')
+    cs = commands.get_cmds('2012:029:12:00:00', '2012:030:12:00:00')
     assert isinstance(cs, commands.CommandTable)
     assert len(cs) == 147
     assert np.all(cs['timeline_id'][:10] == 426098447)
@@ -44,7 +45,7 @@ def test_get_cmds():
     assert cs['date'][-1] == '2012:030:11:00:01.285'
     assert cs['tlmsid'][-1] == 'CTXBON'
 
-    cs = commands.get_cmds('2012:029', '2012:030', type='simtrans')
+    cs = commands.get_cmds('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans')
     assert len(cs) == 2
     assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
     assert np.all(cs['pos'] == [75624, 73176])  # from params
@@ -61,7 +62,7 @@ def test_get_cmds():
 
 
 def test_get_cmds_zero_length_result():
-    cmds = commands.get_cmds(date='2017:001')
+    cmds = commands.get_cmds(date='2017:001:12:00:00')
     assert len(cmds) == 0
     assert cmds.colnames == ['idx', 'date', 'type', 'tlmsid', 'scs',
                              'step', 'timeline_id', 'vcdu', 'params']

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1728,7 +1728,7 @@ class SafeSun(TlmEvent):
                      | (msidset['c1sqax'].vals != 'ENAB'))
 
         # Telemetry indicates a safemode around 1999:221 which isn't real
-        bogus_tstart = DateTime('1999:225').secs
+        bogus_tstart = DateTime('1999:225:12:00:00').secs
         if msidset.tstart < bogus_tstart:
             ok = msidset.times < bogus_tstart
             safe_mode[ok] = False

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -76,7 +76,7 @@ def get_url(page, timeout=TIMEOUT):
 
 
 def get_ifot(event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT, types={}):
-    start = DateTime('1998:001' if start is None else start)
+    start = DateTime('1998:001:12:00:00' if start is None else start)
     stop = DateTime(stop)
     event_props = '.'.join([event_type] + props)
 

--- a/kadi/tests/test_events.py
+++ b/kadi/tests/test_events.py
@@ -76,13 +76,14 @@ def test_interval_pads():
 
 
 def test_query_event_intervals():
-    intervals = (events.manvrs & events.tsc_moves).intervals('2012:001', '2012:002')
+    intervals = (events.manvrs & events.tsc_moves).intervals('2012:001:12:00:00',
+                                                             '2012:002:12:00:00')
     assert intervals == [('2012:001:18:21:31.715', '2012:001:18:22:04.515'),
                          ('2012:002:02:53:03.804', '2012:002:02:54:50.917')]
 
 
 def test_basic_query():
-    rad_zones = events.rad_zones.filter('2013:001', '2013:007')
+    rad_zones = events.rad_zones.filter('2013:001:12:00:00', '2013:007:12:00:00')
     assert str(rad_zones).splitlines() == [
         '<RadZone: 1852 2013:003:16:19:36 2013:004:02:21:34 dur=36.1 ksec>',
         '<RadZone: 1853 2013:006:08:22:22 2013:006:17:58:48 dur=34.6 ksec>']
@@ -97,7 +98,7 @@ def test_basic_query():
         '2013:006:08:22:22.982 2013:006:17:58:48.982 473847810.166 473882396.166 34586.000  1853      1853 2013:006:13:58:21.389'  # noqa
     ]
 
-    rad_zones = events.rad_zones.filter('2013:001', '2013:002')
+    rad_zones = events.rad_zones.filter('2013:001:12:00:00', '2013:002:12:00:00')
     assert len(rad_zones) == 0
     assert len(rad_zones.table) == 0
 
@@ -123,7 +124,7 @@ def test_get_obsid():
     for model in models.values():
         if model.__name__ == 'SafeSun':
             continue  # Doesn't work for SafeSun because of bad OBC telem
-        model_obj = model.objects.filter(start__gte='2002:010')[0]
+        model_obj = model.objects.filter(start__gte='2002:010:12:00:00')[0]
         obsid = model_obj.get_obsid()
         obsid_obj = events.obsids.filter(obsid__exact=obsid)[0]
         model_obj_start = DateTime(getattr(model_obj, model_obj._get_obsid_start_attr)).date
@@ -146,14 +147,14 @@ def test_intervals_filter():
     Test setting filter keywords in the EventQuery object itself.
     """
     ltt_bads = events.ltt_bads
-    start, stop = '2000:121', '2000:134'
+    start, stop = '2000:121:12:00:00', '2000:134:12:00:00'
 
     # 2000-04-30 00:00:00 | ELBI_LOW        | R
     # 2000-04-30 00:00:00 | EPOWER1         | R
     # 2000-05-01 00:00:00 | 3SDTSTSV        | Y
     # 2000-05-13 00:00:00 | 3SDP15V         | 1
 
-    lines = sorted(str(ltt_bads().filter('2000:121', '2000:134')).splitlines())
+    lines = sorted(str(ltt_bads().filter('2000:121:12:00:00', '2000:134:12:00:00')).splitlines())
     assert (lines
             == ['<LttBad: start=2000:121:00:00:00.000 msid=ELBI_LOW flag=R>',
                 '<LttBad: start=2000:121:00:00:00.000 msid=EPOWER1 flag=R>',
@@ -188,7 +189,7 @@ def test_get_overlaps():
     overlap_starts, overlap_stops = zip(*overlaps)
     overlap_starts, overlap_stops = np.array(overlap_starts), np.array(overlap_stops)
 
-    x = events.manvrs.filter('2000:001', '2000:002')
+    x = events.manvrs.filter('2000:001:12:00:00', '2000:002:12:00:00')
     indices = x._get_full_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
     assert np.all(indices == [0, 1, 2])
 

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -80,7 +80,7 @@ HAS_OCCWEB = True if user is not None else False
 
 @pytest.mark.skipif('not HAS_OCCWEB')
 def test_ifot_fetch():
-    events = occweb.get_ifot('LOADSEG', start='2008:001', stop='2008:003')
+    events = occweb.get_ifot('LOADSEG', start='2008:001:12:00:00', stop='2008:003:12:00:00')
     assert len(events) == 1
     assert events[0]['tstart'] == '2008:002:21:00:00.000'
 

--- a/manual_test_cmds.py
+++ b/manual_test_cmds.py
@@ -26,7 +26,7 @@ def test_ingest():
     # sure the LazyVals will re-read.
     data_root_tmp = Ska.File.TempDir()
     data_root = data_root_tmp.name
-    update_cmds.main(['--start', '2011:340', '--stop', '2012:100',
+    update_cmds.main(['--start', '2011:340:12:00:00', '--stop', '2012:100:12:00:00',
                       '--data-root', data_root])
 
     # Some chicken-n-egg
@@ -39,7 +39,7 @@ def test_ingest():
     if hasattr(cmds.pars_dict, '_val'):
         del cmds.pars_dict._val
 
-    cmds_at_once = cmds.filter('2012:010', '2012:090')
+    cmds_at_once = cmds.filter('2012:010:12:00:00', '2012:090:12:00:00')
     pars_at_once = {v: k for k, v in cmds.pars_dict.items()}
 
     # Second part of funkiness to be able to use two different data root values
@@ -53,12 +53,12 @@ def test_ingest():
     if hasattr(cmds.pars_dict, '_val'):
         del cmds.pars_dict._val
 
-    stop0 = DateTime('2012:001')
+    stop0 = DateTime('2012:001:12:00:00')
     for dt in range(0, 100, 1):
         update_cmds.main(['--stop', (stop0 + dt).date,
                           '--data-root', data_root])
 
-    cmds_per_day = cmds.filter('2012:010', '2012:090')
+    cmds_per_day = cmds.filter('2012:010:12:00:00', '2012:090:12:00:00')
     pars_per_day = {v: k for k, v in cmds.pars_dict.items()}
 
     for name in ('date', 'type', 'tlmsid', 'scs', 'step', 'timeline_id'):

--- a/validate/gratings/compare_grating_moves.py
+++ b/validate/gratings/compare_grating_moves.py
@@ -18,7 +18,7 @@ from astropy.io import ascii
 from kadi import events
 from Chandra.Time import DateTime
 
-kadi_moves = events.grating_moves.filter(start='2000:160', stop='2014:008',
+kadi_moves = events.grating_moves.filter(start='2000:160:12:00:00', stop='2014:008:12:00:00',
                                          grating__contains='ETG').table
 mta_moves = Table.read('mta_grating_moves.dat', format='ascii',
                        converters={'START_TIME': [ascii.convert_numpy(np.str)],

--- a/validate/gratings/plot_grating.py
+++ b/validate/gratings/plot_grating.py
@@ -38,7 +38,7 @@ if 'msidset' not in globals():
     # msidset = fetch.Msidset(msids, '2013:357:10:00:00', '2013:357:10:15:00')
     # msidset = fetch.Msidset(msids, '2000:001:10:00:00', '2000:010:10:15:00')
     # msidset = fetch.Msidset(msids, '2001:145:16:40:00', '2001:145:16:46:00')
-    # msidset = fetch.Msidset(msids, '2001:188', '2001:191')
+    # msidset = fetch.Msidset(msids, '2001:188:12:00:00', '2001:191:12:00:00')
     msidset = fetch.Msidset(msids, '2000:048:08:09:19.544', '2000:048:08:14:36.344')
 
 


### PR DESCRIPTION
## Description

Non-controversial updates to dates for Chandra.Time 4.0+ compatibility, almost entirely in test files.

## Testing

- [x] Passes unit tests on MacOS (shiny)
- [x] Passes unit tests on MacOS (flight)
- [N/A] Functional testing
