### PR TITLE
workflow fix: conda channel update depends on mac os build as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
   update-channel:
     runs-on: head
     name: Update Conda Channel
-    needs: [build-linux]
+    needs: [build-linux, build-macos]
     steps:
       - name: Get linux package
         uses: actions/download-artifact@v2


### PR DESCRIPTION
workflow fix: conda channel update depends on mac os build as well