### PR TITLE
add starcat_date argument to get_observations, get_starcats and get_s…

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -709,6 +709,15 @@ def test_get_starcats_date():
     assert sc_cmd['type'] == 'MP_STARCAT'
 
 
+def test_get_starcats_by_date():
+    """Test that the getting a starcat using the starcat_date as argument returns the same catalog
+    as using the OBSID.
+    """
+    sc = get_starcats(obsid=8008, scenario='flight')[0]
+    sc_by_date = get_starcats(starcat_date='2007:002:04:31:43.965', scenario='flight')[0]
+    assert np.all(sc == sc_by_date)
+
+
 def test_get_starcats_as_table():
     """Test that get_starcats_as_table returns the same as vstacked get_starcats"""
     start, stop = '2020:001', '2020:002'


### PR DESCRIPTION
## Description

The starcat_date is effectively the catalog's unique ID, so it would be convenient to be able to fetch a catalog given starcat_date. This PR does that: it adds starcat_date argument to get_observations, get_starcats and get_starcats_as_table.

If the starcat_date argument is given, the start time defaults to starcat_date and the stop time defaults to starcat_date + 7 days.

## Interface impacts

Add one optional argument to three functions. This should not affect any existing code.

## Testing

A unit test was added to check this functionality on a simple case

### Unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

```
In [1]: from kadi.commands import get_observations, get_starcats

In [2]: get_observations(starcat_date='2022:001:17:00:58.521', scenario='flight')
Out[2]: 
[{'obsid': 23800,
  'simpos': 75624,
  'obs_stop': '2022:002:01:24:53.004',
  'manvr_start': '2022:001:17:01:02.772',
  'targ_att': (0.177875061, 0.452625075, 0.827436517, 0.280784286),
  'npnt_enab': True,
  'obs_start': '2022:001:17:33:53.255',
  'prev_att': (0.116555575, -0.407948573, -0.759717367, 0.492770009),
  'starcat_date': '2022:001:17:00:58.521',
  'starcat_idx': 171677,
  'source': 'DEC3021A'}]

In [3]: get_starcats(starcat_date='2022:001:17:00:58.521', scenario='flight')
Out[3]: 
[<ACATable length=11>
  slot  idx     id    type  sz    mag    maxmag   yang     zang    dim   res  halfw
 int64 int64  int64   str3 str3 float64 float64 float64  float64  int64 int64 int64
 ----- ----- -------- ---- ---- ------- ------- -------- -------- ----- ----- -----
     0     1        2  FID  8x8    7.00    8.00  -773.14 -1741.99     1     1    25
     1     2        4  FID  8x8    7.00    8.00  2140.38   166.73     1     1    25
     2     3        5  FID  8x8    7.00    8.00 -1826.24   160.26     1     1    25
     3     4 29886088  BOT  6x6    7.20    8.70  -277.35  1178.46    28     1   160
     4     5 29887352  BOT  6x6    8.24    9.84 -1329.24 -2103.75    28     1   160
     5     6 30288600  BOT  6x6    9.07   10.58  1758.15  -270.45    28     1   160
     6     7 30290968  BOT  6x6    9.50   11.02   761.76  1753.00    28     1   160
     7     8 30292744  BOT  6x6    8.47   10.03  1349.94  -786.44    28     1   160
     0     9 30289640  ACQ  6x6    9.44   11.08  1777.10   544.73    28     1   160
     1    10 29892168  ACQ  6x6    9.46   11.08 -1534.55 -1989.80    16     1   100
     2    11 29884784  ACQ  6x6    9.67   11.14   647.71  -848.31    24     1   140]

```
