### PR TITLE
Fix lucky testing and occweb lucky functionality

### DIFF
--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -31,6 +31,7 @@ URLS = {'fdb_major_events': '/occweb/web/fdb_web/Major_Events.html',
         'fot_major_events': '/occweb/web/fot_web/eng/reports/Chandra_major_events.htm',
         'ifot': '/occweb/web/webapps/ifot/ifot.php',
         }
+LUCKY = 'lucky.cfa.harvard.edu'
 
 # Initialize 'kadi.occweb' logger.
 logger = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
     import Ska.ftp
     import uuid
 
-    ftp = Ska.ftp.SFTP('lucky', logger=logger, user=user)
+    ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
     ftp.cd('/home/{}'.format(user))
@@ -167,7 +168,7 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
     import Ska.ftp
     import Ska.File
 
-    ftp = Ska.ftp.SFTP('lucky', logger=logger, user=user)
+    ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
     ftp.cd('/home/{}/{}'.format(user, ftp_dirname))

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -13,7 +13,7 @@ from kadi import occweb
 
 try:
     Ska.ftp.parse_netrc()['lucky']['login']
-    lucky = Ska.ftp.SFTP('lucky')
+    lucky = Ska.ftp.SFTP(occweb.LUCKY)
 except Exception:
     HAS_LUCKY = False
 else:
@@ -40,7 +40,7 @@ def _test_put_get(user):
     occweb.ftp_get_from_lucky(remote_tmpdir, local_filenames, user=user)
 
     # Clean up remote temp dir
-    lucky = Ska.ftp.SFTP('lucky')
+    lucky = Ska.ftp.SFTP(occweb.LUCKY)
     if user is None:
         user = lucky.ftp.get_channel().transport.get_username()
     lucky.rmdir('/home/{}/{}'.format(user, remote_tmpdir))


### PR DESCRIPTION
## Description

As part of FST-requested testing of the new lucky server, I noticed that testing of the `kadi.occweb` module was inadvertently skipping a test. The tests were written assuming HEAD linux where `lucky` resolves to the right FTP server, but this is not the case for a Mac laptop. Instead this provides the fully-resolved host name.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
