### PR TITLE
Add EventQuery to symbols exported from query.py by events/__init__.py

### DIFF
--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -68,6 +68,7 @@ os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 # With this trick of lazy loading, both pathways work!
 
 __all__ = [
+    'EventQuery',
     'models',
     'obsids',
     'tsc_moves',


### PR DESCRIPTION
## Description

`ska_testr` integration showed a script that was expecting `EventQuery` to be available as an import from `kadi.events`, so this adds that in.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Fixes an unexpected API change where `EventQuery` was not available.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
With `PYTHONPATH` set to the git repo at this branch, I ran `run_testr --include kadi`:
- Without the fix (current master) I reproduced the failure related to `EventQuery` seen in ska3-flight 2022.7rc2.
- With the fix all tests pass.
