### PR TITLE
fix warning

### DIFF
--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -195,6 +195,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
             ],
         },
     },


### PR DESCRIPTION
## Description

I am not sure yet that this is the right solution, but this is "a solution". What is your opinion?

When running regression tests, we get this warning:
```
WARNINGS:
?: (admin.W411) 'django.template.context_processors.request' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar.
```

This PR does as the warning indicates and enables `django.template.context_processors.request` in settings, but we could also:
- ignore the warning
- see why this thing believes someone wants to use the navigation sidebar (is it used?)

## Testing

- [x] Regression tests pass on MacOS ska3-next. Also including the numpy deprecation fixes (in #214) and the changes to data files (sot/ska_testr/pull/47).
- [x] Regression tests pass on MacOS ska3-flight
- [ ] Functional testing

Fixes #