### PR TITLE
Unified documentation style

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+---
+name: Deploy Docs
+on:
+  release:
+    types:
+    - created
+  repository_dispatch:
+    types:
+    - build-docs
+
+jobs:
+  build-linux:
+    runs-on: head
+    name: Deploy Docs
+    steps:
+      - name: Fetch gh-pages
+        uses: actions/checkout@v2
+        with:
+          path: gh-pages
+          ref: gh-pages
+      - name: Fetch source
+        uses: actions/checkout@v2
+        with:
+          path: source
+      - name: clear
+        run: rm -fr gh-pages/docs/*
+      - name: build
+        run: |
+          eval "$(/export/jgonzale/github-workflows/miniconda3-shiny/bin/conda shell.bash hook)"
+          conda activate ska3-masters
+          mkdir -p _static
+          make html
+        working-directory: source/docs
+        env:
+          PYTHONPATH: ${{ github.workspace }}/source
+          GITHUB_API_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}
+      - name: copy
+        run: cp -fr source/docs/_build/html/* gh-pages/docs
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          ref: "gh-pages"
+          cwd: "gh-pages"
+          author_name: Javier Gonzalez
+          author_email: javierggt@yahoo.com
+          message: "Deploy docs"
+          add: "docs"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,9 @@ html_theme_options = {
     'logotext1': 'Ska!' ,
     'logotext2': 'Kadi',
     'logotext3': '',
+    'homepage_url': 'https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc',
+    'homepage_text': 'ska',
+    'homepage_text_2': 'tools'
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,9 +110,9 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 html_theme = 'bootstrap-ska'
 html_theme_options = {
-logotext1: 'Ska!' ,
-logotext2: 'Kadi',
-logotext3: '',
+    'logotext1': 'Ska!' ,
+    'logotext2': 'Kadi',
+    'logotext3': '',
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.pngmath',
+              'sphinx.ext.imgmath',
               'sphinx.ext.viewcode']
 
 try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,12 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'bootstrap-ska'
+html_theme_options = {
+logotext1: 'Ska!' ,
+logotext2: 'Kadi',
+logotext3: '',
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -924,7 +924,7 @@ def decode_power(mnem):
     Decode number of chips and feps from a ACIS power command
     Return a dictionary with the number of chips and their identifiers
 
-    Example::
+    Example:
 
     >>> decode_power("WSPOW08F3E")
     {'ccd_count': 5,


### PR DESCRIPTION
This PR changes the documentation to unify style among all ska packages. Documentation is always in the docs directory, with configuration in conf.py, and uses the ska theme.

This PR also includes trivial changes for documentation:
- `sphinx.ext.pngmath`
- Removing double-colon before code block