### PR TITLE
Make sure django is loaded if it is not already loaded

### DIFF
--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -53,7 +53,7 @@ import django
 # Jupyter notebook: SynchronousOnlyOperation: You cannot call this from an async
 # context. See: https://stackoverflow.com/questions/59119396
 
-if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+if 'DJANGO_SETTINGS_MODULE' not in os.environ or 'manvrs' not in locals():
     os.environ['DJANGO_SETTINGS_MODULE'] = 'kadi.settings'
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
     django.setup()


### PR DESCRIPTION
## Description

This PR would Fix #201.

The way it is currently set up, `kadi` loads django if the DJANGO_SETTINGS_MODULE is not defined. The assumption is that, because django sets this variable during loading, if it is defined it means django is loaded. This fails when a child process is spawned, because the variable will be defined for children processes, but the children processes do no inherit the python module.

I added another condition for loading django. Namely, that the `manvrs` variable is not defined within `kadi.events`.

Possible things to do:
- remove the check for DJANGO_SETTINGS_MODULE
- does this check need to be made elsewhere?
- add a unit test case with the gist from #201 (or some other test involving spawned processes).

## Testing

- [x] Passes unit tests on MacOS. (well, it actually fails, but already failed before this change)
- [x] Functional testing. Used the gist linked to in issue #201

Fixes #