### PR TITLE
Make kadi events complete from start of mission

### DIFF
--- a/NOTES.build
+++ b/NOTES.build
@@ -11,7 +11,7 @@ rm -rf kadi/events/migrations
 
 # First line is just to see that every model works.  One can just drop the
 # --stop=2000:001 if you are sure it will work.
-kadi_update_events --start=1999:240 --stop=2000:001
+kadi_update_events --start=1999:001 --stop=2000:001
 kadi_update_events --start=2000:001
 kadi_update_cmds --start=2000:001
 
@@ -22,14 +22,3 @@ kadi_update_cmds --start=2000:001
 % export KADI=$PWD
 % cp /proj/sot/ska/data/kadi/events.db3 ./
 % python -m kadi.update_events --start=1999:001 --model=CAP --delete-from-start
-
-################# Historical note about running in a test env #################
-#
-# This is not applicable after PR #190.
-#
-# For commands one MUST do this in a dedicated test env because the pickling
-# of UpdatedDict does not work.  That object gets a module of __main__ but for
-# production it must be kadi.update_cmds.  See e.g.
-# https://www.stefaanlippens.net/python-pickling-and-dealing-with-attributeerror-
-# module-object-has-no-attribute-thing.html
-pip install .  # to a TEST env!!  (Maybe with -e for editable install?)

--- a/NOTES.build
+++ b/NOTES.build
@@ -1,24 +1,36 @@
 #################################################################
-# From scratch
+# Events from scratch
 #################################################################
 
 cd ~/git/kadi
 export KADI=$PWD
-rm -f events3.db3 cmds.h5 cmds.pkl
+rm -f events3.db3
 rm -rf kadi/events/migrations
 ./manage.py makemigrations events
 ./manage.py migrate
 
 # First line is just to see that every model works.  One can just drop the
 # --stop=2000:001 if you are sure it will work.
-kadi_update_events --start=1999:001 --stop=2000:001
-kadi_update_events --start=2000:001
-kadi_update_cmds --start=2000:001
+# Note: use kadi_update_events for the installed version.
+python -m kadi.update_events --start=1999:001 --stop=2000:001
+python -m kadi.update_events --start=2000:001
 
 #################################################################
-# Re-build single table
+# Re-build single events table
 #################################################################
 
 % export KADI=$PWD
 % cp /proj/sot/ska/data/kadi/events.db3 ./
 % python -m kadi.update_events --start=1999:001 --model=CAP --delete-from-start
+
+#################################################################
+# Commands from scratch
+#################################################################
+
+cd ~/git/kadi
+export KADI=$PWD
+rm -f cmds.h5 cmds.pkl
+
+# Note: use kadi_update_events for the installed version.
+python -m kadi.update_cmds --start=2000:001
+


### PR DESCRIPTION
## Description

This makes event processing robust to getting no applicable telemetry or events, thus allowing the start of the event database build process to be set to an early date like 1999:001.

The `events3.db3` database was rebuilt from scratch on kady using the updated `NOTES.build` instructions.
- Confirmed that key events like `Obsid` and `Manvr` showed the expected new events coinciding with the beginning of available CXC L0 engineering telemetry on 1999:204.
- No errors and only expected processing warnings.

With the merging of this the new events file will be copied to flight.

## Testing

- [x] Passes unit tests on MacOS (using both current flight and the new events database)
- [x] Functional testing

### Functional testing

Used the `validate/write_events_cmds.py` script to write ECSV text files for each event type corresponding to two date ranges:
- 1999:240 - 2021:070 (expected to match)
- 1999:001 - 1999:240 (expected to have new entries)

```
ska3-kady$ diff -r -q flight new  # 1999:240 to 2021:070
Files flight/orbits.ecsv and new/orbits.ecsv differ   # OK: some few seconds diffs
Files flight/pass_plans.ecsv and new/pass_plans.ecsv differ  # OK, few changes in BOT/EOT like 0345 -> 345
Files flight/rad_zones.ecsv and new/rad_zones.ecsv differ # OK, few seconds diffs
Files flight/safe_suns.ecsv and new/safe_suns.ecsv differ  # OK, float format issues (e.g. 1.0000004 -> 0.9999996)
Files flight/scs107s.ecsv and new/scs107s.ecsv differ  # OK, float format issues
```

Inspection of the files for the 1999:001 - 1999:240 exports show the expected new values 