### PR TITLE
Add instructions on creating .netrc

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -207,6 +207,24 @@ please see:
 
    commands_v2.rst
 
+Initial setup
+^^^^^^^^^^^^^
+
+In order to use commands archive v2 to always get the most up-to-date commands,
+you need to set up automated access to OCCweb so the code can fetch recent
+command loads. This is done by creating a file at the top level of your home
+directory called ``.netrc`` which includes the following contents::
+
+    machine  occweb
+    login    <OCCweb username>
+    password <OCCweb password>
+
+If you have other authentication entries in the same file (e.g. for ``lucky``)
+then there needs to be a blank line between entries.
+
+.. Important::
+   If you are on a machine with other users make sure the file is readable only
+   by you. On linux this is done with ``chmod og-rwx ~/.netrc``.
 
 Getting commands
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

This adds setup instructions for creating `~/.netrc` to allow fetching recent command loads.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
No code changes.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Built the docs with no sphinx warnings or errors and confirmed the docs look as expected.
