### PR TITLE
Remake last two years of MajorEvent table each time

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1818,7 +1818,7 @@ class MajorEvent(BaseEvent):
     note = models.TextField(help_text='Note (comments or CAP # or FSW PR #)')
     source = models.CharField(max_length=3, help_text='Event source (FDB or FOT)')
 
-    # Allow for hand-edits of the source HTML tales back about two years. Make
+    # Allow for hand-edits of the source HTML tables back about two years. Make
     # sure the lookback for getting new events is a bit further back than delete
     # lookback.
     lookback = 365 * 2 + 10

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1818,6 +1818,12 @@ class MajorEvent(BaseEvent):
     note = models.TextField(help_text='Note (comments or CAP # or FSW PR #)')
     source = models.CharField(max_length=3, help_text='Event source (FDB or FOT)')
 
+    # Allow for hand-edits of the source HTML tales back about two years. Make
+    # sure the lookback for getting new events is a bit further back than delete
+    # lookback.
+    lookback = 365 * 2 + 10
+    lookback_delete = 365 * 2
+
     class Meta:
         ordering = ['key']
 


### PR DESCRIPTION
## Description

This fixes a problem where new Major Events were being added to the HTML source tables more than the default lookback time of 21 days. These events were then being lost.

By adding a 2-year `lookback` the code will see newly-added events as far back as 2 years. In addition the `lookback_delete` attribute means that *edits* of existing events (change/delete) can be done in that timeframe. In effect this will now maintain sync between the kadi events table and the source HTML pages.

**NOTE**

On `kady`, I already did a wholesale fix of the flight `MajorEvent` table with the following command. This was necessary to correct for this lookback bug over the entire time span, effectively re-syncing the database to the existing FOT and FDB major event HTML files:
- http://occweb.cfa.harvard.edu/occweb/web/fot_web/eng/reports/Chandra_major_events.htm
- http://occweb.cfa.harvard.edu/occweb/web/fdb_web/Major_Events.html

```
kadi_update_events --data-root=/proj/sot/ska/data/kadi --model MajorEvent \
  --start=1999:001 --delete-from-start
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

None

## Testing
<!-- If relevant describe any special setup for testing. -->


### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran the following, which shows major events from the last two years being removed and then re-added to the database. In particular a number of events from 2022 that were missing in flight are now included.
```
(ska3) ➜  kadi git:(fix-major-events) ✗ python -m kadi.scripts.update_events --model MajorEvent 
2022-04-20 06:26:37,107 ******************************************
2022-04-20 06:26:37,107 Running: /Users/aldcroft/git/kadi/kadi/scripts/update_events.py
2022-04-20 06:26:37,107 Version: 5.9.3.dev3+gf875dc5.d20220420
2022-04-20 06:26:37,107 Time: Wed Apr 20 06:26:37 2022
2022-04-20 06:26:37,107 User: root
2022-04-20 06:26:37,107 Machine: lmabius-l1.occ.harvard.edu
2022-04-20 06:26:37,107 Processing args:
2022-04-20 06:26:37,107 {'data_root': '.',
2022-04-20 06:26:37,107  'delete_from_start': False,
2022-04-20 06:26:37,107  'log_level': 20,
2022-04-20 06:26:37,107  'loop_days': 100,
2022-04-20 06:26:37,107  'models': ['MajorEvent'],
2022-04-20 06:26:37,107  'start': None,
2022-04-20 06:26:37,107  'stop': '2022:110:10:26:37.078'}
2022-04-20 06:26:37,107 ******************************************
2022-04-20 06:26:37,108 Event database : /Users/aldcroft/git/kadi/events3.db3
2022-04-20 06:26:37,108 
2022-04-20 06:26:37,306 Deleting 198 MajorEvent events after 2020:151:10:26:37.078
2022-04-20 06:26:37,308 Updating MajorEvent events from 2020:134:11:01:10 to 2022:110:10:26:37
2022-04-20 06:26:40,068 Added MajorEvent 2020:156 (Jun-04) FDB: EIA Sequencer self-test (CAP 425I, FSW PR &#160;)
2022-04-20 06:26:40,070 Added MajorEvent 2020:156 (Jun-04) FDB: Diagnostic dumps of CPE memory (CAP 563B, FSW PR &#160;)
2022-04-20 06:26:40,071 Added MajorEvent 2020:157 (Jun-05) FOT: HETG retraction long move d... (PR-461 uplinked successfully.)
2022-04-20 06:26:40,072 Added MajorEvent 2020:157 (Jun-05) FDB: Uplink HETG retraction larg... (CAP 1516, FSW PR 461)
2022-04-20 06:26:40,073 Added MajorEvent 2020:157 (Jun-05) FDB: Dump OBC memory (2 days) (CAP 750, FSW PR &#160;)
2022-04-20 06:26:40,074 Added MajorEvent 2020:166 (Jun-14) FDB: Summer 2020 eclipse season ... (CAP &#160;, FSW PR &#160;)
2022-04-20 06:26:40,075 Added MajorEvent 2020:166 (Jun-14) FDB: Disable SCS 29 (CAP 893B, FSW PR &#160;)
2022-04-20 06:26:40,076 Added MajorEvent 2020:166 (Jun-14) FDB: Dump and clear EPS glitch c... (CAP 1036D, FSW PR &#160;)
2022-04-20 06:26:40,077 Added MajorEvent 2020:167 (Jun-15) FDB: Cycle 22 Peer Review (9 day... (CAP &#160;, FSW PR &#160;)
2022-04-20 06:26:40,078 Added MajorEvent 2020:183 (Jul-01) FDB: EIA Sequencer self-test (CAP 425I, FSW PR &#160;)

...
2022-04-20 06:26:40,218 Added MajorEvent 2021:350 (Dec-16) FDB: Dump and clear EPS glitch c... (CAP 1036E, FSW PR &#160;)
2022-04-20 06:26:40,219 Added MajorEvent 2021:351 (Dec-17) FOT: Thermal Health Check Thresh... (PR-511 uplinked successfull...)
2022-04-20 06:26:40,219 Added MajorEvent 2022:016 (Jan-16) FOT: ACIS BEP Reboot Anomaly (Suspect SEU or brief power ...)
2022-04-20 06:26:40,220 Added MajorEvent 2022:038 (Feb-07) FOT: SSR Rollover (Due to failed transmitter a...)
2022-04-20 06:26:40,221 Added MajorEvent 2022:040 (Feb-09) FOT: HRC Anomaly (Unexpected B-side electroni...)
2022-04-20 06:26:40,221 Added MajorEvent 2022:048 (Feb-17) FOT: RadMon Patch to remove use ... (PR-513 uplinked successfully.)
2022-04-20 06:26:40,222 Added MajorEvent 2022:087 (Mar-28) FOT: RadMon trip (High Radiation detected by ...)
2022-04-20 06:26:40,223 Added MajorEvent 2022:097 (Apr-07) FOT: SSR Rollover (Due to failed transmitter a...)
2022-04-20 06:26:40,223 Added MajorEvent 2022:104 (Apr-14) FOT: Flight Software Patch to im... (PR-495 uplinked successfully.)
```