### PR TITLE
Add note about removing bad dump

### DIFF
--- a/NOTES.build
+++ b/NOTES.build
@@ -16,6 +16,14 @@ python -m kadi.update_events --start=1999:001 --stop=2000:001
 python -m kadi.update_events --start=2000:001
 
 #################################################################
+# Remove bad momentum dump (bad telem just before safe mode)
+# Search slack 'momentum "dump" on DOY 2020:145 that is an artifact'
+#################################################################
+% cd $SKA/data/kadi  # As needed
+% sqlite3 events3.db3
+sqlite> delete from events_dump where start='2020:145:14:17:22.641';
+
+#################################################################
 # Re-build single events table
 #################################################################
 


### PR DESCRIPTION
## Description

Inelegant fix to a problem in the events database noted by Scott B. The event has been removed from the flight database with the cited command on HEAD and GRETA.

## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing
After deleting that entry the bad dump is no longer there:
```
In [1]: from kadi import events                                                                                                             
In [2]: events.dumps.filter('2020:140')[0]                                                                                             
Out[2]: <Dump: start=2020:269:20:32:00.619 dur=213>
```

