### PR TITLE
SHINY: add times to states and commands outputs

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from astropy.table import Table, Row, Column, vstack
-from Chandra.Time import DateTime
+from Chandra.Time import DateTime, date2secs
 import pickle
 
 from ..paths import IDX_CMDS_PATH, PARS_DICT_PATH
@@ -90,15 +90,24 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
       >>> print(cmds)
 
     :param start: DateTime format (optional) Start time, defaults to beginning
-        of available commands (2002:001) :param stop: DateTime format (optional)
-        Stop time, defaults to end of available commands :param kwargs: key=val
-        keyword argument pairs
+        of available commands (2002:001)
+    :param stop: DateTime format (optional) Stop time, defaults to end of available
+        commands
+    :param inclusive_stop: bool, include commands at exactly ``stop`` if True.
+    :param kwargs: key=val keyword argument pairs for filtering
 
     :returns: :class:`~kadi.commands.commands.CommandTable` of commands
     """
     cmds = _find(start, stop, inclusive_stop, **kwargs)
     out = CommandTable(cmds)
     out['params'] = None if len(out) > 0 else Column([], dtype=object)
+
+    # Convert 'date' from bytestring to unicode. This allows
+    # date2secs(out['date']) to work and will generally reduce weird problems.
+    out.convert_bytestring_to_unicode()
+
+    out.add_column(date2secs(out['date']), name='time', index=6)
+    out['time'].info.format = '.3f'
 
     return out
 
@@ -133,6 +142,7 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
     out['tlmsid'] = np.chararray.encode(bs['tlmsid'])
     out['scs'] = bs['scs'].astype(np.uint8)
     out['step'] = bs['step'].astype(np.uint16)
+    out['time'] = date2secs(bs['date'])
     # Set timeline_id to 0, does not match any real timeline id
     out['timeline_id'] = np.zeros(n_bs, dtype=np.uint32)
     out['vcdu'] = bs['vcdu'].astype(np.int32)
@@ -154,7 +164,14 @@ def get_cmds_from_backstop(backstop, remove_starcat=True):
             params['event_type'] = params['type']
             del params['type']
 
-    return CommandTable(out)
+    out = CommandTable(out)
+    out['time'].info.format = '.3f'
+
+    # Convert 'date' from bytestring to unicode. This allows
+    # date2secs(out['date']) to work and will generally reduce weird problems.
+    out.convert_bytestring_to_unicode()
+
+    return out
 
 
 def _find(start=None, stop=None, inclusive_stop=False, **kwargs):
@@ -217,6 +234,7 @@ def _find(start=None, stop=None, inclusive_stop=False, **kwargs):
                     par_ok |= (idx_cmds['idx'] == idx)
             ok &= par_ok
     cmds = idx_cmds[ok]
+
     return cmds
 
 
@@ -258,7 +276,7 @@ class CommandRow(Row):
 
         out = ('{} {} '.format(self['date'], self['type'])
                + ' '.join('{}={}'.format(key, self[key]) for key in keys
-                          if key not in ('type', 'date')))
+                          if key not in ('type', 'date', 'time')))
         return out
 
     def __sstr__(self):

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 # Use data file from parse_cm.test for get_cmds_from_backstop test.
 # This package is a dependency
 import parse_cm.tests
+from Chandra.Time import secs2date
 
 # Import cmds module directly (not kadi.cmds package, which is from ... import cmds)
 from .. import commands
@@ -65,7 +66,7 @@ def test_get_cmds_zero_length_result():
     cmds = commands.get_cmds(date='2017:001:12:00:00')
     assert len(cmds) == 0
     assert cmds.colnames == ['idx', 'date', 'type', 'tlmsid', 'scs',
-                             'step', 'timeline_id', 'vcdu', 'params']
+                             'step', 'time', 'timeline_id', 'vcdu', 'params']
 
 
 def test_get_cmds_inclusive_stop():
@@ -85,8 +86,7 @@ def test_get_cmds_from_backstop_and_add_cmds():
     bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
     bs_cmds = commands.get_cmds_from_backstop(bs_file)
 
-    cmds = commands.get_cmds(start='2018:182:00:00:00',
-                             stop='2018:182:08:00:00')
+    cmds = commands.get_cmds(start='2018:182:00:00:00', stop='2018:182:08:00:00')
 
     assert len(bs_cmds) == 674
     assert len(cmds) == 56
@@ -94,6 +94,9 @@ def test_get_cmds_from_backstop_and_add_cmds():
     assert bs_cmds.colnames == cmds.colnames
     for bs_col, col in zip(bs_cmds.itercols(), cmds.itercols()):
         assert bs_col.dtype == col.dtype
+
+    assert np.all(secs2date(cmds['time']) == cmds['date'])
+    assert np.all(secs2date(bs_cmds['time']) == bs_cmds['date'])
 
     new_cmds = cmds.add_cmds(bs_cmds)
     assert len(new_cmds) == len(cmds) + len(bs_cmds)


### PR DESCRIPTION
## Description

This adds times (in CXC seconds) to states and commands.  In looking at real use cases these columns are typically needed and the impact of adding them by default is not so bad.

It also converts columns in the `CommandsTable` from bytes to unicode. I found that `Chandra.Time.date2secs` failed for bytes input.  This could be fixed, but that failure points to other subtle problems that can be encountered using bytestring values (even though astropy Table does a reasonable job of hiding that with the unicode sandwich).

## Testing

- [x] Passes unit tests on MacOS (shiny) (no longer targeted for merging to flight before shiny)
- [N/A] Functional testing
