### PR TITLE
Fix misorders between obsid cmd and NMM cmd

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -448,6 +448,28 @@ def get_state_cmds(cmds):
     ok |= cmds['type'] == 'SIMTRANS'
     cmds = cmds[ok]
     cmds.sort(['date', 'scs'])
+
+    # Deal with this issue where the obsid command is at exactly the same time
+    # as the AONMMODE commands instead of just after it (e.g. in a null maneuver).
+    #  idx            date             type     tlmsid
+    # ------ --------------------- ----------- --------
+    #      6 2005:177:09:14:38.119  COMMAND_SW AOMANUVR
+    #  10620 2005:177:09:17:27.868    MP_OBSID COAOSQID
+    #  10621 2005:177:10:04:15.740    MP_OBSID COAOSQID
+    #      1 2005:177:10:04:15.740  COMMAND_SW AONMMODE
+    #      2 2005:177:10:04:15.997  COMMAND_SW AONM2NPE
+    c0 = cmds[:-1]
+    c1 = cmds[1:]
+    ok = ((c0['date'] == c1['date'])
+          & (c0['tlmsid'] == 'COAOSQID')
+          & (c1['tlmsid'] == 'AONMMODE'))
+    idxs_swap = np.where(ok)[0]
+    if len(idxs_swap) > 0:
+        idxs = np.arange(len(cmds))
+        idxs[idxs_swap] += 1
+        idxs[idxs_swap + 1] -= 1
+        cmds = cmds[idxs]
+
     return cmds
 
 

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -447,10 +447,16 @@ def get_state_cmds(cmds):
     ok = np.isin(cmds['tlmsid'], vals)
     ok |= cmds['type'] == 'SIMTRANS'
     cmds = cmds[ok]
-    cmds.sort(['date', 'scs'])
+    cmds.sort(['date', 'scs', 'tlmsid'])
 
-    # Deal with this issue where the obsid command is at exactly the same time
-    # as the AONMMODE commands instead of just after it (e.g. in a null maneuver).
+    # Note about sorting by 'tlmsid': this relates to an issue where the obsid
+    # command COAOSQID is at exactly the same time as the AONMMODE commands
+    # instead of just after it (e.g. in a null maneuver). In this case we need
+    # to ensure that the AONMMODE commands are before the COAOSQID command in
+    # the table order. The order of other commands is not important, so we rely
+    # on the lucky fact that AONMMODE is alphabetically before COAOSQID to just
+    # include `tlmsid`` in the lexical sort.
+    #
     #  idx            date             type     tlmsid
     # ------ --------------------- ----------- --------
     #      6 2005:177:09:14:38.119  COMMAND_SW AOMANUVR
@@ -458,17 +464,6 @@ def get_state_cmds(cmds):
     #  10621 2005:177:10:04:15.740    MP_OBSID COAOSQID
     #      1 2005:177:10:04:15.740  COMMAND_SW AONMMODE
     #      2 2005:177:10:04:15.997  COMMAND_SW AONM2NPE
-    c0 = cmds[:-1]
-    c1 = cmds[1:]
-    ok = ((c0['date'] == c1['date'])
-          & (c0['tlmsid'] == 'COAOSQID')
-          & (c1['tlmsid'] == 'AONMMODE'))
-    idxs_swap = np.where(ok)[0]
-    if len(idxs_swap) > 0:
-        idxs = np.arange(len(cmds))
-        idxs[idxs_swap] += 1
-        idxs[idxs_swap + 1] -= 1
-        cmds = cmds[idxs]
 
     return cmds
 


### PR DESCRIPTION
## Description

As noted in originally in slack there are cases where obsids in nominal schedules had two star catalogs / observations. E.g.
```
observations = Table(commands.get_observations(obsid=57244))

observations[['obs_start', 'obs_stop']]

<Table length=2>
      obs_start              obs_stop      
        str21                 str21        
--------------------- ---------------------
2009:068:08:40:02.068 2009:068:08:40:02.068
2009:068:08:54:32.010 2009:068:16:16:30.660
```
Then obsid=57245 had exactly the same observation info and star catalog. This was due to the obsid and NMM command happening at exactly the same time, but with the obsid *before* the NMM command. This causes the observation code to assign the second obsid prior (in command order) to the NMM command.

This PR looks through the commands for this situation and swaps the commands.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
With this change I regenerated the `cmds2.*` files and then did this in IPython with the local files. This shows only the one expected observation.
```
In [5]: Table(get_observations(obsid=57244, scenario='flight'))
Out[5]: 
<Table length=1>
obsid simpos        obs_stop            manvr_start      ...      starcat_date     starcat_idx  source 
int64 int64          str21                 str21         ...         str21            int32      str8  
----- ------ --------------------- --------------------- ... --------------------- ----------- --------
57244 -99616 2009:068:16:16:30.660 2009:068:08:40:12.319 ... 2009:068:08:40:08.068      139097 MAR0909B
```
