### PR TITLE
Improve list view and fix old web-kadi issue

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -2174,12 +2174,12 @@ class Orbit(BaseEvent):
     ================== ========== ==================================================
           Field           Type                       Description
     ================== ========== ==================================================
+            orbit_num    Integer                                       Orbit number
                 start   Char(21)         Start time (orbit ascending node crossing)
                  stop   Char(21)     Stop time (next orbit ascending node crossing)
                tstart      Float         Start time (orbit ascending node crossing)
                 tstop      Float     Stop time (next orbit ascending node crossing)
                   dur      Float                               Orbit duration (sec)
-            orbit_num    Integer                                       Orbit number
               perigee   Char(21)                                       Perigee time
                apogee   Char(21)                                        Apogee time
             t_perigee      Float                             Perigee time (CXC sec)
@@ -2189,6 +2189,7 @@ class Orbit(BaseEvent):
       dt_stop_radzone      Float    Stop time of rad zone relative to perigee (sec)
     ================== ========== ==================================================
     """
+    orbit_num = models.IntegerField(primary_key=True, help_text='Orbit number')
     start = models.CharField(max_length=21,
                              help_text='Start time (orbit ascending node crossing)')
     stop = models.CharField(max_length=21,
@@ -2197,7 +2198,6 @@ class Orbit(BaseEvent):
                                help_text='Start time (orbit ascending node crossing)')
     tstop = models.FloatField(help_text='Stop time (next orbit ascending node crossing)')
     dur = models.FloatField(help_text='Orbit duration (sec)')
-    orbit_num = models.IntegerField(primary_key=True, help_text='Orbit number')
     perigee = models.CharField(max_length=21, help_text='Perigee time')
     apogee = models.CharField(max_length=21, help_text='Apogee time')
     t_perigee = models.FloatField(help_text='Perigee time (CXC sec)')

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -2174,12 +2174,12 @@ class Orbit(BaseEvent):
     ================== ========== ==================================================
           Field           Type                       Description
     ================== ========== ==================================================
-            orbit_num    Integer                                       Orbit number
                 start   Char(21)         Start time (orbit ascending node crossing)
                  stop   Char(21)     Stop time (next orbit ascending node crossing)
                tstart      Float         Start time (orbit ascending node crossing)
                 tstop      Float     Stop time (next orbit ascending node crossing)
                   dur      Float                               Orbit duration (sec)
+            orbit_num    Integer                                       Orbit number
               perigee   Char(21)                                       Perigee time
                apogee   Char(21)                                        Apogee time
             t_perigee      Float                             Perigee time (CXC sec)
@@ -2189,7 +2189,6 @@ class Orbit(BaseEvent):
       dt_stop_radzone      Float    Stop time of rad zone relative to perigee (sec)
     ================== ========== ==================================================
     """
-    orbit_num = models.IntegerField(primary_key=True, help_text='Orbit number')
     start = models.CharField(max_length=21,
                              help_text='Start time (orbit ascending node crossing)')
     stop = models.CharField(max_length=21,
@@ -2198,6 +2197,7 @@ class Orbit(BaseEvent):
                                help_text='Start time (orbit ascending node crossing)')
     tstop = models.FloatField(help_text='Stop time (next orbit ascending node crossing)')
     dur = models.FloatField(help_text='Orbit duration (sec)')
+    orbit_num = models.IntegerField(primary_key=True, help_text='Orbit number')
     perigee = models.CharField(max_length=21, help_text='Perigee time')
     apogee = models.CharField(max_length=21, help_text='Apogee time')
     t_perigee = models.FloatField(help_text='Perigee time (CXC sec)')

--- a/kadi/events/templates/events/event_list.html
+++ b/kadi/events/templates/events/event_list.html
@@ -20,11 +20,11 @@
         <tr>
           {% for val in event_row %}
           <td>
-            {% if forloop.first %}
+            {% ifequal forloop.counter0 model_pk_col_index %}
             <a href="/kadi/events/{{ model_name }}/{{val}}?filter={{filter}}&sort={{sort}}&index={{index}}">{{ val }}</a>
             {% else %}
             {{ val }}
-            {% endif %}
+            {% endifequal %}
           </td>
           {% endfor %}
         </tr>

--- a/kadi/events/views.py
+++ b/kadi/events/views.py
@@ -200,6 +200,10 @@ Examples:
                   if field.name not in self.ignore_fields]
         field_names = [field.name for field in fields]
 
+        # Get index of primary key in field_names. This gets used in the
+        # template to make a reference for the detail page.
+        context['model_pk_col_index'] = field_names.index(self.model._meta.pk.name)
+
         root_url = '/kadi/events/{}/list'.format(context['model_name'])
         filter_ = context['filter']
         sort = context['sort']

--- a/kadi/events/views.py
+++ b/kadi/events/views.py
@@ -15,7 +15,7 @@ MODEL_NAMES = {m_class.__name__: m_name
 
 
 class BaseView(object):
-    reverse_sort = False  # Reverse the default sort by model primary key (e.g. CAPs)
+    reverse_sort = True  # Reverse the default sort by model primary key (e.g. CAPs)
 
     def get_sort(self):
         sort = self.request.GET.get('sort')
@@ -255,17 +255,14 @@ class TscMoveList(EventList):
 
 class DarkCalReplicaList(EventList):
     model = models.DarkCalReplica
-    reverse_sort = True
 
 
 class DarkCalList(EventList):
     model = models.DarkCal
-    reverse_sort = True
 
 
 class Scs107List(EventList):
     model = models.Scs107
-    reverse_sort = True
 
 
 class GratingMoveList(EventList):
@@ -274,7 +271,6 @@ class GratingMoveList(EventList):
 
 class LoadSegmentList(EventList):
     model = models.LoadSegment
-    reverse_sort = True
 
 
 class FaMoveList(EventList):
@@ -321,14 +317,12 @@ class CAPList(EventList):
     filter_string_field = 'title'
     filter_string_op = 'icontains'
     ignore_fields = EventList.ignore_fields + ['descr', 'notes', 'link']
-    reverse_sort = True
 
 
 class DsnCommList(EventList):
     model = models.DsnComm
     filter_string_field = 'activity'
     filter_string_op = 'icontains'
-    reverse_sort = True
 
 
 class OrbitList(EventList):

--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -88,6 +88,7 @@ except IOError:
 DEBUG = True
 
 ALLOWED_HOSTS = [
+    '127.0.0.1',
     'kadi.cfa.harvard.edu',
     'web-kadi.cfa.harvard.edu',
     'kadi-test.cfa.harvard.edu',


### PR DESCRIPTION
## Description

Fix the old issue https://github.com/sot/web-kadi/issues/2. The problem was that the template expects the first field to be the primary key. This PR takes the approach of just changing the field order to make that the case for `Orbit` events.

It also addresses the request to reverse the time order. This is done for all event types, which seems reasonable to me.

Lastly, this PR adds localhost to the ALLOWED_HOSTS list because the local server doesn't work without that.

Note: this is based on eed97c1 (Merge pull request #204 from sot/note-bad-dump) which is the commit before #202 that breaks using the local server.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

- Ran a local server and verified that Orbit events can be selected from the list view and properly displayed in detail view.
- Confirmed that the sort order is reversed in all event types.

Fixes https://github.com/sot/web-kadi/issues/2