### PR TITLE
Add functions to help use OCCweb as a file server, including caching

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,3 +26,9 @@ Command states
 .. automodule:: kadi.commands.states
    :members:
    :show-inheritance:
+
+OCCweb access
+-------------
+
+.. automodule:: kadi.occweb
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_logo = 'ska.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -17,23 +17,32 @@ import requests
 
 from Chandra.Time import DateTime
 from astropy.io import ascii
+from astropy.table import Table
+from astropy.utils.data import download_file
+import pyyaks.logger
 
+# This is for deprecated functionality to cache to a local directory
 CACHE_DIR = 'cache'
 CACHE_TIME = 86000
 TIMEOUT = 60
 
-ROOTURL = 'http://occweb.cfa.harvard.edu'
+ROOTURL = 'https://occweb.cfa.harvard.edu'
 URLS = {'fdb_major_events': '/occweb/web/fdb_web/Major_Events.html',
         'fot_major_events': '/occweb/web/fot_web/eng/reports/Chandra_major_events.htm',
         'ifot': '/occweb/web/webapps/ifot/ifot.php',
         }
 
+# Initialize logger with default INFO level. Logging in this module is VERBOSE.
+logger = pyyaks.logger.get_logger(__name__)
 
-def get_auth():
-    username = None
+
+def get_auth(username=None, password=None):
+    if username and password:
+        return (username, password)
+
     ska = os.environ.get('SKA')
     if ska:
-        user = os.environ.get('USER') or os.environ.get('LOGNAME')
+        user = username or os.environ.get('USER') or os.environ.get('LOGNAME')
         authfile = Path(ska, 'data', 'aspect_authorization', f'occweb-{user}')
         config = configobj.ConfigObj(str(authfile))
         username = config.get('username')
@@ -53,12 +62,16 @@ def get_auth():
 
 
 def get_url(page, timeout=TIMEOUT):
-    """
-    Get the HTML for a web `page` on OCCweb.  This caches the result if the CACHE_DIR is
-    available.  The cachefile is used if it is less than a day old.  This is mostly for
-    testing, in production the cron job runs once a day.
+    """Get the HTML for a web `page` on OCCweb.
+
+    DEPRECATED for new code, use get_occweb_page() instead.
+
+    This caches the result if the CACHE_DIR is available.  The cachefile is used
+    if it is less than a day old.  This is mostly for testing, in production the
+    cron job runs once a day.
     """
     url = ROOTURL + URLS[page]
+
     cachefile = os.path.join(CACHE_DIR, hashlib.sha1(url.encode('utf-8')).hexdigest())
     now = time.time()
     if os.path.exists(cachefile) and now - os.stat(cachefile).st_mtime < CACHE_TIME:
@@ -166,3 +179,98 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
                 ftp.delete(file_base)
 
     ftp.close()
+
+
+def get_auth_http_headers(username, password):
+    """Get HTTP header for basic authentication"""
+    from base64 import b64encode
+    authorization = ('Basic '
+                     + b64encode(f'{username}:{password}'.encode('utf-8')).decode('utf-8'))
+    headers = {'Authorization': authorization}
+    return headers
+
+
+def get_occweb_page(path, timeout=30, cache=False, binary=False,
+                    user=None, password=None):
+    """Get contents of ``path`` on OCCweb.
+
+    This returns the contents of the OCCweb page at ``path`` where it assumed
+    that ``path`` is either a URL (which starts with 'https://occweb') or a
+    relative path::
+
+      https://occweb.cfa.harvard.edu/occweb/<path>
+
+    If ``user`` and ``password`` are not provided then it is required that
+    credentials are stored in the file ``~/.netrc``. See the ``Ska.ftp`` package
+    for details.
+
+    :param path: str, Path
+        Relative path on OCCweb or an OCCweb URL
+    :param timeout: int
+        Timeout in seconds for the request
+    :param cache: bool
+        If True, cache the result and check cache for subsequent calls
+    :param binary: bool
+        If True, return the binary contents of the page
+    :param user: str, optional
+        Username for OCCweb authentication
+    :param password: str, optional
+        Password for OCCweb authentication
+    :returns: str, bytes
+        File contents (str if ``binary`` is False, bytes if ``binary`` is True)
+    """
+    if isinstance(path, str) and path.startswith('https://occweb'):
+        url = path
+    else:
+        url = ROOTURL + (Path('/occweb') / path).as_posix()
+
+    logger.verbose(f'Getting OCCweb {path} with {cache=}')
+    if cache:
+        user, password = get_auth(user, password)
+        headers = get_auth_http_headers(user, password)
+        cachefile = download_file(url, cache=cache, show_progress=False,
+                                  http_headers=headers, timeout=timeout,
+                                  pkgname='kadi')
+        pth = Path(cachefile)
+        out = pth.read_bytes() if binary else pth.read_text()
+    else:
+        # Not caching so don't write to a file (per download_file) just get it.
+        auth = get_auth(user, password)
+        req = requests.get(url, auth=auth, timeout=timeout)
+        req.raise_for_status()  # raise exception if not 200
+
+        out = req.content if binary else req.text
+
+    return out
+
+
+def get_occweb_dir(path, timeout=30, cache=False, user=None, password=None):
+    """Get directory listing for ``path`` on OCCweb.
+
+    This returns the directory for ``path`` on OCCweb, where it assumed that
+    ``path`` is a relative path::
+
+      https://occweb.cfa.harvard.edu/occweb/<path>
+
+    If ``user`` and ``password`` are not provided then it is required that
+    credentials are stored in the file ``~/.netrc``. See the ``Ska.ftp`` package
+    for details.
+
+    :param path: str, Path
+        Relative path on OCCweb
+    :param timeout: int
+        Timeout in seconds for the request
+    :param cache: bool
+        If True, cache the result and check cache for subsequent calls
+    :param user: str, optional
+        Username for OCCweb authentication
+    :param password: str, optional
+        Password for OCCweb authentication
+    :returns: astropy Table
+        Table of directory entries
+    """
+    html = get_occweb_page(path, timeout=timeout, cache=cache)
+    out = Table.read(html, format='ascii.html', guess=False)
+    del out['col0']
+    del out['Description']
+    return out

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -46,7 +46,7 @@ def get_auth(username=None, password=None):
     This takes credentials either from:
 
     - Supplied ``username`` and ``password`` if both are given
-    - ``$SKA/data/aspect_authorization/occweb-<user>.cfg``
+    - ``$SKA/data/aspect_authorization/occweb-<username>.cfg``
     - ``~/.netrc``
 
     :param username: str, optional

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Provide an interface for getting pages from the OCCweb.  For good measure leave
-this off of github.
+Provide an interface for getting pages from the OCCweb.
 """
 
 import re
@@ -36,7 +35,28 @@ URLS = {'fdb_major_events': '/occweb/web/fdb_web/Major_Events.html',
 logger = pyyaks.logger.get_logger(__name__)
 
 
+__all__ = ['get_auth', 'get_url', 'get_ifot', 'get_occweb_page',
+           'get_auth_http_headers', 'get_occweb_dir', 'ftp_put_to_lucky',
+           'ftp_get_from_lucky']
+
+
 def get_auth(username=None, password=None):
+    """Get OCCweb authentication credentials.
+
+    This takes credentials either from:
+
+    - Supplied ``username`` and ``password`` if both are given
+    - ``$SKA/data/aspect_authorization/occweb-<user>.cfg``
+    - ``~/.netrc``
+
+    :param username: str, optional
+        Username for OCCweb authentication
+    :param password: str, optional
+        Password for OCCweb authentication
+
+    :returns: tuple
+        (username, password)
+    """
     if username and password:
         return (username, password)
 


### PR DESCRIPTION
## Description

This adds a couple of utility functions to facilitate access to files on OCCweb. Both of these handle authentication implicitly and allow specifying either a full URL or a shortened path. 

The shortened path can be either a string or a Path (where the latter makes it easier to chain down directories). The shortened path basically starts at the top of where OCCweb can be viewed as a file server.

This was initially developed within #212 but I decided to pull it out as a separate PR, in part because https://github.com/sot/parse_cm/pull/35 needs this functionality.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing 

### Functional testing

This got a lot of independent testing during developing of #212.