### PR TITLE
Add helpers for compatibility with legacy commands / states code

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -372,3 +372,17 @@ class CommandTable(Table):
         out.sort(['date', 'step', 'scs'])
 
         return out
+
+    def as_list_of_dict(self):
+        """Convert CommandTable to a list of dict (ala Ska.ParseCM)
+
+        The command ``params`` are embedded as a dict for each command.
+
+        :return: list of dict
+        """
+        self.fetch_params()
+
+        names = self.colnames
+        cmds_list = [{name: cmd[name] for name in names} for cmd in self]
+
+        return cmds_list

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1510,6 +1510,10 @@ def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000)):
     if continuity_transitions:
         continuity['__transitions__'] = continuity_transitions
 
+    # Add tstart, tstop for legacy compatibility treating this as a state0 dict.
+    continuity['tstart'] = stop.secs
+    continuity['tstop'] = stop.secs
+
     return continuity
 
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -82,6 +82,17 @@ def test_get_cmds_inclusive_stop():
     assert np.all(cmds['date'] == [start, stop])
 
 
+def test_cmds_as_list_of_dict():
+    cmds = commands.get_cmds('2020:140', '2020:141')
+    cmds_list = cmds.as_list_of_dict()
+    assert isinstance(cmds_list, list)
+    assert isinstance(cmds_list[0], dict)
+    cmds_rt = commands.CommandTable(cmds)
+    assert set(cmds_rt.colnames) == set(cmds.colnames)
+    for name in cmds.colnames:
+        assert np.all(cmds_rt[name] == cmds[name])
+
+
 def test_get_cmds_from_backstop_and_add_cmds():
     bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
     bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=True)


### PR DESCRIPTION
## Description

This adds a helper method to convert CommandTable to list of dict.  This was useful for the ACIS review tools to get back to a format like Ska.ParseCM.

It also adds `tstart` and `tstop` to the continuity to make it look more like a `state0` dict.

## Testing

- [x] Passes unit tests on MacOS(shiny)
- [N/A] Functional testing
