### PR TITLE
Add starcat_date to observation parameters + fix caching and minor issues

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -474,6 +474,37 @@ between 2015 and 2022 with MON windows commanded::
    CCD temperatures are set to -20 C and the ``.acqs`` and ``.guides`` attributes
    are stubbed with empty tables.
 
+Getting dicts instead of ACA tables
+"""""""""""""""""""""""""""""""""""
+Another performance option which can be useful in some cases is to set the
+``as_dict`` keyword to ``True``. This will return a list of dictionaries instead
+of converting each catalog into an ``ACATable`` object.
+
+Getting a Table of catalog entries
+""""""""""""""""""""""""""""""""""
+For some use cases you want a single table of all star catalog entries matching
+the specified criteria. This can be done with the
+:func:`~kadi.commands.observations.get_starcats_as_table` function. This is
+roughly the equivalent of doing a Table ``vstack`` of the individual
+``ACATable`` catalogs but is much faster. In addition two columns ``obsid`` and
+``starcat_date`` are added to provide this information for each entry.
+
+Caching
+"""""""
+
+In order to significantly speed up the retrieval of historical star catalogs for
+typical ACA operations analysis, the results of each call to ``get_starcats()``
+are (by default) cached in a file ``~/.kadi/starcats.db``.
+
+This caching is controlled by a configuration parameter ``cache_starcats``. To
+permanently disable caching you can edit your configuration file (see
+:ref:`configuration-options`). To disable caching for a single call to
+``get_starcats()``, you can do something like::
+
+    >>> from kadi.commands import get_starcats, conf
+    >>> with conf.set_temp('cache_starcats', False):
+    ...    starcats = get_starcats('2022:001', '2022:002')
+
 Chandra states and continuity
 ------------------------------
 

--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -450,24 +450,6 @@ The ACA star catalogs associated with observations can be retrieved using the
         2    10 263201064  ACQ  6x6   10.44   11.20   529.26   324.30     8     1    60
         7    11 263196576  ACQ  6x6   10.56   11.20 -1046.29   258.97    16     1   100
 
-This function can be used to get star catalogs over a range of time. Depending
-on your specific needs, you might want to specify ``set_ids=False`` in the call,
-which disables the time-consuming step of finding the star and fid ids by
-cross-matching with expected star / fid locations. For example, to find catalogs
-between 2015 and 2022 with MON windows commanded::
-
-    >>> %time acas = get_starcats(start='2015:001', stop='2022:001', set_ids=False)
-    CPU times: user 13.4 s, sys: 91.8 ms, total: 13.5 s
-    Wall time: 13.5 s
-
-    >>> len(acas)
-    13261
-    >>> acas_with_mon = [aca for aca in acas if 'MON' in aca['type']]
-    >>> len(acas_with_mon)
-    119
-    >>> acas_with_mon[0].obsid
-    17320
-
 .. Note::
    The ``ACATable`` objects that are returned can be plotted but they
    are not fully equivalent to the catalogs that ``proseco`` would return. The

--- a/docs/commands_v2.rst
+++ b/docs/commands_v2.rst
@@ -148,6 +148,8 @@ Then from the bash command line::
         --state-builder=sql \
         --run-start=2021:296:18:00:00
 
+.. _configuration-options:
+
 Configuration options
 ---------------------
 

--- a/kadi/commands/__init__.py
+++ b/kadi/commands/__init__.py
@@ -20,6 +20,12 @@ class Conf(ConfigNamespace):
         'Cache backstop downloads in the astropy cache. Should typically be False, '
         'but useful during development to avoid re-downloading backstops.'
     )
+    cache_starcats = ConfigItem(
+        True,
+        'Cache star catalogs that are retrieved to a file to avoid repeating the '
+        'slow process of identifying fid and stars in catalogs. The cache file is '
+        'conf.commands_dir/starcats.db.'
+    )
     clean_loads_dir = ConfigItem(
         True,
         'Clean backstop loads (like APR1421B.pkl.gz) in the loads directory that are '

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -194,7 +194,7 @@ def get_cmds_from_event(date, event, params_str):
     if isinstance(params_str, str):
         if event == 'RTS':
             args = [params_str]
-        elif event == 'Command':
+        elif event in ('Command', 'Command not run'):
             # Delegate parsing to cmd_set_command
             args = [params_str]
         else:

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -448,6 +448,28 @@ def get_state_cmds(cmds):
     ok |= cmds['type'] == 'SIMTRANS'
     cmds = cmds[ok]
     cmds.sort(['date', 'scs'])
+
+    # Deal with this issue where the obsid command is at exactly the same time
+    # as the AONMMODE commands instead of just after it (e.g. in a null maneuver).
+    #  idx            date             type     tlmsid
+    # ------ --------------------- ----------- --------
+    #      6 2005:177:09:14:38.119  COMMAND_SW AOMANUVR
+    #  10620 2005:177:09:17:27.868    MP_OBSID COAOSQID
+    #  10621 2005:177:10:04:15.740    MP_OBSID COAOSQID
+    #      1 2005:177:10:04:15.740  COMMAND_SW AONMMODE
+    #      2 2005:177:10:04:15.997  COMMAND_SW AONM2NPE
+    c0 = cmds[:-1]
+    c1 = cmds[1:]
+    ok = ((c0['date'] == c1['date'])
+          & (c0['tlmsid'] == 'COAOSQID')
+          & (c1['tlmsid'] == 'AONMMODE'))
+    idxs_swap = np.where(ok)[0]
+    if len(idxs_swap) > 0:
+        idxs = np.arange(len(cmds))
+        idxs[idxs_swap] += 1
+        idxs[idxs_swap + 1] -= 1
+        cmds = cmds[idxs]
+
     return cmds
 
 

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -447,10 +447,16 @@ def get_state_cmds(cmds):
     ok = np.isin(cmds['tlmsid'], vals)
     ok |= cmds['type'] == 'SIMTRANS'
     cmds = cmds[ok]
-    cmds.sort(['date', 'scs'])
+    cmds.sort(['date', 'scs', 'tlmsid'])
 
-    # Deal with this issue where the obsid command is at exactly the same time
-    # as the AONMMODE commands instead of just after it (e.g. in a null maneuver).
+    # Note about sorting by 'tlmsid': this relates to an issue where the obsid
+    # command COAOSQID is at exactly the same time as the AONMMODE commands
+    # instead of just after it (e.g. in a null maneuver). In this case we need
+    # to ensure that the AONMMODE commands are before the COAOSQID command in
+    # the table order. The order of other commands is not important, so we rely
+    # on the lucky fact that AONMMODE is alphabetically before COAOSQID to just
+    # include `tlmsid`` in the lexical sort.
+    #
     #  idx            date             type     tlmsid
     # ------ --------------------- ----------- --------
     #      6 2005:177:09:14:38.119  COMMAND_SW AOMANUVR
@@ -458,17 +464,6 @@ def get_state_cmds(cmds):
     #  10621 2005:177:10:04:15.740    MP_OBSID COAOSQID
     #      1 2005:177:10:04:15.740  COMMAND_SW AONMMODE
     #      2 2005:177:10:04:15.997  COMMAND_SW AONM2NPE
-    c0 = cmds[:-1]
-    c1 = cmds[1:]
-    ok = ((c0['date'] == c1['date'])
-          & (c0['tlmsid'] == 'COAOSQID')
-          & (c1['tlmsid'] == 'AONMMODE'))
-    idxs_swap = np.where(ok)[0]
-    if len(idxs_swap) > 0:
-        idxs = np.arange(len(cmds))
-        idxs[idxs_swap] += 1
-        idxs[idxs_swap + 1] -= 1
-        cmds = cmds[idxs]
 
     return cmds
 

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -616,6 +616,7 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     for cmd in cmds:
         tlmsid = cmd['tlmsid']
         if tlmsid == 'AOSTRCAT':
+            starcat_date = cmd['date']
             if cmd['idx'] == -1:
                 # OBS command only stores the index of the starcat params, so at
                 # this point we need to put those params into the pars_dict and
@@ -655,6 +656,7 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
             obs_params['obs_start'] = cmd['date']
             if obs_params['npnt_enab']:
                 obs_params['starcat_idx'] = starcat_idx
+                obs_params['starcat_date'] = starcat_date
 
         elif (tlmsid in ('AONMMODE', 'AONSMSAF')
               or (tlmsid == 'AONM2NPE' and cmd['vcdu'] == -1)):

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -855,8 +855,12 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
         # Get directory listing for Year/Month
         try:
             contents = occweb.get_occweb_dir(dir_year_month)
-        except requests.exceptions.HTTPError:
-            continue
+        except requests.exceptions.HTTPError as exc:
+            if str(exc).startswith('404'):
+                logger.debug(f'No OCCweb directory for {dir_year_month}')
+                continue
+            else:
+                raise
 
         # Find each valid load name in the directory listing and process:
         # - Find and download the backstop file
@@ -875,6 +879,9 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
                     cmds = get_load_cmds_from_occweb_or_local(dir_year_month, load_name)
                     load = get_load_dict_from_cmds(load_name, cmds, cmd_events)
                     loads_rows.append(load)
+
+    if not loads_rows:
+        raise ValueError(f'No loads found in {lookback} days')
 
     # Finally, save the table to file
     loads_table = Table(loads_rows)

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -73,6 +73,9 @@ def clear_caches():
         except AttributeError:
             pass
 
+    from kadi.commands.observations import OBSERVATIONS
+    OBSERVATIONS.clear()
+
 
 def interrupt_load_commands(load, cmds):
     """Cut commands beyond observing or vehicle stop times.

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -306,6 +306,8 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
         the archive.
+    :param as_dict: bool, False Return a list of dictionaries instead of a list
+        of ACATable objects.
     :returns: list of ACATable List star catalogs for matching observations.
     """
     import shelve

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -332,7 +332,8 @@ def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
             if (idx := obs.get('starcat_idx')) is None:
                 continue
 
-            db_key = obs['starcat_date'] + obs['source']
+            db_key = '{}-{}-{:05d}'.format(
+                obs['starcat_date'], obs['source'], obs['obsid'])
             if db_key in starcats_db:
                 # From the cache
                 starcat_dict = starcats_db[db_key]

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -241,17 +241,12 @@ def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
     return out
 
 
-def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=None,
+def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
                  cmds=None, as_dict=False):
     """Get a list of star catalogs corresponding to input parameters.
 
     The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of star catalogs that is returned.
-
-    The ``set_ids`` parameter controls whether the star and fid IDs are set.
-    This increases run time by about a factor of 4 (mostly due to identifying
-    stars from position), so if you don't need the IDs then set ``set_ids`` to
-    ``False``.
 
     By default the result is a list of ``ACATable`` objects similar to the
     output of ``proseco.get_aca_catalog``. If ``as_dict`` is ``True`` then the
@@ -302,7 +297,6 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
     :param start: CxoTime-like, None Start time (default=beginning of commands)
     :param stop: CxoTime-like, None Stop time (default=end of commands)
     :param obsid: int, None ObsID
-    :param set_ids: bool, True Set star and fid IDs
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
         the archive.
@@ -357,24 +351,20 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
                     params = decode_starcat_params(params)
                 starcat = convert_aostrcat_to_acatable(obs, params)
                 set_detector_and_sim_offset(starcat, obs['simpos'])
-                if set_ids:
-                    starcat.add_column(-999, index=2, name='id')
-                    starcat.add_column(-999.0, index=5, name='mag')
-                    set_fid_ids(starcat)
-                    set_star_ids(starcat)
+                starcat.add_column(-999, index=2, name='id')
+                starcat.add_column(-999.0, index=5, name='mag')
+                set_fid_ids(starcat)
+                set_star_ids(starcat)
 
-                if as_dict or set_ids:
-                    starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
-                    starcat_dict['meta'] = starcat.meta
-                    del starcat_dict['meta']['acqs']
-                    del starcat_dict['meta']['guides']
+                starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
+                starcat_dict['meta'] = starcat.meta
+                del starcat_dict['meta']['acqs']
+                del starcat_dict['meta']['guides']
 
                 if as_dict:
                     starcat = starcat_dict
 
-                if set_ids:
-                    # Cache the starcat (only if set_ids is True)
-                    starcats_db[db_key] = starcat_dict
+                starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -181,7 +181,7 @@ def convert_aostrcat_to_acatable(obs, params):
     return aca
 
 
-def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
+def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
                           scenario=None, cmds=None):
     starcats = get_starcats(obsid=obsid, start=start, stop=stop, scenario=scenario,
                             cmds=cmds, as_dict=True)
@@ -200,11 +200,11 @@ def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
     return Table(out)
 
 
-def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=None,
+def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=None,
                  cmds=None, as_dict=False):
-    """Get star catalogs corresponding to input parameters.
+    """Get a list of star catalogs corresponding to input parameters.
 
-    The ``obsid``, ``start``, and ``stop`` parameters serve as matching filters
+    The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of star catalogs that is returned.
 
     The ``set_ids`` parameter controls whether the star and fid IDs are set.
@@ -251,9 +251,9 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
             1    10 31982136  ACQ  6x6   10.19   11.70   562.06  -186.39    20     1
             2    11 32375384  ACQ  6x6    9.79   11.30  1612.28  -428.24    20     1]
 
-    :param obsid: int, None ObsID
     :param start: CxoTime-like, None Start time (default=beginning of commands)
     :param stop: CxoTime-like, None Stop time (default=end of commands)
+    :param obsid: int, None ObsID
     :param set_ids: bool, True Set star and fid IDs
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
@@ -314,10 +314,10 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
     return starcats
 
 
-def get_observations(obsid=None, *, start=None, stop=None, scenario=None, cmds=None):
+def get_observations(start=None, stop=None, *, obsid=None, scenario=None, cmds=None):
     """Get observations corresponding to input parameters.
 
-    The ``obsid``, ``start``, and ``stop`` parameters serve as matching filters
+    The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of observations that is returned.
 
     Over the mission there are thousands of instances of multiple observations
@@ -349,12 +349,12 @@ def get_observations(obsid=None, *, start=None, stop=None, scenario=None, cmds=N
         >>> from astropy.table import Table
         >>> obs_all = Table(obs_all)
 
-    :param obsid: int, None
-        ObsID
     :param start: CxoTime-like, None
         Start time (default=beginning of commands)
     :param stop: CxoTime-like, None
         Stop time (default=end of commands)
+    :param obsid: int, None
+        ObsID
     :param scenario: str, None
         Scenario
     :param cmds: CommandTable, None

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -343,7 +343,7 @@ def get_observations(obsid=None, *, start=None, stop=None, scenario=None, cmds=N
         if len(cmds_obs) == 0:
             raise ValueError(f'No matching observations for {obsid=}')
 
-    obss = [cmd['params'] for cmd in cmds_obs]
+    obss = [cmd['params'].copy() for cmd in cmds_obs]
     for obs, cmd_obs in zip(obss, cmds_obs):
         obs['source'] = cmd_obs['source']
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -256,9 +256,10 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
             if (idx := obs.get('starcat_idx')) is None:
                 continue
 
-            if obs['starcat_date'] in starcats_db:
+            db_key = obs['starcat_date'] + obs['source']
+            if db_key in starcats_db:
                 # From the disk cache
-                starcat_dict = starcats_db[str(idx)]
+                starcat_dict = starcats_db[db_key]
                 if as_dict:
                     starcat = starcat_dict
                 else:
@@ -281,7 +282,7 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
                     # Cache the starcat (only if set_ids is True)
                     starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
                     starcat_dict['meta'] = starcat.meta
-                    starcats_db[obs['starcat_date']] = starcat_dict
+                    starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -166,7 +166,7 @@ def convert_aostrcat_to_acatable(obs, params):
 
     aca.obsid = obs['obsid']
     aca.att = obs['targ_att']
-    aca.date = obs['obs_start']
+    aca.date = obs['starcat_date']
     aca.duration = date2secs(obs['obs_stop']) - date2secs(obs['obs_start'])
 
     # Make the catalog more complete and provide stuff temps needed for plot()

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -21,13 +21,14 @@ AGASC_FILE = Path(os.environ['SKA'], 'data', 'agasc', 'proseco_agasc_1p7.h5')
 
 TYPE_MAP = ['ACQ', 'GUI', 'BOT', 'FID', 'MON']
 IMGSZ_MAP = ['4x4', '6x6', '8x8']
+RAD_TO_DEG = 180 / np.pi * 3600
 PAR_MAPS = [
     ('imnum', 'slot', int),
     ('type', 'type', lambda n: TYPE_MAP[n]),
     ('imgsz', 'sz', lambda n: IMGSZ_MAP[n]),
     ('maxmag', 'maxmag', float),
-    ('yang', 'yang', lambda x: np.degrees(x) * 3600),
-    ('zang', 'zang', lambda x: np.degrees(x) * 3600),
+    ('yang', 'yang', lambda x: x * RAD_TO_DEG),
+    ('zang', 'zang', lambda x: x * RAD_TO_DEG),
     ('dimdts', 'dim', int),
     ('restrk', 'res', int),
 ]
@@ -120,7 +121,7 @@ def set_star_ids(aca):
                         f'{aca.date}')
 
 
-def convert_aostrcat_to_acatable(obs, params):
+def convert_aostrcat_to_acatable(obs, params, as_dict=False):
     """Convert dict of AOSTRCAT parameters to an ACATable.
 
     The dict looks like::
@@ -360,11 +361,17 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
                     set_fid_ids(starcat)
                     set_star_ids(starcat)
 
-                    # Cache the starcat (only if set_ids is True)
+                if as_dict or set_ids:
                     starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
                     starcat_dict['meta'] = starcat.meta
                     del starcat_dict['meta']['acqs']
                     del starcat_dict['meta']['guides']
+
+                if as_dict:
+                    starcat = starcat_dict
+
+                if set_ids:
+                    # Cache the starcat (only if set_ids is True)
                     starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -15,7 +15,7 @@ from astropy.table import Table
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['get_starcats', 'get_observations', 'get_stars']
+__all__ = ['get_starcats', 'get_observations', 'get_starcats_as_table']
 
 AGASC_FILE = Path(os.environ['SKA'], 'data', 'agasc', 'proseco_agasc_1p7.h5')
 
@@ -181,12 +181,15 @@ def convert_aostrcat_to_acatable(obs, params):
     return aca
 
 
-def get_stars(obsid=None, *, start=None, stop=None, set_ids=True, scenario=None,
-              cmds=None):
+def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
+                          scenario=None, cmds=None):
     starcats = get_starcats(obsid=obsid, start=start, stop=stop, scenario=scenario,
                             cmds=cmds, as_dict=True)
     out = defaultdict(list)
     for starcat in starcats:
+        n_cat = len(starcat['slot'])
+        out['obsid'].append([starcat['meta']['obsid']] * n_cat)
+        out['starcat_date'].append([starcat['meta']['date']] * n_cat)
         for name, vals in starcat.items():
             if name != 'meta':
                 out[name].append(vals)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -551,7 +551,7 @@ Definitive,2020:337:00:00:00,Bright star hold,,Tom Aldcroft,
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_get_observations_by_obsid_single():
-    obss = get_observations(8008)
+    obss = get_observations(obsid=8008)
     assert len(obss) == 1
     del obss[0]['starcat_idx']
     assert obss == [
@@ -569,7 +569,7 @@ def test_get_observations_by_obsid_single():
 
 
 def test_get_observations_by_obsid_multi():
-    obss = get_observations(47912, scenario='flight')  # Following ACA high background NSM 2019:248
+    obss = get_observations(obsid=47912, scenario='flight')  # Following ACA high background NSM 2019:248
     # Don't compare starcat_idx because it might change with a repro
     for obs in obss:
         obs.pop('starcat_idx', None)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -711,6 +711,95 @@ def test_get_cmds_from_event_case(par_str):
                              'par2': -1.0}
 
 
+cmd_events_all_text = """\
+    Event,Params
+    Observing not run,FEB1422A
+    Load not run,OCT2521A
+    Command,ACISPKT | TLMSID=AA00000000
+    Command not run,COMMAND_SW | TLMSID=4OHETGIN
+    RTS,"RTSLOAD,1_4_CTI,NUM_HOURS=39:00:00,SCS_NUM=135"
+    Obsid,65527
+    Maneuver,0.70546907 0.32988307 0.53440901 0.32847766
+    Safe mode,
+    NSM,
+    SCS-107,
+    Bright star hold,
+    Dither,ON
+    """
+cmd_events_all = Table.read(cmd_events_all_text, format='ascii.csv')
+cmd_events_all_exps = [
+    None,
+    None,
+    ['2020:001:00:00:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=Command, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPEN, scs=135',  # noqa
+        '2020:001:00:00:01.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:001:00:00:02.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135',  # noqa
+        '2020:001:00:00:03.000 | COMMAND_HW       | 2S2HVON    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVON, scs=135',  # noqa
+        '2020:001:00:00:13.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=4 , msid=2S2STHV, scs=135',  # noqa
+        '2020:001:00:00:23.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=8 , msid=2S2STHV, scs=135',  # noqa
+        '2020:001:00:00:24.000 | ACISPKT          | WSPOW08E1E | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:001:00:01:27.000 | ACISPKT          | WT00C62014 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:001:00:01:31.000 | ACISPKT          | XTZ0000005 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:001:00:01:35.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:001:00:01:39.000 | ACISPKT          | RH_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:002:15:01:39.000 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVOF, scs=135',  # noqa
+        '2020:002:15:01:39.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPDS, scs=135',  # noqa
+        '2020:002:15:01:40.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135',  # noqa
+        '2020:002:17:40:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:002:17:40:10.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:002:17:40:14.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
+        '2020:002:17:40:18.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135'],  # noqa
+    ['2020:001:00:00:00.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | event=Obsid, event_date=2020:001:00:00:00, id=65527, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONMMODE, scs=0',  # noqa
+        '2020:001:00:00:00.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONM2NPE, scs=0',  # noqa
+        '2020:001:00:00:04.356 | MP_TARGQUAT      | AOUPTARQ   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, q1=7.05469070e-01, q2=3.29883070e-01, q3=5.34409010e-01, q4=3.28477660e-01, scs=0',  # noqa
+        '2020:001:00:00:10.250 | COMMAND_SW       | AOMANUVR   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AOMANUVR, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | ACPCSFSU   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:00.000 | COMMAND_SW       | CSELFMT5   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
+        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
+        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
+        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
+        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
+        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
+        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
+        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
+        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
+        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0'],  # noqa
+    ['2020:001:00:00:00.000 | COMMAND_SW       | AOENDITH   | CMD_EVT  | event=Dither, event_date=2020:001:00:00:00, scs=0']]  # noqa
+
+
+@pytest.mark.parametrize('idx', range(len(cmd_events_all_exps)))
+def test_get_cmds_from_event_all(idx):
+    """Test getting commands from every event type in the Command Events sheet"""
+    cevt = cmd_events_all[idx]
+    exp = cmd_events_all_exps[idx]
+    cmds = get_cmds_from_event('2020:001:00:00:00', cevt['Event'], cevt['Params'])
+    if cmds is not None:
+        cmds = cmds.pformat_like_backstop(max_params_width=None)
+    assert cmds == exp
+
+
 @pytest.mark.skipif(not HAS_INTERNET, reason='No internet connection')
 def test_scenario_with_rts(monkeypatch):
     """Test a custom scenario with RTS. This is basically the same as the

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -666,6 +666,21 @@ def test_get_starcats_obsid():
             assert np.all(sc_kadi[name] == sc_mica[name])
 
 
+def test_get_starcats_date():
+    """Test that the starcat `date` is set to obs `starcat_date` and that
+    this matches the time of the corresponding MP_STARCAT AOSTRCAT command.
+
+    Note: from https://icxc.harvard.edu//mp/mplogs/2006/DEC2506/oflsc/starcheck.html#obsid8008
+    MP_STARCAT at 2007:002:04:31:43.965 (VCDU count = 7477935)
+    """
+    sc = get_starcats(obsid=8008)[0]
+    obs = get_observations(obsid=8008)[0]
+    assert sc.date == obs['starcat_date'] == '2007:002:04:31:43.965'
+    cmds = commands_v2.get_cmds('2007:002', '2007:003')
+    sc_cmd = cmds[cmds['date'] == obs['starcat_date']][0]
+    assert sc_cmd['type'] == 'MP_STARCAT'
+
+
 @pytest.mark.parametrize(
     'par_str', ['ACISPKT|  TLmSID= aa0000000 par1 = 1    par2=-1.0',
                 'AcisPKT|TLmSID=AA0000000 par1=1 par2=-1.0',

--- a/kadi/paths.py
+++ b/kadi/paths.py
@@ -68,3 +68,8 @@ def LOADS_TABLE_PATH(scenario=None):
 
 def CMD_EVENTS_PATH(scenario=None):
     return SCENARIO_DIR(scenario) / 'cmd_events.csv'
+
+
+def STARCATS_CACHE_PATH():
+    from kadi.commands import conf
+    return Path(conf.commands_dir).expanduser() / 'starcats'


### PR DESCRIPTION
## Description

Add `starcat_date` to the parameters stored in observations.

Other things along the way:
- Noticed that the `clear_caches` was missing the OBSERVATIONS cache, so that was fixed.
- Noticed that the result from `get_observations` was a reference to the original params dicts in cache, so this allowed for shenanigans if the user played with those outputs. This, of course, came up in testing and took quite a while to figure out.
- Added some `clear_cache()` commands in certain tests to ensure independence of results from test order.
- Updated to run most of the `get_observations` or `get_starcats` test using the `flight` scenario so they will run on GRETA.

Also includes #225 and #226.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #220

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

- Adds a new key `starcat_date` to the dict returned by `get_observations`
- Changes the star catalog `date` from being the `obs_start` (start of NPNT) to `starcat_date` (commanded star catalog time).
- Requires new versions of `cmds2.pkl` and `cmds2.h5`. I've generated these and will place them on HEAD and GRETA. The new data files are expected to be compatible with the release 5.9.2 version in 2022.3 but I'll check that.

Running the 5.9.2 unit tests with the new data files gives 3 failures, all expected:
```
=================================================== short test summary info ====================================================
FAILED kadi/commands/tests/test_commands.py::test_commands_create_archive_regress[2] - AssertionError: assert False
FAILED kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_single - AssertionError: assert [{'manvr_star...2...
FAILED kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_multi - AssertionError: assert [{'manvr_star...00...
======================================== 3 failed, 50 passed, 103 deselected in 31.06s =========================================
```

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Jean functionally confirmed the `unique` option to get_starcats_as_table with this query that gets the two catalogs (same catalog) of an ACIS undercover series.
```
In [5]: get_starcats_as_table(start='2020:366:17:04:20.000', stop='2020:366:23:00:00.000')
Out[5]: 
<Table length=22>
obsid      starcat_date      slot  idx      id    type  sz         mag          maxmag          yang                zang         dim   res  halfw
int64         str21         int64 int64   int64   str3 str3      float64       float64        float64             float64       int64 int64 int64
----- --------------------- ----- ----- --------- ---- ---- ----------------- --------- ------------------- ------------------- ----- ----- -----
24882 2020:366:17:04:20.000     0     1         1  FID  8x8               7.0       8.0 -1174.9607093061636  -468.1481719926585     1     1    25
24882 2020:366:17:04:20.000     1     2         3  FID  8x8               7.0       8.0 -1177.6232024219992   561.4018012757298     1     1    25
24882 2020:366:17:04:20.000     2     3         4  FID  8x8               7.0       8.0  1223.4393109616512   563.8018390366224     1     1    25
24882 2020:366:17:04:20.000     3     4 552075520  BOT  6x6 8.885130882263184 10.390625  -912.6106246537174  -703.8856678520224     8     1    60
24882 2020:366:17:04:20.000     4     5 552086952  BOT  6x6 8.897590637207031  10.40625 -1510.7731283644346  -2392.854408253782     8     1    60
24882 2020:366:17:04:20.000     5     6 552206400  BOT  6x6 8.648664474487305  10.15625  -84.90442138289295  -2367.635642290802    12     1    80
24882 2020:366:17:04:20.000     6     7 552206936  BOT  6x6 6.875301837921143     8.375  2104.7955129097486  1092.1642810692815    16     1   100
24882 2020:366:17:04:20.000     7     8 552213664  BOT  6x6  8.73717975616455 10.234375    1073.65803292352  -944.4668937469213    12     1    80
24882 2020:366:17:04:20.000     0     9 552217088  ACQ  6x6 8.083139419555664   9.59375  168.79558020035054 -2223.1544736547244    12     1    80
24882 2020:366:17:04:20.000     1    10 552081976  ACQ  6x6  9.25229549407959     10.75 -1094.5981762913334  1597.2393211928293     8     1    60
24882 2020:366:17:04:20.000     2    11 552084112  ACQ  6x6  9.63385009765625 11.140625  -782.1356873895911  -292.7544209467494     8     1    60
62647 2020:366:17:04:20.000     0     1         1  FID  8x8               7.0       8.0 -1174.9607093061636  -468.1481719926585     1     1    25
62647 2020:366:17:04:20.000     1     2         3  FID  8x8               7.0       8.0 -1177.6232024219992   561.4018012757298     1     1    25
62647 2020:366:17:04:20.000     2     3         4  FID  8x8               7.0       8.0  1223.4393109616512   563.8018390366224     1     1    25
62647 2020:366:17:04:20.000     3     4 552075520  BOT  6x6 8.885130882263184 10.390625  -912.6106246537174  -703.8856678520224     8     1    60
62647 2020:366:17:04:20.000     4     5 552086952  BOT  6x6 8.897590637207031  10.40625 -1510.7731283644346  -2392.854408253782     8     1    60
62647 2020:366:17:04:20.000     5     6 552206400  BOT  6x6 8.648664474487305  10.15625  -84.90442138289295  -2367.635642290802    12     1    80
62647 2020:366:17:04:20.000     6     7 552206936  BOT  6x6 6.875301837921143     8.375  2104.7955129097486  1092.1642810692815    16     1   100
62647 2020:366:17:04:20.000     7     8 552213664  BOT  6x6  8.73717975616455 10.234375    1073.65803292352  -944.4668937469213    12     1    80
62647 2020:366:17:04:20.000     0     9 552217088  ACQ  6x6 8.083139419555664   9.59375  168.79558020035054 -2223.1544736547244    12     1    80
62647 2020:366:17:04:20.000     1    10 552081976  ACQ  6x6  9.25229549407959     10.75 -1094.5981762913334  1597.2393211928293     8     1    60
62647 2020:366:17:04:20.000     2    11 552084112  ACQ  6x6  9.63385009765625 11.140625  -782.1356873895911  -292.7544209467494     8     1    60

In [6]: get_starcats_as_table(start='2020:366:17:04:20.000', stop='2020:366:23:00:00.000', unique=True)
Out[6]: 
<Table length=11>
obsid      starcat_date      slot  idx      id    type  sz         mag          maxmag          yang                zang         dim   res  halfw
int64         str21         int64 int64   int64   str3 str3      float64       float64        float64             float64       int64 int64 int64
----- --------------------- ----- ----- --------- ---- ---- ----------------- --------- ------------------- ------------------- ----- ----- -----
24882 2020:366:17:04:20.000     0     1         1  FID  8x8               7.0       8.0 -1174.9607093061636  -468.1481719926585     1     1    25
24882 2020:366:17:04:20.000     1     2         3  FID  8x8               7.0       8.0 -1177.6232024219992   561.4018012757298     1     1    25
24882 2020:366:17:04:20.000     2     3         4  FID  8x8               7.0       8.0  1223.4393109616512   563.8018390366224     1     1    25
24882 2020:366:17:04:20.000     3     4 552075520  BOT  6x6 8.885130882263184 10.390625  -912.6106246537174  -703.8856678520224     8     1    60
24882 2020:366:17:04:20.000     4     5 552086952  BOT  6x6 8.897590637207031  10.40625 -1510.7731283644346  -2392.854408253782     8     1    60
24882 2020:366:17:04:20.000     5     6 552206400  BOT  6x6 8.648664474487305  10.15625  -84.90442138289295  -2367.635642290802    12     1    80
24882 2020:366:17:04:20.000     6     7 552206936  BOT  6x6 6.875301837921143     8.375  2104.7955129097486  1092.1642810692815    16     1   100
24882 2020:366:17:04:20.000     7     8 552213664  BOT  6x6  8.73717975616455 10.234375    1073.65803292352  -944.4668937469213    12     1    80
24882 2020:366:17:04:20.000     0     9 552217088  ACQ  6x6 8.083139419555664   9.59375  168.79558020035054 -2223.1544736547244    12     1    80
24882 2020:366:17:04:20.000     1    10 552081976  ACQ  6x6  9.25229549407959     10.75 -1094.5981762913334  1597.2393211928293     8     1    60
24882 2020:366:17:04:20.000     2    11 552084112  ACQ  6x6  9.63385009765625 11.140625  -782.1356873895911  -292.7544209467494     8     1    60
```


Tom generated new commands archive data files.
