### PR TITLE
changed ALLOWED_HOSTS to include all host names we use.

### DIFF
--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -87,8 +87,12 @@ except IOError:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS = [
+    'kadi.cfa.harvard.edu',
+    'web-kadi.cfa.harvard.edu',
+    'kadi-test.cfa.harvard.edu',
+    'web-kadi-test.cfa.harvard.edu',
+]
 
 # Application definition
 


### PR DESCRIPTION
## Description

This PR changes the ALLOWED_HOSTS variable in Django settings so it includes all our common hostnames. Perhaps we should consider going over the configuration.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing on web-kadi-test server
