### PR TITLE
Add test of creating cmds archive and retry opening cmds.h5

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -132,7 +132,8 @@ def test_get_cmds_from_backstop_and_add_cmds():
 
 
 @pytest.mark.skipif('not HAS_MPDIR')
-def test_commands_regress(tmpdir):
+def test_commands_create_archive_regress(tmpdir):
+    """Create cmds archive from scratch and test that it matches flight"""
     kadi_orig = os.environ.get('KADI')
     start = CxoTime('2020:159:00:00:00')
     stop = start + 30

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1,15 +1,22 @@
 from pathlib import Path
+import os
 
 import numpy as np
 from astropy.table import Table
+import pytest
 
 # Use data file from parse_cm.test for get_cmds_from_backstop test.
 # This package is a dependency
 import parse_cm.tests
 from Chandra.Time import secs2date
+from cxotime import CxoTime
 
 # Import cmds module directly (not kadi.cmds package, which is from ... import cmds)
 from .. import commands
+from ... import update_cmds
+
+
+HAS_MPDIR = Path(os.environ['SKA'], 'data', 'mpcrit1', 'mplogs', '2020').exists()
 
 
 def test_find():
@@ -122,3 +129,43 @@ def test_get_cmds_from_backstop_and_add_cmds():
     ok = bs_cmds['type'] == 'MP_STARCAT'
     assert np.count_nonzero(ok) == 15
     assert np.all(bs_cmds['params'][ok] != {})
+
+
+@pytest.mark.skipif('not HAS_MPDIR')
+def test_commands_regress(tmpdir):
+    kadi_orig = os.environ.get('KADI')
+    start = CxoTime('2020:159:00:00:00')
+    stop = start + 30
+    cmds_flight = commands.get_cmds(start + 3, stop - 3)
+    cmds_flight.fetch_params()
+
+    try:
+        os.environ['KADI'] = str(tmpdir)
+        update_cmds.main((f'--start={start.date}',
+                          f'--stop={stop.date}',
+                          f'--data-root={tmpdir}'))
+        # Force reload of LazyVal
+        del commands.idx_cmds._val
+        del commands.pars_dict._val
+        del commands.rev_pars_dict._val
+
+        # Make sure we are seeing the temporary cmds archive
+        cmds_empty = commands.get_cmds(start - 60, start - 50)
+        assert len(cmds_empty) == 0
+
+        cmds_local = commands.get_cmds(start + 3, stop - 3)
+        cmds_local.fetch_params()
+        assert len(cmds_flight) == len(cmds_local)
+        for attr in ('tlmsid', 'date', 'params'):
+            assert np.all(cmds_flight[attr] == cmds_local[attr])
+
+    finally:
+        if kadi_orig is None:
+            del os.environ['KADI']
+        else:
+            os.environ['KADI'] = kadi_orig
+
+        # Force reload
+        del commands.idx_cmds._val
+        del commands.pars_dict._val
+        del commands.rev_pars_dict._val

--- a/kadi/update_cmds.py
+++ b/kadi/update_cmds.py
@@ -13,6 +13,7 @@ import Ska.DBI
 import Ska.File
 from Chandra.Time import DateTime
 from ska_helpers.run_info import log_run_info
+from ska_helpers.retry import retry_call
 
 from .paths import IDX_CMDS_PATH, PARS_DICT_PATH
 from . import __version__
@@ -324,7 +325,8 @@ def add_h5_cmds(h5file, idx_cmds):
     """
     # Note: reading this file uncompressed is about 5 times faster, so sacrifice file size
     # for read speed and do not use compression.
-    h5 = tables.open_file(h5file, mode='a')
+    h5 = retry_call(tables.open_file, [h5file], {'mode': 'a'},
+                    tries=4, delay=1, backoff=4)
 
     # Convert cmds (list of tuples) to numpy structured array.  This also works for an
     # existing structured array.


### PR DESCRIPTION
## Description

The driver here is to use `ska_helpers.retry` to avoid the 'Resource temporarily unavailable' error seen occasionally when updating the cmds archive.  See also #196 for the "client-side" analog.

In order to test that this was working, I ported the regression test from `ska_testr/packages/kadi/test_regress.sh` into a unit test. In theory that ska_testr test can be removed (but it isn't hurting anything and runs quickly).

## Testing

- [x] Passes unit tests on MacOS including new unit test (tested in ska3-dev with masters)
- [x] Functional testing

### Functional testing

I forced the open file function to fail twice to see it fail and then subsequently succeed. This was done by calling this stub `tables_open_file` function instead of `tables.open_file`.
```
fail_count = 0
def tables_open_file(*args, **kwargs):
    global fail_count
    if fail_count < 2:
        fail_count += 1
        raise IOError()
    else:
        return tables.open_file(*args, **kwargs)
```
The output was:
```
(ska3-shiny) ➜  kadi git:(update-cmds) ✗ pytest -k test_commands -v -s
============================================================== test session starts ==============================================================
platform darwin -- Python 3.8.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /Users/aldcroft/miniconda3/envs/ska3-shiny/bin/python
cachedir: .pytest_cache
rootdir: /Users/aldcroft/git/kadi, inifile: pytest.ini
collected 60 items / 51 deselected / 9 selected                                                                                                 

kadi/cmds/tests/test_commands.py::test_find PASSED
kadi/cmds/tests/test_commands.py::test_filter PASSED
kadi/commands/tests/test_commands.py::test_find PASSED
kadi/commands/tests/test_commands.py::test_get_cmds PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_zero_length_result PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_inclusive_stop PASSED
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_backstop_and_add_cmds PASSED
kadi/commands/tests/test_commands.py::test_commands_regress 2020-12-06 06:58:11,509 ******************************************
2020-12-06 06:58:11,509 Running: /Users/aldcroft/git/kadi/kadi/update_cmds.py
2020-12-06 06:58:11,510 Version: 5.4.1.dev2+g8135838.d20201206
2020-12-06 06:58:11,510 Time: Sun Dec  6 06:58:11 2020
2020-12-06 06:58:11,510 User: root
2020-12-06 06:58:11,510 Machine: sp4-mpt.occ.harvard.edu
2020-12-06 06:58:11,510 Processing args:
2020-12-06 06:58:11,510 {'data_root': '/private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0',
2020-12-06 06:58:11,510  'log_level': 10,
2020-12-06 06:58:11,510  'mp_dir': None,
2020-12-06 06:58:11,510  'start': '2020:159:00:00:00.000',
2020-12-06 06:58:11,510  'stop': '2020:189:00:00:00.000'}
2020-12-06 06:58:11,510 ******************************************
2020-12-06 06:58:11,510 No pars_dict file /private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.pkl found, starting from empty dict
2020-12-06 06:58:11,576 Using mission planning files at /Users/aldcroft/ska/data/mpcrit1/mplogs
2020-12-06 06:58:11,583 Found 0 non-load commands between 2020:157:10:40:59.137 : 2020:189:00:00:00.000
2020-12-06 06:58:11,584 Found 28 timelines included within 2020:159:00:00:00.000 to 2020:189:00:00:00.000
2020-12-06 06:58:11,944 Read 1116 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUN0120/oflsa/CR153_0501.backstop
2020-12-06 06:58:11,947   Got 263 backstop commands for timeline_id=426104305 and SCS=129
2020-12-06 06:58:12,010   Got 155 backstop commands for timeline_id=426104306 and SCS=132
2020-12-06 06:58:12,376 Read 1568 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUN0820/oflsa/CR160_0004.backstop
2020-12-06 06:58:12,380   Got 228 backstop commands for timeline_id=426104307 and SCS=130
2020-12-06 06:58:12,446   Got 150 backstop commands for timeline_id=426104308 and SCS=133
2020-12-06 06:58:12,513   Got 268 backstop commands for timeline_id=426104309 and SCS=128
2020-12-06 06:58:12,578   Got 145 backstop commands for timeline_id=426104310 and SCS=131
2020-12-06 06:58:12,645   Got 306 backstop commands for timeline_id=426104311 and SCS=129
2020-12-06 06:58:12,710   Got 407 backstop commands for timeline_id=426104312 and SCS=132
2020-12-06 06:58:13,076 Read 1359 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUN1520/oflsa/CR166_1003.backstop
2020-12-06 06:58:13,079   Got 273 backstop commands for timeline_id=426104313 and SCS=130
2020-12-06 06:58:13,144   Got 133 backstop commands for timeline_id=426104314 and SCS=133
2020-12-06 06:58:13,207   Got 258 backstop commands for timeline_id=426104315 and SCS=128
2020-12-06 06:58:13,271   Got 144 backstop commands for timeline_id=426104316 and SCS=131
2020-12-06 06:58:13,334   Got 244 backstop commands for timeline_id=426104317 and SCS=129
2020-12-06 06:58:13,398   Got 143 backstop commands for timeline_id=426104318 and SCS=132
2020-12-06 06:58:13,461   Got 54 backstop commands for timeline_id=426104319 and SCS=130
2020-12-06 06:58:13,525   Got 35 backstop commands for timeline_id=426104320 and SCS=133
2020-12-06 06:58:13,881 Read 1196 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUN2220/oflsa/CR174_0901.backstop
2020-12-06 06:58:13,885   Got 419 backstop commands for timeline_id=426104321 and SCS=128
2020-12-06 06:58:13,949   Got 281 backstop commands for timeline_id=426104322 and SCS=131
2020-12-06 06:58:14,014   Got 258 backstop commands for timeline_id=426104323 and SCS=129
2020-12-06 06:58:14,212   Got 175 backstop commands for timeline_id=426104324 and SCS=132
2020-12-06 06:58:14,568 Read 1406 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUN2920/oflsa/CR181_0402.backstop
2020-12-06 06:58:14,572   Got 296 backstop commands for timeline_id=426104325 and SCS=130
2020-12-06 06:58:14,638   Got 172 backstop commands for timeline_id=426104326 and SCS=133
2020-12-06 06:58:14,702   Got 370 backstop commands for timeline_id=426104327 and SCS=128
2020-12-06 06:58:14,768   Got 223 backstop commands for timeline_id=426104328 and SCS=131
2020-12-06 06:58:14,831   Got 178 backstop commands for timeline_id=426104329 and SCS=129
2020-12-06 06:58:14,894   Got 109 backstop commands for timeline_id=426104330 and SCS=132
2020-12-06 06:58:15,263 Read 1908 commands from /Users/aldcroft/ska/data/mpcrit1/mplogs/2020/JUL0620/oflsb/CR187_1502.backstop
2020-12-06 06:58:15,269   Got 377 backstop commands for timeline_id=426104331 and SCS=130
2020-12-06 06:58:15,336   Got 242 backstop commands for timeline_id=426104332 and SCS=133
2020-12-06 06:58:15,361 Read total of 384 orbit commands
2020-12-06 06:58:15,365 Read total of 6690 commands (0 non-load commands)
WARNING: tables_open_file(/private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.h5, mode=a) exception: , retrying in 1 seconds...
WARNING: tables_open_file(/private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.h5, mode=a) exception: , retrying in 4 seconds...
2020-12-06 06:58:16,898 Created h5 cmds table /private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.h5
2020-12-06 06:58:16,899 Upated HDF5 cmds table /private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.h5
2020-12-06 06:58:16,900 Wrote 608 pars_dict values (608 new) to /private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pytest-of-aldcroft/pytest-160/test_commands_regress0/cmds.pkl
PASSED

======================================================= 9 passed, 51 deselected in 9.90s ========================================================
```
