### PR TITLE
Better exception message in get_states for too-early start arg

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1328,7 +1328,17 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
 
     # Get initial state at start of commands
     if continuity is None:
-        continuity = get_continuity(start, state_keys, scenario=scenario)
+        try:
+            continuity = get_continuity(start, state_keys, scenario=scenario)
+        except ValueError as exc:
+            if 'did not find transitions' in str(exc):
+                raise ValueError(
+                    f'no continuity found for {start=}. Need to have state '
+                    f'transitions following first command at {cmds[0]["date"]} '
+                    'so use a later start date.'
+                )
+            else:
+                raise
 
     # Get transitions, which is a list of dict (state key
     # and new state value at that date).  This goes through each active

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1507,3 +1507,8 @@ def test_grating_motion_states():
            '2021:230:00:37:56.002 2021:230:00:41:19.002 RETR_MOVE      RETR    NONE grating,letg',
            '2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg']
     assert sts.pformat_all() == exp
+
+
+def test_early_start_exception():
+    with pytest.raises(ValueError, match="no continuity found for start='2002:001:00:00:00.000'"):
+        states.get_states('2002:001', '2003:001', state_keys=['orbit_point'])


### PR DESCRIPTION
## Description

This improves the exception message to provide better feedback to the user in the case when an early `start` time makes it not possible to establish continuity.

The suggestion in #239 was to make it that the returned states start when available data allow, similar to how `cheta` functions when fetching telemetry. This is a good idea, but due to the way dynamic command states are built up on the fly from continuity, implementing this would not be straightforward. The effective start time depends on when all of the required commands to define a particular state or states have been issued.

Instead, this just gets the user on the right track more quickly by highlighting the problem and a workaround.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #239

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
In [1]: from kadi.commands import states

In [2]: states.get_states('2002:001', '2003:001', state_keys = ['orbit_point'])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/git/kadi/kadi/commands/states.py in get_states(start, stop, state_keys, cmds, continuity, reduce, merge_identical, scenario)
   1331         try:
-> 1332             continuity = get_continuity(start, state_keys, scenario=scenario)
   1333         except ValueError as exc:

~/git/kadi/kadi/commands/states.py in get_continuity(date, state_keys, lookbacks, scenario)
   1608         if missing_keys:
-> 1609             raise ValueError('did not find transitions for state key(s)'
   1610                              ' {} within {} days of {}.  Maybe adjust the `lookbacks` argument?'

ValueError: did not find transitions for state key(s) {'orbit_point'} within 1000 days of 2002:001:00:00:00.000.  Maybe adjust the `lookbacks` argument?

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-2-bccec27564a3> in <module>
----> 1 states.get_states('2002:001', '2003:001', state_keys = ['orbit_point'])

~/git/kadi/kadi/commands/states.py in get_states(start, stop, state_keys, cmds, continuity, reduce, merge_identical, scenario)
   1333         except ValueError as exc:
   1334             if 'did not find transitions' in str(exc):
-> 1335                 raise ValueError(
   1336                     f'no continuity found for {start=}. Need to have state '
   1337                     f'transitions following first command at {cmds[0]["date"]} '

ValueError: no continuity found for start='2002:001:00:00:00.000'. Need to have state transitions following first command at 2002:007:13:35:57.743 so use a later start date.
```
