### PR TITLE
Cache starcat and other goodies

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -474,6 +474,37 @@ between 2015 and 2022 with MON windows commanded::
    CCD temperatures are set to -20 C and the ``.acqs`` and ``.guides`` attributes
    are stubbed with empty tables.
 
+Getting dicts instead of ACA tables
+"""""""""""""""""""""""""""""""""""
+Another performance option which can be useful in some cases is to set the
+``as_dict`` keyword to ``True``. This will return a list of dictionaries instead
+of converting each catalog into an ``ACATable`` object.
+
+Getting a Table of catalog entries
+""""""""""""""""""""""""""""""""""
+For some use cases you want a single table of all star catalog entries matching
+the specified criteria. This can be done with the
+:func:`~kadi.commands.observations.get_starcats_as_table` function. This is
+roughly the equivalent of doing a Table ``vstack`` of the individual
+``ACATable`` catalogs but is much faster. In addition two columns ``obsid`` and
+``starcat_date`` are added to provide this information for each entry.
+
+Caching
+"""""""
+
+In order to significantly speed up the retrieval of historical star catalogs for
+typical ACA operations analysis, the results of each call to ``get_starcats()``
+are (by default) cached in a file ``~/.kadi/starcats.db``.
+
+This caching is controlled by a configuration parameter ``cache_starcats``. To
+permanently disable caching you can edit your configuration file (see
+:ref:`configuration-options`). To disable caching for a single call to
+``get_starcats()``, you can do something like::
+
+    >>> from kadi.commands import get_starcats, conf
+    >>> with conf.set_temp('cache_starcats', False):
+    ...    starcats = get_starcats('2022:001', '2022:002')
+
 Chandra states and continuity
 ------------------------------
 

--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -450,24 +450,6 @@ The ACA star catalogs associated with observations can be retrieved using the
         2    10 263201064  ACQ  6x6   10.44   11.20   529.26   324.30     8     1    60
         7    11 263196576  ACQ  6x6   10.56   11.20 -1046.29   258.97    16     1   100
 
-This function can be used to get star catalogs over a range of time. Depending
-on your specific needs, you might want to specify ``set_ids=False`` in the call,
-which disables the time-consuming step of finding the star and fid ids by
-cross-matching with expected star / fid locations. For example, to find catalogs
-between 2015 and 2022 with MON windows commanded::
-
-    >>> %time acas = get_starcats(start='2015:001', stop='2022:001', set_ids=False)
-    CPU times: user 13.4 s, sys: 91.8 ms, total: 13.5 s
-    Wall time: 13.5 s
-
-    >>> len(acas)
-    13261
-    >>> acas_with_mon = [aca for aca in acas if 'MON' in aca['type']]
-    >>> len(acas_with_mon)
-    119
-    >>> acas_with_mon[0].obsid
-    17320
-
 .. Note::
    The ``ACATable`` objects that are returned can be plotted but they
    are not fully equivalent to the catalogs that ``proseco`` would return. The

--- a/docs/commands_v2.rst
+++ b/docs/commands_v2.rst
@@ -148,6 +148,8 @@ Then from the bash command line::
         --state-builder=sql \
         --run-start=2021:296:18:00:00
 
+.. _configuration-options:
+
 Configuration options
 ---------------------
 

--- a/kadi/commands/__init__.py
+++ b/kadi/commands/__init__.py
@@ -20,6 +20,12 @@ class Conf(ConfigNamespace):
         'Cache backstop downloads in the astropy cache. Should typically be False, '
         'but useful during development to avoid re-downloading backstops.'
     )
+    cache_starcats = ConfigItem(
+        True,
+        'Cache star catalogs that are retrieved to a file to avoid repeating the '
+        'slow process of identifying fid and stars in catalogs. The cache file is '
+        'conf.commands_dir/starcats.db.'
+    )
     clean_loads_dir = ConfigItem(
         True,
         'Clean backstop loads (like APR1421B.pkl.gz) in the loads directory that are '

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -306,6 +306,8 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
         the archive.
+    :param as_dict: bool, False Return a list of dictionaries instead of a list
+        of ACATable objects.
     :returns: list of ACATable List star catalogs for matching observations.
     """
     import shelve

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -241,17 +241,12 @@ def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
     return out
 
 
-def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=None,
+def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
                  cmds=None, as_dict=False):
     """Get a list of star catalogs corresponding to input parameters.
 
     The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of star catalogs that is returned.
-
-    The ``set_ids`` parameter controls whether the star and fid IDs are set.
-    This increases run time by about a factor of 4 (mostly due to identifying
-    stars from position), so if you don't need the IDs then set ``set_ids`` to
-    ``False``.
 
     By default the result is a list of ``ACATable`` objects similar to the
     output of ``proseco.get_aca_catalog``. If ``as_dict`` is ``True`` then the
@@ -302,7 +297,6 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
     :param start: CxoTime-like, None Start time (default=beginning of commands)
     :param stop: CxoTime-like, None Stop time (default=end of commands)
     :param obsid: int, None ObsID
-    :param set_ids: bool, True Set star and fid IDs
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
         the archive.
@@ -357,24 +351,20 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
                     params = decode_starcat_params(params)
                 starcat = convert_aostrcat_to_acatable(obs, params)
                 set_detector_and_sim_offset(starcat, obs['simpos'])
-                if set_ids:
-                    starcat.add_column(-999, index=2, name='id')
-                    starcat.add_column(-999.0, index=5, name='mag')
-                    set_fid_ids(starcat)
-                    set_star_ids(starcat)
+                starcat.add_column(-999, index=2, name='id')
+                starcat.add_column(-999.0, index=5, name='mag')
+                set_fid_ids(starcat)
+                set_star_ids(starcat)
 
-                if as_dict or set_ids:
-                    starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
-                    starcat_dict['meta'] = starcat.meta
-                    del starcat_dict['meta']['acqs']
-                    del starcat_dict['meta']['guides']
+                starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
+                starcat_dict['meta'] = starcat.meta
+                del starcat_dict['meta']['acqs']
+                del starcat_dict['meta']['guides']
 
                 if as_dict:
                     starcat = starcat_dict
 
-                if set_ids:
-                    # Cache the starcat (only if set_ids is True)
-                    starcats_db[db_key] = starcat_dict
+                starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -181,7 +181,7 @@ def convert_aostrcat_to_acatable(obs, params):
     return aca
 
 
-def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
+def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
                           scenario=None, cmds=None):
     starcats = get_starcats(obsid=obsid, start=start, stop=stop, scenario=scenario,
                             cmds=cmds, as_dict=True)
@@ -200,11 +200,11 @@ def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
     return Table(out)
 
 
-def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=None,
+def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=None,
                  cmds=None, as_dict=False):
-    """Get star catalogs corresponding to input parameters.
+    """Get a list of star catalogs corresponding to input parameters.
 
-    The ``obsid``, ``start``, and ``stop`` parameters serve as matching filters
+    The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of star catalogs that is returned.
 
     The ``set_ids`` parameter controls whether the star and fid IDs are set.
@@ -251,9 +251,9 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
             1    10 31982136  ACQ  6x6   10.19   11.70   562.06  -186.39    20     1
             2    11 32375384  ACQ  6x6    9.79   11.30  1612.28  -428.24    20     1]
 
-    :param obsid: int, None ObsID
     :param start: CxoTime-like, None Start time (default=beginning of commands)
     :param stop: CxoTime-like, None Stop time (default=end of commands)
+    :param obsid: int, None ObsID
     :param set_ids: bool, True Set star and fid IDs
     :param scenario: str, None Scenario
     :param cmds: CommandTable, None Use this command table instead of querying
@@ -314,10 +314,10 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
     return starcats
 
 
-def get_observations(obsid=None, *, start=None, stop=None, scenario=None, cmds=None):
+def get_observations(start=None, stop=None, *, obsid=None, scenario=None, cmds=None):
     """Get observations corresponding to input parameters.
 
-    The ``obsid``, ``start``, and ``stop`` parameters serve as matching filters
+    The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
     on the list of observations that is returned.
 
     Over the mission there are thousands of instances of multiple observations
@@ -349,12 +349,12 @@ def get_observations(obsid=None, *, start=None, stop=None, scenario=None, cmds=N
         >>> from astropy.table import Table
         >>> obs_all = Table(obs_all)
 
-    :param obsid: int, None
-        ObsID
     :param start: CxoTime-like, None
         Start time (default=beginning of commands)
     :param stop: CxoTime-like, None
         Stop time (default=end of commands)
+    :param obsid: int, None
+        ObsID
     :param scenario: str, None
         Scenario
     :param cmds: CommandTable, None

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -256,9 +256,10 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
             if (idx := obs.get('starcat_idx')) is None:
                 continue
 
-            if obs['starcat_date'] in starcats_db:
+            db_key = obs['starcat_date'] + obs['source']
+            if db_key in starcats_db:
                 # From the disk cache
-                starcat_dict = starcats_db[str(idx)]
+                starcat_dict = starcats_db[db_key]
                 if as_dict:
                     starcat = starcat_dict
                 else:
@@ -281,7 +282,7 @@ def get_starcats(obsid=None, *, start=None, stop=None, set_ids=True, scenario=No
                     # Cache the starcat (only if set_ids is True)
                     starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
                     starcat_dict['meta'] = starcat.meta
-                    starcats_db[obs['starcat_date']] = starcat_dict
+                    starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -21,13 +21,14 @@ AGASC_FILE = Path(os.environ['SKA'], 'data', 'agasc', 'proseco_agasc_1p7.h5')
 
 TYPE_MAP = ['ACQ', 'GUI', 'BOT', 'FID', 'MON']
 IMGSZ_MAP = ['4x4', '6x6', '8x8']
+RAD_TO_DEG = 180 / np.pi * 3600
 PAR_MAPS = [
     ('imnum', 'slot', int),
     ('type', 'type', lambda n: TYPE_MAP[n]),
     ('imgsz', 'sz', lambda n: IMGSZ_MAP[n]),
     ('maxmag', 'maxmag', float),
-    ('yang', 'yang', lambda x: np.degrees(x) * 3600),
-    ('zang', 'zang', lambda x: np.degrees(x) * 3600),
+    ('yang', 'yang', lambda x: x * RAD_TO_DEG),
+    ('zang', 'zang', lambda x: x * RAD_TO_DEG),
     ('dimdts', 'dim', int),
     ('restrk', 'res', int),
 ]
@@ -120,7 +121,7 @@ def set_star_ids(aca):
                         f'{aca.date}')
 
 
-def convert_aostrcat_to_acatable(obs, params):
+def convert_aostrcat_to_acatable(obs, params, as_dict=False):
     """Convert dict of AOSTRCAT parameters to an ACATable.
 
     The dict looks like::
@@ -360,11 +361,17 @@ def get_starcats(start=None, stop=None, *, obsid=None, set_ids=True, scenario=No
                     set_fid_ids(starcat)
                     set_star_ids(starcat)
 
-                    # Cache the starcat (only if set_ids is True)
+                if as_dict or set_ids:
                     starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
                     starcat_dict['meta'] = starcat.meta
                     del starcat_dict['meta']['acqs']
                     del starcat_dict['meta']['guides']
+
+                if as_dict:
+                    starcat = starcat_dict
+
+                if set_ids:
+                    # Cache the starcat (only if set_ids is True)
                     starcats_db[db_key] = starcat_dict
 
             starcats.append(starcat)

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -15,7 +15,7 @@ from astropy.table import Table
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['get_starcats', 'get_observations', 'get_stars']
+__all__ = ['get_starcats', 'get_observations', 'get_starcats_as_table']
 
 AGASC_FILE = Path(os.environ['SKA'], 'data', 'agasc', 'proseco_agasc_1p7.h5')
 
@@ -181,12 +181,15 @@ def convert_aostrcat_to_acatable(obs, params):
     return aca
 
 
-def get_stars(obsid=None, *, start=None, stop=None, set_ids=True, scenario=None,
-              cmds=None):
+def get_starcats_as_table(obsid=None, *, start=None, stop=None, set_ids=True,
+                          scenario=None, cmds=None):
     starcats = get_starcats(obsid=obsid, start=start, stop=stop, scenario=scenario,
                             cmds=cmds, as_dict=True)
     out = defaultdict(list)
     for starcat in starcats:
+        n_cat = len(starcat['slot'])
+        out['obsid'].append([starcat['meta']['obsid']] * n_cat)
+        out['starcat_date'].append([starcat['meta']['date']] * n_cat)
         for name, vals in starcat.items():
             if name != 'meta':
                 out[name].append(vals)

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1459,6 +1459,7 @@ def reduce_states(states, state_keys, merge_identical=False):
         has_transition |= has_transitions[key]
 
     # Create output with only desired state keys and only states with a transition
+
     out = states[['datestart', 'datestop', 'tstart', 'tstop'] + list(state_keys)][has_transition]
     for dt in ('date', 't'):
         out[f'{dt}stop'][:-1] = out[f'{dt}start'][1:]

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -551,7 +551,7 @@ Definitive,2020:337:00:00:00,Bright star hold,,Tom Aldcroft,
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_get_observations_by_obsid_single():
-    obss = get_observations(8008)
+    obss = get_observations(obsid=8008)
     assert len(obss) == 1
     del obss[0]['starcat_idx']
     assert obss == [
@@ -569,7 +569,7 @@ def test_get_observations_by_obsid_single():
 
 
 def test_get_observations_by_obsid_multi():
-    obss = get_observations(47912, scenario='flight')  # Following ACA high background NSM 2019:248
+    obss = get_observations(obsid=47912, scenario='flight')  # Following ACA high background NSM 2019:248
     # Don't compare starcat_idx because it might change with a repro
     for obs in obss:
         obs.pop('starcat_idx', None)

--- a/kadi/paths.py
+++ b/kadi/paths.py
@@ -68,3 +68,8 @@ def LOADS_TABLE_PATH(scenario=None):
 
 def CMD_EVENTS_PATH(scenario=None):
     return SCENARIO_DIR(scenario) / 'cmd_events.csv'
+
+
+def STARCATS_CACHE_PATH():
+    from kadi.commands import conf
+    return Path(conf.commands_dir).expanduser() / 'starcats'


### PR DESCRIPTION
## Description

This is hodge-podge PR that makes improvements related to getting star catalogs from the commands archive.

- Adds `get_starcats_as_table` function
- Changes API on `get_observations` and `get_starcats`. First three args are now `start=None, stop=None, *, obsid=None, ...`. This is more consistent with signatures for other methods in kadi commands.
- Adds file-based caching of star catalog data to greatly improve performance.
- Adds `as_dict` option to `get_starcats` to allow getting catalogs as plain Python dict instead of converting to `ACATable` objects. This is another performance-driven feature.
- Changes API to update start/stop date filtering in `get_observations` (and by proxy `get_starcats`) so the filtering is inclusive. That means any observation where `obs_start` / `obs_stop` intersects `start` / `stop` will be included. Previously the filtering was just `start` <= `obs_start` <= `stop`.
- Better exception handling (#228) related to web access

Fixes #228

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

Two API changes as noted above.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Mac and Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### Caching control

After removing `~/.kadi/starcats.db`, I ran the code below and confirmed that the cache was NOT created, as expected:
```
from kadi.commands import get_starcats, conf
with conf.set_temp('cache_starcats', False):
    starcats = get_starcats(start='2020:001', stop='2020:100')
```

Then I did the same `starcats = ...` command but with caching enabled (the default) and confirmed that the file was created and that the expected performance improvement was seen on subsequent queries.

#### HTTP exceptions

Testing of d1d30fd consisted of:
- Change my `~/.netrc` to force an authentication error. Confirmed that I get a `401 authentication error` when trying `get_observations(obsid=8008)`.
- Change the code temporarily to force all of the directory download requests to fail, thus falling through to the line which raises `ValueError(f'No loads found in {lookback} days')`. This worked as expected.