### PR TITLE
Add Ska.ParseCM compatibility + read_backstop function

### DIFF
--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -10,7 +10,7 @@ import pickle
 
 from ..paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
-__all__ = ['get_cmds', 'get_cmds_from_backstop', 'CommandTable']
+__all__ = ['get_cmds', 'read_backstop', 'get_cmds_from_backstop', 'CommandTable']
 
 
 class LazyVal(object):
@@ -110,6 +110,21 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
     out['time'].info.format = '.3f'
 
     return out
+
+
+def read_backstop(backstop):
+    """Read ``backstop`` and return a ``CommandTable``.
+
+    The ``backstop`` argument can be either be a string file name or a backstop
+    table from ``parse_cm.read_backstop``.
+
+    This function is a wrapper around ``get_cmds_from_backstop`` but follows a
+    more typical naming convention.
+
+    :param backstop: str or Table
+    :returns: :class:`~kadi.commands.commands.CommandTable` of commands
+    """
+    return get_cmds_from_backstop(backstop)
 
 
 def get_cmds_from_backstop(backstop, remove_starcat=False):
@@ -373,16 +388,30 @@ class CommandTable(Table):
 
         return out
 
-    def as_list_of_dict(self):
-        """Convert CommandTable to a list of dict (ala Ska.ParseCM)
+    def as_list_of_dict(self, ska_parsecm=False):
+        """Convert CommandTable to a list of dict.
 
         The command ``params`` are embedded as a dict for each command.
 
+        If ``ska_parsecm`` is True then the output is made more compatible with
+        the legacy output from ``Ska.ParseCM.read_backstop()``, namely:
+
+        - Add ``cmd`` key which is set to the ``type`` key
+        - Make ``params`` keys uppercase.
+
+        :param ska_parsecm: bool, make output more Ska.ParseCM compatible
         :return: list of dict
         """
         self.fetch_params()
 
         names = self.colnames
         cmds_list = [{name: cmd[name] for name in names} for cmd in self]
+
+        if ska_parsecm:
+            for cmd in cmds_list:
+                if 'type' in cmd:
+                    cmd['cmd'] = cmd['type']
+                if 'params' in cmd:
+                    cmd['params'] = {key.upper(): val for key, val in cmd['params'].items()}
 
         return cmds_list

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -93,6 +93,29 @@ def test_cmds_as_list_of_dict():
         assert np.all(cmds_rt[name] == cmds[name])
 
 
+def test_cmds_as_list_of_dict_ska_parsecm():
+    """Test the ska_parsecm=True compatibility mode for list_of_dict"""
+    cmds = commands.get_cmds('2020:140', '2020:141')
+    cmds_list = cmds.as_list_of_dict(ska_parsecm=True)
+    assert isinstance(cmds_list, list)
+    assert isinstance(cmds_list[0], dict)
+    assert cmds_list[0] == {
+        'cmd': 'COMMAND_HW',  # Cmd parameter exists and matches type
+        'date': '2020:140:00:00:00.000',
+        'idx': 21387,
+        'params': {'HEX': '7C063C0', 'MSID': 'CIU1024T'},  # Keys are upper case
+        'scs': 129,
+        'step': 496,
+        'time': 706233669.184,
+        'timeline_id': 426104285,
+        'tlmsid': 'CIMODESL',
+        'type': 'COMMAND_HW',
+        'vcdu': 12516929}
+    for cmd in cmds_list:
+        assert cmd.get('cmd') == cmd.get('type')
+        assert all(param.upper() == param for param in cmd['params'])
+
+
 def test_get_cmds_from_backstop_and_add_cmds():
     bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
     bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=True)
@@ -117,8 +140,8 @@ def test_get_cmds_from_backstop_and_add_cmds():
     assert np.count_nonzero(ok) == 15
     assert np.all(bs_cmds['params'][ok] == {})
 
-    # Accept MP_STARCAT commands
-    bs_cmds = commands.get_cmds_from_backstop(bs_file)
+    # Accept MP_STARCAT commands (also check read_backstop command)
+    bs_cmds = commands.read_backstop(bs_file)
     ok = bs_cmds['type'] == 'MP_STARCAT'
     assert np.count_nonzero(ok) == 15
     assert np.all(bs_cmds['params'][ok] != {})


### PR DESCRIPTION
## Description

This PR does two things:

- Add a `ska_parsecm` flag to `CommandTable.as_list_of_dict` to provide better compatibility with code that had previously been using `Ska.ParseCM`.
- Adds a function `read_backstop` which is more consistent with the naming convention for similar functions (and in particular `parse_cm.read_backstop`. The `kadi.commands.read_backstop` function is preferred as it has a more performant data structure, but either are OK.  (And in fact the kadi version calls the parse_cm version under the hood).

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (new / updated unit tests)
