### PR TITLE
remove use of deprecated np.str

### DIFF
--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -577,7 +577,7 @@ def test_reduce_states_cmd_states():
 
 def compare_backstop_history(history, state_key, compare_val=True):
     hist = ascii.read(history, guess=False, format='no_header',
-                      converters={'col1': [ascii.convert_numpy(np.str_)]})
+                      converters={'col1': [ascii.convert_numpy(str)]})
     start = DateTime(hist['col1'][0], format='greta') - 1 / 86400.
     stop = DateTime(hist['col1'][-1], format='greta') + 1 / 86400.
     sts = states.get_states(start=start, stop=stop, state_keys=state_key)

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -577,7 +577,7 @@ def test_reduce_states_cmd_states():
 
 def compare_backstop_history(history, state_key, compare_val=True):
     hist = ascii.read(history, guess=False, format='no_header',
-                      converters={'col1': [ascii.convert_numpy(np.str)]})
+                      converters={'col1': [ascii.convert_numpy(np.str_)]})
     start = DateTime(hist['col1'][0], format='greta') - 1 / 86400.
     stop = DateTime(hist['col1'][-1], format='greta') + 1 / 86400.
     sts = states.get_states(start=start, stop=stop, state_keys=state_key)

--- a/validate/gratings/compare_grating_moves.py
+++ b/validate/gratings/compare_grating_moves.py
@@ -21,8 +21,8 @@ from Chandra.Time import DateTime
 kadi_moves = events.grating_moves.filter(start='2000:160:12:00:00', stop='2014:008:12:00:00',
                                          grating__contains='ETG').table
 mta_moves = Table.read('mta_grating_moves.dat', format='ascii',
-                       converters={'START_TIME': [ascii.convert_numpy(np.str)],
-                                   'STOP_TIME': [ascii.convert_numpy(np.str)]})
+                       converters={'START_TIME': [ascii.convert_numpy(str)],
+                                   'STOP_TIME': [ascii.convert_numpy(str)]})
 mta_moves.sort('START_TIME')
 
 kadi_starts = kadi_moves['tstart']


### PR DESCRIPTION
## Description

This PR makes tiny changes to remove uses of a few deprecated dtypes (https://github.com/sot/skare3/issues/753).

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required). Also verified that the warning appeared in the test before changes.
- [ ] Functional testing

Fixes #