### PR TITLE
Fix #206

### DIFF
--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -43,6 +43,8 @@ More help available at:
 
 import os
 import django
+from django.conf import settings
+from django.utils.functional import empty
 
 # If we are running standalone then this ENV var is not set.  Need to explicitly
 # do the setup and then import query module attributes for standalone.
@@ -53,7 +55,7 @@ import django
 # Jupyter notebook: SynchronousOnlyOperation: You cannot call this from an async
 # context. See: https://stackoverflow.com/questions/59119396
 
-if 'DJANGO_SETTINGS_MODULE' not in os.environ or 'manvrs' not in locals():
+if 'DJANGO_SETTINGS_MODULE' not in os.environ or settings._wrapped is empty:
     os.environ['DJANGO_SETTINGS_MODULE'] = 'kadi.settings'
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
     django.setup()

--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -55,8 +55,9 @@ from django.utils.functional import empty
 # Jupyter notebook: SynchronousOnlyOperation: You cannot call this from an async
 # context. See: https://stackoverflow.com/questions/59119396
 
-if 'DJANGO_SETTINGS_MODULE' not in os.environ or settings._wrapped is empty:
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'kadi.settings'
+if settings._wrapped is empty:
+    if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'kadi.settings'
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
     django.setup()
     from .query import *  # noqa


### PR DESCRIPTION
## Description

PR #202 was made to enable importing kadi in subprocesses, as explained in #201, but that broke the local server functionality (#206). This PR is an attempt to fix that.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing
     - [x] gist linked to in #201
     - [x] the local server functionality from ska_testr/packages/kadi/test_regress.sh (I'm not sure running the actual test using runtestr will do the right thing here)

Fixes #206