### PR TITLE
Fix regressions from v2 (#212)

### DIFF
--- a/kadi/cmds/cmds.py
+++ b/kadi/cmds/cmds.py
@@ -8,7 +8,7 @@ from Chandra.Time import DateTime
 import pickle
 import warnings
 
-from ..paths import IDX_CMDS_PATH, PARS_DICT_PATH
+from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
 __all__ = ['filter']
 

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -2337,7 +2337,7 @@ class AsciiTableEvent(BaseEvent):
         Get events from telemetry defined by a simple rule that the value of
         `event_msids[0]` == `event_val`.
         """
-        from ..paths import DATA_DIR
+        from kadi.paths import DATA_DIR
 
         start = DateTime(start).date
         stop = DateTime(stop).date

--- a/kadi/scripts/update_cmds_v1.py
+++ b/kadi/scripts/update_cmds_v1.py
@@ -403,7 +403,7 @@ def main(args=None):
 
     opt = get_opt(args)
 
-    logger = pyyaks.logger.get_logger(name=__name__, level=opt.log_level,
+    logger = pyyaks.logger.get_logger(name='kadi_update_cmds', level=opt.log_level,
                                       format="%(asctime)s %(message)s")
 
     log_run_info(logger.info, opt)

--- a/kadi/scripts/update_events.py
+++ b/kadi/scripts/update_events.py
@@ -82,7 +82,7 @@ def try4times(func, *arg, **kwarg):
 
 
 def delete_from_date(EventModel, start, set_update_date=True):
-    from .events import models
+    from kadi.events import models
 
     date_start = DateTime(start).date
     cls_name = EventModel.__name__
@@ -101,7 +101,7 @@ def delete_from_date(EventModel, start, set_update_date=True):
 def update(EventModel, date_stop):
     import django.db
     from django.core.exceptions import ObjectDoesNotExist
-    from .events import models
+    from kadi.events import models
 
     date_stop = DateTime(date_stop)
     cls_name = EventModel.__name__
@@ -212,19 +212,19 @@ def main():
 
     opt = get_opt()
 
-    logger = pyyaks.logger.get_logger(name=__name__, level=opt.log_level,
+    logger = pyyaks.logger.get_logger(name='kadi_update_events', level=opt.log_level,
                                       format="%(asctime)s %(message)s")
     log_run_info(logger.info, opt)
 
     # Set the global root data directory.  This gets used in the django
     # setup to find the sqlite3 database file.
     os.environ['KADI'] = os.path.abspath(opt.data_root)
-    from .paths import EVENTS_DB_PATH
+    from kadi.paths import EVENTS_DB_PATH
 
     logger.info('Event database : {}'.format(EVENTS_DB_PATH()))
     logger.info('')
 
-    from .events import models
+    from kadi.events import models
 
     # Allow for a cmd line option --start.  If supplied then loop the
     # effective value of opt.stop from start to the cmd line

--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -38,7 +38,7 @@ if any(pth.startswith('/proj/web-kadi') for pth in sys.path):
 BASE_DIR = dirname(dirname(realpath(__file__)))
 
 # Data paths for kadi project
-from .paths import EVENTS_DB_PATH, DATA_DIR  # noqa
+from kadi.paths import EVENTS_DB_PATH, DATA_DIR  # noqa
 
 # Make sure there is an events database
 if not os.path.exists(EVENTS_DB_PATH()):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ else:
 
 entry_points = {'console_scripts': [
     'get_chandra_states = kadi.commands.states:get_chandra_states',
-    'kadi_update_cmds_v1 = kadi.scripts.update_cmds_v1:main',
+    'kadi_update_cmds = kadi.scripts.update_cmds_v1:main',
     'kadi_update_cmds_v2 = kadi.scripts.update_cmds_v2:main',
     'kadi_update_events = kadi.scripts.update_events:main']}
 

--- a/task_schedule_cmds.cfg
+++ b/task_schedule_cmds.cfg
@@ -39,6 +39,6 @@ alert       aca@head.cfa.harvard.edu
 
 <task kadi_cmds>
       cron       * * * * *
-      exec kadi_update_cmds_v1 --data-root=$ENV{SKA}/data/kadi
+      exec kadi_update_cmds --data-root=$ENV{SKA}/data/kadi
       exec kadi_update_cmds_v2 --data-root=$ENV{SKA}/data/kadi
 </task>


### PR DESCRIPTION
## Description

This fixes some regression (ska_testr) problems introduced by #212.

- Use absolute rather than relative imports. When I moved scripts into the `scripts` subpackage those relative imports were broken. Another reason to avoid relative imports in most (but not all) situations.
- Reverted the name of the command-line script from `kadi_update_cmds_v1` back to the original `kadi_update_cmds`. This should fix the error in ska_testr where it failed to find the expected script.
- Logging was doing unexpected things because of the addition of a new top-level logger with the name `kadi`. Modules that initialized a logger with `__name__` were generating output from two loggers. For some reason that is actually still a mystery to me, when I did a local install test of kadi the top-level logger was getting a log-level of DEBUG and generating unexpected logging output. I'd still like to track that down, but using new logger names that don't start with `kadi.` fixes this.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing

Installed into a test environment, copied the current (but a few days out of date) kadi data (cmds v1, v2 and events) into a  local test directory (not the git repo), and successfully ran:
```
kadi_update_cmds
kadi_update_cmds_v2
kadi_update_events
```

Then ran ska_testr in the test env and got a PASS (with https://github.com/sot/ska_testr/pull/51)
```
cd ~/git/ska_testr
run_testr --include kadi
```