### PR TITLE
Change default remove_starcat to False

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -103,13 +103,13 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
     return out
 
 
-def get_cmds_from_backstop(backstop, remove_starcat=True):
+def get_cmds_from_backstop(backstop, remove_starcat=False):
     """
     Initialize a ``CommandTable`` from ``backstop``, which can either
     be a string file name or a backstop table from ``parse_cm.read_backstop``.
 
     :param backstop: str or Table
-    :param remove_starcat: remove star catalog command parameters (default=True)
+    :param remove_starcat: remove star catalog command parameters (default=False)
     :returns: :class:`~kadi.commands.commands.CommandTable` of commands
     """
     if isinstance(backstop, Path):

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -83,7 +83,7 @@ def test_get_cmds_inclusive_stop():
 
 def test_get_cmds_from_backstop_and_add_cmds():
     bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
-    bs_cmds = commands.get_cmds_from_backstop(bs_file)
+    bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=True)
 
     cmds = commands.get_cmds(start='2018:182:00:00:00',
                              stop='2018:182:08:00:00')
@@ -104,7 +104,7 @@ def test_get_cmds_from_backstop_and_add_cmds():
     assert np.all(bs_cmds['params'][ok] == {})
 
     # Accept MP_STARCAT commands
-    bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=False)
+    bs_cmds = commands.get_cmds_from_backstop(bs_file)
     ok = bs_cmds['type'] == 'MP_STARCAT'
     assert np.count_nonzero(ok) == 15
     assert np.all(bs_cmds['params'][ok] != {})


### PR DESCRIPTION
## Description

I really don't recall why this option was there and why the default was True. From searching the sot org this only gets used in starcheck (using the previous default of removing star catalogs).  It doesn't matter there, but of all the places to toss out the star catalogs this one seems ironic.

## Testing

- [x] Passes unit tests on MacOS (shiny) (not planning to promote to current flight)
- [N/A] Functional testing
