### PR TITLE
Use $SKA/data/mpcrit1 not /data/mpcrit1

### DIFF
--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -17,6 +17,8 @@ from ska_helpers.run_info import log_run_info
 from .paths import IDX_CMDS_PATH, PARS_DICT_PATH
 from . import __version__
 
+MPLOGS_DIR = Path(os.environ['SKA'], 'data', 'mpcrit1', 'mplogs')
+
 MIN_MATCHING_BLOCK_SIZE = 500
 BACKSTOP_CACHE = {}
 CMDS_DTYPE = [('idx', np.int32),
@@ -148,13 +150,15 @@ def _tl_to_bs_cmds(tl_cmds, tl_id, db):
     return bs_cmds
 
 
-def get_cmds(start, stop, mp_dir='/data/mpcrit1/mplogs'):
+def get_cmds(start, stop, mp_dir=MPLOGS_DIR):
     """
     Get backstop commands corresponding to the supplied timeline load segments.
     The timeline load segments must be ordered by 'id'.
 
     Return cmds in the format defined by Ska.ParseCM.read_backstop().
     """
+    mp_dir = str(mp_dir)
+
     # Get timeline_loads within date range.  Also get non-load commands
     # within the date range covered by the timelines.
     server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')


### PR DESCRIPTION
## Description

This continues the theme of making all required data for Ska3 be referenced from `$SKA/data`.

This changes the cmds update process to $SKA/data/mpcrit1 instead of /data/mpcrit1. This link is set up on HEAD and for standalone machines one can make an sshfs mount to the HEAD version.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (MacOS)

Functional testing was the ska_testr kadi regression test which generates a new events and cmds database. I did not run this on linux but it will get run automatically by the dashboard.
