### PR TITLE
Migrate cmds.h5 idx column from 16 to 32 bits

### DIFF
--- a/NOTES.build
+++ b/NOTES.build
@@ -9,13 +9,6 @@ rm -rf kadi/events/migrations
 ./manage.py makemigrations events
 ./manage.py migrate
 
-# For commands one MUST do this in a dedicated test env because the pickling
-# of UpdatedDict does not work.  That object gets a module of __main__ but for
-# production it must be kadi.update_cmds.  See e.g.
-# https://www.stefaanlippens.net/python-pickling-and-dealing-with-attributeerror-
-# module-object-has-no-attribute-thing.html
-pip install .  # to a TEST env!!  (Maybe with -e for editable install?)
-
 # First line is just to see that every model works.  One can just drop the
 # --stop=2000:001 if you are sure it will work.
 kadi_update_events --start=1999:240 --stop=2000:001
@@ -29,3 +22,14 @@ kadi_update_cmds --start=2000:001
 % export KADI=$PWD
 % cp /proj/sot/ska/data/kadi/events.db3 ./
 % python -m kadi.update_events --start=1999:001 --model=CAP --delete-from-start
+
+################# Historical note about running in a test env #################
+#
+# This is not applicable after PR #190.
+#
+# For commands one MUST do this in a dedicated test env because the pickling
+# of UpdatedDict does not work.  That object gets a module of __main__ but for
+# production it must be kadi.update_cmds.  See e.g.
+# https://www.stefaanlippens.net/python-pickling-and-dealing-with-attributeerror-
+# module-object-has-no-attribute-thing.html
+pip install .  # to a TEST env!!  (Maybe with -e for editable install?)

--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -135,8 +135,8 @@ def get_cmds_from_backstop(backstop, remove_starcat=False):
 
     n_bs = len(bs)
     out = {}
-    # Set idx to max (2**32 -1) so it does not match any real idx
-    out['idx'] = np.full(n_bs, fill_value=4294967295, dtype=np.uint32)
+    # Set idx to -1 so it does not match any real idx
+    out['idx'] = np.full(n_bs, fill_value=-1, dtype=np.int32)
     out['date'] = np.chararray.encode(bs['date'])
     out['type'] = np.chararray.encode(bs['type'])
     out['tlmsid'] = np.chararray.encode(bs['tlmsid'])

--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -135,8 +135,8 @@ def get_cmds_from_backstop(backstop, remove_starcat=False):
 
     n_bs = len(bs)
     out = {}
-    # Set idx to max (2**16 -1) so it does not match any real idx
-    out['idx'] = np.full(n_bs, fill_value=65535, dtype=np.uint16)
+    # Set idx to max (2**32 -1) so it does not match any real idx
+    out['idx'] = np.full(n_bs, fill_value=4294967295, dtype=np.uint32)
     out['date'] = np.chararray.encode(bs['date'])
     out['type'] = np.chararray.encode(bs['type'])
     out['tlmsid'] = np.chararray.encode(bs['tlmsid'])

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -281,7 +281,7 @@ class ParamTransition(BaseTransition):
             try:
                 # This is generally faster than cmd['params'] since it avoids the 'params'
                 # magic in the Command class.  It will work unless the commands are from
-                # backstop; these have idx=65535 which gives KeyError.
+                # backstop; these have idx=4294967295 which gives KeyError.
                 params = dict(REV_PARS_DICT[cmd['idx']])
             except KeyError:
                 params = cmd['params']

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -281,7 +281,7 @@ class ParamTransition(BaseTransition):
             try:
                 # This is generally faster than cmd['params'] since it avoids the 'params'
                 # magic in the Command class.  It will work unless the commands are from
-                # backstop; these have idx=4294967295 which gives KeyError.
+                # backstop; these have idx=-1 which gives KeyError.
                 params = dict(REV_PARS_DICT[cmd['idx']])
             except KeyError:
                 params = cmd['params']

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -440,7 +440,10 @@ def main(args=None):
 
     if pars_dict.n_updated > 0:
         with open(pars_dict_path, 'wb') as fh:
-            pickle.dump(pars_dict, fh, protocol=2)
+            # Dump as pickle, first converting pars_dict from UpdatedDict to
+            # plain dict. The n_updated attribute is not used outside of
+            # update_cmds.py. See historical note in NOTES.build for context.
+            pickle.dump(dict(pars_dict), fh, protocol=2)
             logger.info('Wrote {} pars_dict values ({} new) to {}'
                         .format(len(pars_dict), pars_dict.n_updated, pars_dict_path))
     else:

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -19,7 +19,7 @@ from . import __version__
 
 MIN_MATCHING_BLOCK_SIZE = 500
 BACKSTOP_CACHE = {}
-CMDS_DTYPE = [('idx', np.uint16),
+CMDS_DTYPE = [('idx', np.uint32),
               ('date', '|S21'),
               ('type', '|S12'),
               ('tlmsid', '|S10'),

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -19,7 +19,7 @@ from . import __version__
 
 MIN_MATCHING_BLOCK_SIZE = 500
 BACKSTOP_CACHE = {}
-CMDS_DTYPE = [('idx', np.uint32),
+CMDS_DTYPE = [('idx', np.int32),
               ('date', '|S21'),
               ('type', '|S12'),
               ('tlmsid', '|S10'),

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -299,7 +299,12 @@ def get_idx_cmds(cmds, pars_dict):
         try:
             par_idx = pars_dict[pars_tup]
         except KeyError:
-            par_idx = len(pars_dict)
+            # Along with transition to 32-bit idx in #190, ensure that idx=65535
+            # never gets used. Prior to #190 this value was being used by
+            # get_cmds_from_backstop() assuming that it will never occur as a
+            # key in the pars_dict. Adding 65536 allows older versions to work
+            # with the new cmds.pkl pars_dict.
+            par_idx = len(pars_dict) + 65536
             pars_dict[pars_tup] = par_idx
 
         idx_cmds.append((par_idx, cmd['date'], cmd['type'], cmd.get('tlmsid'),

--- a/utils/migrate_cmds_idx_32bit.py
+++ b/utils/migrate_cmds_idx_32bit.py
@@ -10,7 +10,7 @@ print(cmds.dtype)
 # [('idx', '<u2'), ('date', 'S21'), ('type', 'S12'), ('tlmsid', 'S10'),
 #  ('scs', 'u1'), ('step', '<u2'), ('timeline_id', '<u4'), ('vcdu', '<i4')]
 
-new_dtype = [('idx', '<u4'), ('date', 'S21'), ('type', 'S12'), ('tlmsid', 'S10'),
+new_dtype = [('idx', '<i4'), ('date', 'S21'), ('type', 'S12'), ('tlmsid', 'S10'),
              ('scs', 'u1'), ('step', '<u2'), ('timeline_id', '<u4'), ('vcdu', '<i4')]
 new_cmds = cmds.astype(new_dtype)
 
@@ -33,4 +33,4 @@ for name in cmds.dtype.names:
     if name != 'idx':
         assert cmds[name].dtype == new_cmds[name].dtype
 
-assert new_cmds['idx'].dtype.str == '<u4'
+assert new_cmds['idx'].dtype.str == '<i4'

--- a/utils/migrate_cmds_idx_32bit.py
+++ b/utils/migrate_cmds_idx_32bit.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import numpy as np
+import tables
+
+# Use snapshot from aug08 before the last update that broke things.
+with tables.open_file('cmds_aug08.h5') as h5:
+    cmds = h5.root.data[:]
+
+print(cmds.dtype)
+# [('idx', '<u2'), ('date', 'S21'), ('type', 'S12'), ('tlmsid', 'S10'),
+#  ('scs', 'u1'), ('step', '<u2'), ('timeline_id', '<u4'), ('vcdu', '<i4')]
+
+new_dtype = [('idx', '<u4'), ('date', 'S21'), ('type', 'S12'), ('tlmsid', 'S10'),
+             ('scs', 'u1'), ('step', '<u2'), ('timeline_id', '<u4'), ('vcdu', '<i4')]
+new_cmds = cmds.astype(new_dtype)
+
+for name in cmds.dtype.names:
+    assert np.all(cmds[name] == new_cmds[name])
+
+cmds_h5 = Path('cmds.h5')
+if cmds_h5.exists():
+    cmds_h5.unlink()
+
+with tables.open_file('cmds.h5', mode='a') as h5:
+    h5.create_table(h5.root, 'data', new_cmds, "cmds", expectedrows=2e6)
+
+# Make sure the new file is really the same except the dtype
+with tables.open_file('cmds.h5') as h5:
+    new_cmds = h5.root.data[:]
+
+for name in cmds.dtype.names:
+    assert np.all(cmds[name] == new_cmds[name])
+    if name != 'idx':
+        assert cmds[name].dtype == new_cmds[name].dtype
+
+assert new_cmds['idx'].dtype.str == '<u4'


### PR DESCRIPTION
## Description

The `idx` column in the `cmds.h5` file was unfortunately sized at unsigned 16-bit int (65536). This identifies unique command parameters. The initial estimate that this would be more than enough proved to be faulty and the number exceeded 65536 with the AUG1720 loads.

Key elements are:
- Changed from uint16 to int32 for the `idx` column.
- Added code to ensure that `idx=65536` is never used. This ensures that the current ska3-flight kadi version 5.2.0 runs correctly (in particular `get_cmds_from_backstop`) with the new files.

This PR includes a new utility script that was used to migrate the `cmds.h5` as of August 8 (which did not suffer from the overflow issue) to a new version. The script contains checks that the new and previous commands are identical except for the dtype of `idx`.

With this PR that `cmds.h5` and `cmds.pkl` files were updated to the present using `python -m kadi.update_cmds` from the git repo on this branch. They have been installed to `/proj/sot/ska/data/kadi`.

The footprint of the fix is small and no current flight code is impacted.

## Testing

- [x] Passes unit tests on linux (HEAD flight) with one workaround to ignore an expected failure in dtype comparison
- [x] Passes units tests on linux (HEAD shiny)
- [x] Functional testing

### Functional testing

**Original problem report**

```
from kadi import commands
from kadi.commands import states

# Get commands from JUN2720 from backstop
backstop_file = "/data/acis/LoadReviews/2020/JUL2720/oflsb/CR208_1806.backstop"
cmds = commands.get_cmds_from_backstop(backstop_file)

t = states.get_states(cmds=cmds, merge_identical=True)
```
This produces the expected output on HEAD (kady) and GRETA (cheru).

**Starcheck**

- Ran starcheck on HEAD on the AUG2420A loads. No process problems and gave the expected output.
- Ran starcheck on HEAD on the AUG1020A loads. Outputs identical to flight except for small propagation changes.

**File contents**

Manually examined the `cmds.pkl` file and confirmed that the `idx` value jumps as expected and no 65535 is found.

Fixes #189