### PR TITLE
Apply Black and isort autoformatting

### DIFF
--- a/kadi/__init__.py
+++ b/kadi/__init__.py
@@ -14,7 +14,7 @@ def _get_kadi_logger():
     """
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.WARNING)
-    fmt = logging.Formatter('%(asctime)s %(funcName)s: %(message)s', datefmt=None)
+    fmt = logging.Formatter("%(asctime)s %(funcName)s: %(message)s", datefmt=None)
     hdlr = logging.StreamHandler(sys.stdout)
     hdlr.setFormatter(fmt)
     logger.addHandler(hdlr)
@@ -25,10 +25,11 @@ logger = _get_kadi_logger()
 
 
 def test(*args, **kwargs):
-    '''
+    """
     Run py.test unit tests.
-    '''
+    """
     import testr
+
     return testr.test(*args, **kwargs)
 
 
@@ -39,4 +40,5 @@ def create_config_file(overwrite=False):
         Force updating the file if it already exists.
     """
     from astropy import config
-    return config.create_config_file(pkg='kadi', rootname='kadi', overwrite=overwrite)
+
+    return config.create_config_file(pkg="kadi", rootname="kadi", overwrite=overwrite)

--- a/kadi/cmds/cmds.py
+++ b/kadi/cmds/cmds.py
@@ -10,12 +10,14 @@ import warnings
 
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
-__all__ = ['filter']
+__all__ = ["filter"]
 
 # Warn about deprecation but use FutureWarning so it actually shows up (since
 # DeprecationWarning is ignored by default)
-warnings.warn('kadi.cmds is deprecated and no longer tested, use kadi.commands instead',
-              FutureWarning)
+warnings.warn(
+    "kadi.cmds is deprecated and no longer tested, use kadi.commands instead",
+    FutureWarning,
+)
 
 
 class LazyVal(object):
@@ -24,12 +26,12 @@ class LazyVal(object):
 
     def __getattribute__(self, name):
         try:
-            val = object.__getattribute__(self, '_val')
+            val = object.__getattribute__(self, "_val")
         except AttributeError:
-            val = object.__getattribute__(self, '_load_func')()
+            val = object.__getattribute__(self, "_load_func")()
             self._val = val
 
-        if name == '_val':
+        if name == "_val":
             return val
         else:
             return val.__getattribute__(name)
@@ -48,15 +50,15 @@ class LazyVal(object):
 
 
 def load_idx_cmds():
-    h5 = tables.open_file(IDX_CMDS_PATH(), mode='r')
+    h5 = tables.open_file(IDX_CMDS_PATH(), mode="r")
     idx_cmds = Table(h5.root.data[:])
     h5.close()
     return idx_cmds
 
 
 def load_pars_dict():
-    with open(PARS_DICT_PATH(), 'rb') as fh:
-        pars_dict = pickle.load(fh, encoding='ascii')
+    with open(PARS_DICT_PATH(), "rb") as fh:
+        pars_dict = pickle.load(fh, encoding="ascii")
     return pars_dict
 
 
@@ -140,9 +142,9 @@ def _find(start=None, stop=None, **kwargs):
     par_ok = np.zeros(len(idx_cmds), dtype=bool)
 
     if start:
-        ok &= idx_cmds['date'] >= DateTime(start).date
+        ok &= idx_cmds["date"] >= DateTime(start).date
     if stop:
-        ok &= idx_cmds['date'] < DateTime(stop).date
+        ok &= idx_cmds["date"] < DateTime(stop).date
     for key, val in kwargs.items():
         key = key.lower()
         if isinstance(val, str):
@@ -154,7 +156,7 @@ def _find(start=None, stop=None, **kwargs):
             for pars_tuple, idx in pars_dict.items():
                 pars = dict(pars_tuple)
                 if pars.get(key) == val:
-                    par_ok |= (idx_cmds['idx'] == idx)
+                    par_ok |= idx_cmds["idx"] == idx
             ok &= par_ok
     cmds = idx_cmds[ok]
     return cmds
@@ -172,22 +174,25 @@ class Cmd(dict):
                 self[name] = value.item()
             except AttributeError:
                 self[name] = value
-        self.update(rev_pars_dict[cmd['idx']])
+        self.update(rev_pars_dict[cmd["idx"]])
 
-        if self['tlmsid'] == 'None':
-            colnames.remove('tlmsid')
+        if self["tlmsid"] == "None":
+            colnames.remove("tlmsid")
 
-        self._ordered_keys = (colnames[1:]
-                              + [par[0] for par in rev_pars_dict[cmd['idx']]])
+        self._ordered_keys = colnames[1:] + [
+            par[0] for par in rev_pars_dict[cmd["idx"]]
+        ]
 
     def __repr__(self):
-        out = ('<{} '.format(self.__class__.__name__) + str(self) + '>')
+        out = "<{} ".format(self.__class__.__name__) + str(self) + ">"
         return out
 
     def __str__(self):
-        out = ('{} {:11s} '.format(self['date'], self['type'])
-               + ' '.join('{}={}'.format(key, self[key]) for key in self._ordered_keys
-                          if key not in ('type', 'date')))
+        out = "{} {:11s} ".format(self["date"], self["type"]) + " ".join(
+            "{}={}".format(key, self[key])
+            for key in self._ordered_keys
+            if key not in ("type", "date")
+        )
         return out
 
 
@@ -197,9 +202,9 @@ class CmdList(object):
 
     @property
     def table(self):
-        if not hasattr(self, '_table'):
+        if not hasattr(self, "_table"):
             self._table = Table(self.cmds, copy=False)
-            self._table.remove_column('idx')
+            self._table.remove_column("idx")
         return self._table
 
     def __len__(self):
@@ -212,7 +217,7 @@ class CmdList(object):
                 return cmds[item]
 
             out = []
-            for idx in cmds['idx']:
+            for idx in cmds["idx"]:
                 # Find the parameters dict for this command from the reverse
                 # lookup table which maps index to the params tuple.
                 out.append(dict(rev_pars_dict[idx]).get(item))
@@ -227,7 +232,7 @@ class CmdList(object):
         return out
 
     def __repr__(self):
-        return '\n'.join(str(Cmd(cmd)) for cmd in self.cmds)
+        return "\n".join(str(Cmd(cmd)) for cmd in self.cmds)
 
     def __str__(self):
         return repr(self)

--- a/kadi/cmds/cmds.py
+++ b/kadi/cmds/cmds.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import tables
-
-import numpy as np
-
-from astropy.table import Table
-from Chandra.Time import DateTime
 import pickle
 import warnings
+
+import numpy as np
+import tables
+from astropy.table import Table
+from Chandra.Time import DateTime
 
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 

--- a/kadi/commands/__init__.py
+++ b/kadi/commands/__init__.py
@@ -4,6 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from astropy.config import ConfigNamespace
+
 from kadi.config import ConfigItem
 
 
@@ -61,5 +62,5 @@ class Conf(ConfigNamespace):
 conf = Conf()
 
 
-from .core import *  # noqa
 from .commands import *  # noqa
+from .core import *  # noqa

--- a/kadi/commands/__init__.py
+++ b/kadi/commands/__init__.py
@@ -11,51 +11,49 @@ class Conf(ConfigNamespace):
     """
     Configuration parameters for my subpackage.
     """
+
     default_lookback = ConfigItem(
-        30,
-        'Default lookback for previous approved loads (days).'
+        30, "Default lookback for previous approved loads (days)."
     )
     cache_loads_in_astropy_cache = ConfigItem(
         False,
-        'Cache backstop downloads in the astropy cache. Should typically be False, '
-        'but useful during development to avoid re-downloading backstops.'
+        "Cache backstop downloads in the astropy cache. Should typically be False, "
+        "but useful during development to avoid re-downloading backstops.",
     )
     cache_starcats = ConfigItem(
         True,
-        'Cache star catalogs that are retrieved to a file to avoid repeating the '
-        'slow process of identifying fid and stars in catalogs. The cache file is '
-        'conf.commands_dir/starcats.db.'
+        "Cache star catalogs that are retrieved to a file to avoid repeating the "
+        "slow process of identifying fid and stars in catalogs. The cache file is "
+        "conf.commands_dir/starcats.db.",
     )
     clean_loads_dir = ConfigItem(
         True,
-        'Clean backstop loads (like APR1421B.pkl.gz) in the loads directory that are '
-        'older than the default lookback. Most users will want this to be True, but '
-        'for development or if you always want a copy of the loads set to False.'
+        "Clean backstop loads (like APR1421B.pkl.gz) in the loads directory that are "
+        "older than the default lookback. Most users will want this to be True, but "
+        "for development or if you always want a copy of the loads set to False.",
     )
     commands_dir = ConfigItem(
-        '~/.kadi',
-        'Directory where command loads and command events are stored after '
-        'downloading from Google Sheets and OCCweb.'
+        "~/.kadi",
+        "Directory where command loads and command events are stored after "
+        "downloading from Google Sheets and OCCweb.",
     )
     commands_version = ConfigItem(
-        '1',
+        "1",
         'Default version of kadi commands ("1" or "2").  Overridden by '
-        'KADI_COMMANDS_VERSION environment variable.'
+        "KADI_COMMANDS_VERSION environment variable.",
     )
 
     cmd_events_flight_id = ConfigItem(
-        '19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ',
-        'Google Sheet ID for command events (flight scenario).'
+        "19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ",
+        "Google Sheet ID for command events (flight scenario).",
     )
 
     star_id_match_halfwidth = ConfigItem(
-        1.5,
-        'Half-width box size of star ID match for get_starcats() (arcsec).'
+        1.5, "Half-width box size of star ID match for get_starcats() (arcsec)."
     )
 
     fid_id_match_halfwidth = ConfigItem(
-        40,
-        'Half-width box size of fid ID match for get_starcats() (arcsec).'
+        40, "Half-width box size of fid ID match for get_starcats() (arcsec)."
     )
 
 

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -9,13 +9,13 @@ from cxotime import CxoTime
 from parse_cm.common import _coerce_type as coerce_type
 from kadi.commands.core import CommandTable
 
-RTS_PATH = Path('FOT/configuration/products/rts')
+RTS_PATH = Path("FOT/configuration/products/rts")
 
 
 def cmd_set_rts(*args, date=None):
     from parse_cm.csd import csd_cmd_gen
 
-    rts = 'SCS_CATEGORY,OBSERVING\n' + '\n'.join(args).upper()
+    rts = "SCS_CATEGORY,OBSERVING\n" + "\n".join(args).upper()
     cmds = csd_cmd_gen(rts, date=date)
     return cmds
 
@@ -26,9 +26,7 @@ def cmd_set_obsid(obs_id, date=None):
     :param obsid: obsid
     :returns: list of command defs suitable for generate_cmds()
     """
-    return (dict(type='MP_OBSID',
-                 tlmsid='COAOSQID',
-                 params=dict(ID=obs_id)),)
+    return (dict(type="MP_OBSID", tlmsid="COAOSQID", params=dict(ID=obs_id)),)
 
 
 def cmd_set_maneuver(*args, date=None):
@@ -39,106 +37,83 @@ def cmd_set_maneuver(*args, date=None):
     :returns: list of command defs suitable for generate_cmds()
     """
     att = Quat(args)
-    return (dict(type='COMMAND_SW',
-                 tlmsid='AONMMODE',
-                 msid='AONMMODE',
-                 dur=0.25625),
-            dict(type='COMMAND_SW',
-                 tlmsid='AONM2NPE',
-                 msid='AONM2NPE',
-                 dur=4.1),
-            dict(type='MP_TARGQUAT',
-                 tlmsid='AOUPTARQ',
-                 params=dict(Q1=att.q[0], Q2=att.q[1],
-                             Q3=att.q[2], Q4=att.q[3]),
-                 dur=5.894),
-            dict(type='COMMAND_SW',
-                 tlmsid='AOMANUVR',
-                 msid='AOMANUVR'),
-            )
+    return (
+        dict(type="COMMAND_SW", tlmsid="AONMMODE", msid="AONMMODE", dur=0.25625),
+        dict(type="COMMAND_SW", tlmsid="AONM2NPE", msid="AONM2NPE", dur=4.1),
+        dict(
+            type="MP_TARGQUAT",
+            tlmsid="AOUPTARQ",
+            params=dict(Q1=att.q[0], Q2=att.q[1], Q3=att.q[2], Q4=att.q[3]),
+            dur=5.894,
+        ),
+        dict(type="COMMAND_SW", tlmsid="AOMANUVR", msid="AOMANUVR"),
+    )
 
 
 def cmd_set_aciscti(date=None):
-    return (dict(type='ACISPKT',
-                 tlmsid='WSVIDALLDN',
-                 dur=1.025),
-            dict(type='ACISPKT',
-                 tlmsid='WSPOW0CF3F',
-                 dur=1.025),
-            dict(type='ACISPKT',
-                 tlmsid='WT00216024',
-                 dur=67),
-            dict(type='ACISPKT',
-                 tlmsid='XTZ0000005'))
+    return (
+        dict(type="ACISPKT", tlmsid="WSVIDALLDN", dur=1.025),
+        dict(type="ACISPKT", tlmsid="WSPOW0CF3F", dur=1.025),
+        dict(type="ACISPKT", tlmsid="WT00216024", dur=67),
+        dict(type="ACISPKT", tlmsid="XTZ0000005"),
+    )
 
 
 def cmd_set_scs107(date=None):
     # SCS-106 (which is called by 107) was patched around 2021-Jun-08
-    if date is not None and date > CxoTime('2021-06-08').date:
-        pow_cmd = 'WSPOW0002A'  # 3-FEPS
+    if date is not None and date > CxoTime("2021-06-08").date:
+        pow_cmd = "WSPOW0002A"  # 3-FEPS
     else:
-        pow_cmd = 'WSPOW00000'  # 0-FEPS
+        pow_cmd = "WSPOW00000"  # 0-FEPS
 
-    return (dict(type='COMMAND_SW',
-                 dur=1.025,
-                 tlmsid='OORMPDS'),
-            dict(type='COMMAND_HW',
-                 # dur=1.025,
-                 tlmsid='AFIDP',
-                 msid='AFLCRSET'),
-            dict(type='SIMTRANS',
-                 params=dict(POS=-99616),
-                 dur=65.66),
-            dict(type='ACISPKT',
-                 tlmsid='AA00000000',
-                 dur=1.025),
-            dict(type='ACISPKT',
-                 tlmsid='AA00000000',
-                 dur=10.25),
-            dict(type='ACISPKT',
-                 tlmsid=pow_cmd),
-            )
+    return (
+        dict(type="COMMAND_SW", dur=1.025, tlmsid="OORMPDS"),
+        dict(
+            type="COMMAND_HW",
+            # dur=1.025,
+            tlmsid="AFIDP",
+            msid="AFLCRSET",
+        ),
+        dict(type="SIMTRANS", params=dict(POS=-99616), dur=65.66),
+        dict(type="ACISPKT", tlmsid="AA00000000", dur=1.025),
+        dict(type="ACISPKT", tlmsid="AA00000000", dur=10.25),
+        dict(type="ACISPKT", tlmsid=pow_cmd),
+    )
 
 
 def cmd_set_dither(state, date=None):
-    if state not in ('ON', 'OFF'):
-        raise ValueError(f'Invalid dither state {state!r}')
-    enab = 'EN' if state == 'ON' else 'DS'
-    return (dict(type='COMMAND_SW',
-                 tlmsid=f'AO{enab}DITH',
-                 ),
-            )
+    if state not in ("ON", "OFF"):
+        raise ValueError(f"Invalid dither state {state!r}")
+    enab = "EN" if state == "ON" else "DS"
+    return (
+        dict(
+            type="COMMAND_SW",
+            tlmsid=f"AO{enab}DITH",
+        ),
+    )
 
 
 def cmd_set_bright_star_hold(date=None):
-    out = (cmd_set_scs107(date=date)
-           + cmd_set_dither('OFF', date=date)
-           )
+    out = cmd_set_scs107(date=date) + cmd_set_dither("OFF", date=date)
     return out
 
 
 def cmd_set_nsm(date=None):
-    nsm_cmd = dict(type='COMMAND_SW',
-                   tlmsid='AONSMSAF')
-    out = ((nsm_cmd,)
-           + cmd_set_scs107(date=date)
-           + cmd_set_dither('OFF', date=date)
-           )
+    nsm_cmd = dict(type="COMMAND_SW", tlmsid="AONSMSAF")
+    out = (nsm_cmd,) + cmd_set_scs107(date=date) + cmd_set_dither("OFF", date=date)
     return out
 
 
 def cmd_set_safe_mode(date=None):
-    safe_mode_cmds = (dict(type='COMMAND_SW',
-                           tlmsid='ACPCSFSU'),  # CPE set pcad mode to safe sun
-                      dict(type='COMMAND_SW',
-                           tlmsid='CSELFMT5')  # Format 5 (programmable) select
-                      )
+    safe_mode_cmds = (
+        dict(type="COMMAND_SW", tlmsid="ACPCSFSU"),  # CPE set pcad mode to safe sun
+        dict(type="COMMAND_SW", tlmsid="CSELFMT5"),  # Format 5 (programmable) select
+    )
     # This is a little lazy, but put the NSM commands on top of safe mode.
     # Even though not 100% accurate this does the right thing for commands and
     # state processing. Otherwise need to put stuff into commands_v2 and states
     # to handle the ACPCSFSU command.
-    out = (safe_mode_cmds
-           + cmd_set_nsm(date=date))
+    out = safe_mode_cmds + cmd_set_nsm(date=date)
     return out
 
 
@@ -152,28 +127,28 @@ def cmd_set_observing_not_run(load_name, date=None):
 
 def cmd_set_command(*args, date=None):
     params_str = args[0]
-    cmd_type, args_str = params_str.split('|', 1)
-    cmd = {'type': cmd_type.strip().upper()}
+    cmd_type, args_str = params_str.split("|", 1)
+    cmd = {"type": cmd_type.strip().upper()}
 
     # Strip spaces around equals signs and uppercase args (note that later the
     # keys are lowercased).
-    args_str = re.sub(r'\s*=\s*', '=', args_str).upper()
+    args_str = re.sub(r"\s*=\s*", "=", args_str).upper()
 
     params = {}
     for param in args_str.split():
-        key, val = param.split('=')
-        if key == 'TLMSID':
-            cmd['tlmsid'] = val
+        key, val = param.split("=")
+        if key == "TLMSID":
+            cmd["tlmsid"] = val
         else:
             params[key] = coerce_type(val)
-    cmd['params'] = params
+    cmd["params"] = params
 
     return (cmd,)
 
 
 def cmd_set_command_not_run(*args, date=None):
-    cmd, = cmd_set_command(*args, date=date)
-    cmd['type'] = 'NOT_RUN'
+    (cmd,) = cmd_set_command(*args, date=date)
+    cmd["type"] = "NOT_RUN"
     return (cmd,)
 
 
@@ -186,15 +161,15 @@ def get_cmds_from_event(date, event, params_str):
     :param params_str: str, command event parameters string
     :returns: ``CommandTable`` with commands
     """
-    event_func_name = event.lower().replace(' ', '_').replace('-', '')
-    event_func = globals().get('cmd_set_' + event_func_name)
+    event_func_name = event.lower().replace(" ", "_").replace("-", "")
+    event_func = globals().get("cmd_set_" + event_func_name)
     if event_func is None:
-        raise ValueError(f'unknown event {event!r}')
+        raise ValueError(f"unknown event {event!r}")
 
     if isinstance(params_str, str):
-        if event == 'RTS':
+        if event == "RTS":
             args = [params_str]
-        elif event in ('Command', 'Command not run'):
+        elif event in ("Command", "Command not run"):
             # Delegate parsing to cmd_set_command
             args = [params_str]
         else:
@@ -211,7 +186,7 @@ def get_cmds_from_event(date, event, params_str):
 
     cmd_date = CxoTime(date)
     outs = []
-    event_text = event.replace(' ', '_')
+    event_text = event.replace(" ", "_")
     event_date = CxoTime(date).date[:17]
 
     # Loop through commands. This could be a list of dict which is a relative
@@ -224,36 +199,38 @@ def get_cmds_from_event(date, event, params_str):
 
         # Get command duration (if any). If the cmd is only {'dur': <dt>} then
         # it is a pure delay so skip subsequent processing.
-        dur = cmd.pop('dur', None)
+        dur = cmd.pop("dur", None)
         if dur and not cmd:
             cmd_date += dur * u.s
             continue
 
-        date = cmd.pop('date', cmd_date.date)
-        tlmsid = cmd.pop('tlmsid', None)
-        cmd_type = cmd.pop('type')
+        date = cmd.pop("date", cmd_date.date)
+        tlmsid = cmd.pop("tlmsid", None)
+        cmd_type = cmd.pop("type")
 
         params = {}
-        params['event'] = event_text
-        params['event_date'] = event_date
-        for key, val in cmd.pop('params', {}).items():
+        params["event"] = event_text
+        params["event_date"] = event_date
+        for key, val in cmd.pop("params", {}).items():
             params[key.lower()] = val
         # Allow for params to be included in cmd dict directly as well as within
         # the 'params' key.
         for key, val in cmd.items():
             params[key.lower()] = val
-        scs = params.pop('scs', 0)
+        scs = params.pop("scs", 0)
 
-        out = {'idx': -1,
-               'date': date,
-               'type': cmd_type,
-               'tlmsid': tlmsid,
-               'scs': scs,
-               'step': step,
-               'time': CxoTime(date).secs,
-               'source': 'CMD_EVT',
-               'vcdu': -1,
-               'params': params}
+        out = {
+            "idx": -1,
+            "date": date,
+            "type": cmd_type,
+            "tlmsid": tlmsid,
+            "scs": scs,
+            "step": step,
+            "time": CxoTime(date).secs,
+            "source": "CMD_EVT",
+            "vcdu": -1,
+            "params": params,
+        }
         outs.append(out)
 
         if dur is not None:

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -3,10 +3,10 @@ import re
 from pathlib import Path
 
 import astropy.units as u
-
-from Quaternion import Quat
 from cxotime import CxoTime
 from parse_cm.common import _coerce_type as coerce_type
+from Quaternion import Quat
+
 from kadi.commands.core import CommandTable
 
 RTS_PATH = Path("FOT/configuration/products/rts")

--- a/kadi/commands/commands.py
+++ b/kadi/commands/commands.py
@@ -43,17 +43,15 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, scenario=None, **kwarg
 
     :returns: :class:`~kadi.commands.commands.CommandTable` of commands
     """
-    commands_version = os.environ.get('KADI_COMMANDS_VERSION',
-                                      conf.commands_version)
-    if commands_version == '2':
+    commands_version = os.environ.get("KADI_COMMANDS_VERSION", conf.commands_version)
+    if commands_version == "2":
         from kadi.commands.commands_v2 import get_cmds as get_cmds_
+
         get_cmds_ = functools.partial(get_cmds_, scenario=scenario)
     else:
         from kadi.commands.commands_v1 import get_cmds as get_cmds_
 
-    cmds = get_cmds_(start=start, stop=stop,
-                     inclusive_stop=inclusive_stop,
-                     **kwargs)
+    cmds = get_cmds_(start=start, stop=stop, inclusive_stop=inclusive_stop, **kwargs)
     return cmds
 
 
@@ -63,9 +61,8 @@ def clear_caches():
     This is useful for testing and in case upstream products like the Command
     Events sheet have changed during a session.
     """
-    commands_version = os.environ.get('KADI_COMMANDS_VERSION',
-                                      conf.commands_version)
-    if commands_version == '2':
+    commands_version = os.environ.get("KADI_COMMANDS_VERSION", conf.commands_version)
+    if commands_version == "2":
         from kadi.commands.commands_v2 import clear_caches as clear_caches_vN
     else:
         from kadi.commands.commands_v1 import clear_caches as clear_caches_vN

--- a/kadi/commands/commands_v1.py
+++ b/kadi/commands/commands_v1.py
@@ -50,10 +50,10 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, **kwargs):
     """
     out = _find(start, stop, inclusive_stop, IDX_CMDS, PARS_DICT, **kwargs)
     out.rev_pars_dict = weakref.ref(REV_PARS_DICT)
-    out['params'] = None if len(out) > 0 else Column([], dtype=object)
+    out["params"] = None if len(out) > 0 else Column([], dtype=object)
 
-    out.add_column(CxoTime(out['date'], format='date').secs, name='time', index=6)
-    out['time'].info.format = '.3f'
+    out.add_column(CxoTime(out["date"], format="date").secs, name="time", index=6)
+    out["time"].info.format = ".3f"
 
     # Convert 'date' from bytestring to unicode. This is for compatibility with
     # the legacy V1 API.

--- a/kadi/commands/commands_v1.py
+++ b/kadi/commands/commands_v1.py
@@ -1,9 +1,9 @@
 import weakref
 
 from astropy.table import Column
-from kadi.commands.core import LazyVal, _find, load_idx_cmds, load_pars_dict
 from cxotime import CxoTime
 
+from kadi.commands.core import LazyVal, _find, load_idx_cmds, load_pars_dict
 
 # Globals that contain the entire commands table and the parameters index
 # dictionary.

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -23,9 +23,17 @@ from Chandra.Maneuver import NSM_attitude
 
 
 from kadi.commands import get_cmds_from_backstop, conf
-from kadi.commands.core import (load_idx_cmds, load_pars_dict, LazyVal,
-                                get_par_idx_update_pars_dict, _find, vstack_exact,
-                                ska_load_dir, CommandTable, load_name_to_cxotime)
+from kadi.commands.core import (
+    load_idx_cmds,
+    load_pars_dict,
+    LazyVal,
+    get_par_idx_update_pars_dict,
+    _find,
+    vstack_exact,
+    ska_load_dir,
+    CommandTable,
+    load_name_to_cxotime,
+)
 from kadi.commands.command_sets import get_cmds_from_event
 from kadi import occweb, paths
 
@@ -36,10 +44,12 @@ MATCHING_BLOCK_SIZE = 500
 
 # TODO: cache translation from cmd_events to CommandTable's  [Probably not]
 
-APPROVED_LOADS_OCCWEB_DIR = Path('FOT/mission_planning/PRODUCTS/APPR_LOADS')
+APPROVED_LOADS_OCCWEB_DIR = Path("FOT/mission_planning/PRODUCTS/APPR_LOADS")
 
 # URL to download google sheets `doc_id`
-CMD_EVENTS_SHEET_URL = 'https://docs.google.com/spreadsheets/d/{doc_id}/export?format=csv'
+CMD_EVENTS_SHEET_URL = (
+    "https://docs.google.com/spreadsheets/d/{doc_id}/export?format=csv"
+)
 
 # Cached values of the full mission commands archive (cmds_v2.h5, cmds_v2.pkl).
 # These are loaded on demand.
@@ -52,7 +62,7 @@ CMDS_RECENT = {}
 MATCHING_BLOCKS = {}
 
 # APR1420B was the first load set to have RLTT (backstop 6.9)
-RLTT_ERA_START = CxoTime('2020-04-14')
+RLTT_ERA_START = CxoTime("2020-04-14")
 
 HAS_INTERNET = has_internet()
 
@@ -74,6 +84,7 @@ def clear_caches():
             pass
 
     from kadi.commands.observations import OBSERVATIONS
+
     OBSERVATIONS.clear()
 
 
@@ -85,13 +96,14 @@ def interrupt_load_commands(load, cmds):
     that de-duplicates orbit points.
     """
     bad = np.zeros(len(cmds), dtype=bool)
-    if load['observing_stop'] != '':
-        bad |= ((cmds['date'] > load['observing_stop'])
-                & (cmds['scs'] > 130))
-    if load['vehicle_stop'] != '':
-        bad |= ((cmds['date'] > load['vehicle_stop'])
-                & (cmds['scs'] < 131)
-                & (cmds['type'] != 'ORBPOINT'))
+    if load["observing_stop"] != "":
+        bad |= (cmds["date"] > load["observing_stop"]) & (cmds["scs"] > 130)
+    if load["vehicle_stop"] != "":
+        bad |= (
+            (cmds["date"] > load["vehicle_stop"])
+            & (cmds["scs"] < 131)
+            & (cmds["type"] != "ORBPOINT")
+        )
     if np.any(bad):
         logger.info(f'Cutting {bad.sum()} commands from {load["name"]}')
         cmds = cmds[~bad]
@@ -114,11 +126,11 @@ def _merge_cmds_archive_recent(start, scenario):
     """
     cmds_recent = CMDS_RECENT[scenario]
 
-    logger.info(f'Merging cmds_recent with archive commands from {start}')
+    logger.info(f"Merging cmds_recent with archive commands from {start}")
 
     if scenario not in MATCHING_BLOCKS:
         # Get index for start of cmds_recent within the cmds archive
-        i0_arch_recent = IDX_CMDS.find_date(cmds_recent['date'][0])
+        i0_arch_recent = IDX_CMDS.find_date(cmds_recent["date"][0])
 
         # Find the end of the first large (MATCHING_BLOCK_SIZE) block of
         # cmds_recent that overlap with archive cmds. Look for the matching
@@ -127,7 +139,8 @@ def _merge_cmds_archive_recent(start, scenario):
         # to the end of the matching block. `i0_recent` is the end of the
         # matching block in recent commands.
         arch_recent_offset, recent_block_end = get_matching_block_idx(
-            IDX_CMDS[i0_arch_recent:], cmds_recent)
+            IDX_CMDS[i0_arch_recent:], cmds_recent
+        )
         arch_block_end = i0_arch_recent + arch_recent_offset
         MATCHING_BLOCKS[scenario] = arch_block_end, recent_block_end, i0_arch_recent
     else:
@@ -157,9 +170,9 @@ def get_matching_block_idx_simple(cmds_recent, cmds_arch, min_match):
     # block of recent commands. There might be multiple commands at the same
     # date, so we walk through this getting a block match of `min_match` size.
     # Matching block is defined by all `key_names` columns matching.
-    date0 = cmds_recent['date'][0]
+    date0 = cmds_recent["date"][0]
     i0_arch = cmds_arch.find_date(date0)
-    key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'vcdu')
+    key_names = ("date", "type", "tlmsid", "scs", "step", "vcdu")
 
     # Find block of commands in cmd_arch that match first min_match of
     # cmds_recent. Special case is min_match=0, which means we just want to
@@ -167,16 +180,22 @@ def get_matching_block_idx_simple(cmds_recent, cmds_arch, min_match):
     # the transition from pre-RLTT (APR1420B) to post, for the one-time
     # migration from version 1 to version 2.
     while min_match > 0:
-        if all(np.all(cmds_arch[name][i0_arch:i0_arch + min_match]
-                      == cmds_recent[name][:min_match])
-               for name in key_names):
+        if all(
+            np.all(
+                cmds_arch[name][i0_arch : i0_arch + min_match]
+                == cmds_recent[name][:min_match]
+            )
+            for name in key_names
+        ):
             break
         # No joy, step forward and make sure date still matches
         i0_arch += 1
-        if cmds_arch['date'][i0_arch] != date0:
-            raise ValueError(f'No matching commands block in archive found for recent_commands')
+        if cmds_arch["date"][i0_arch] != date0:
+            raise ValueError(
+                f"No matching commands block in archive found for recent_commands"
+            )
 
-    logger.info(f'Found matching commands block in archive at {i0_arch}')
+    logger.info(f"Found matching commands block in archive at {i0_arch}")
     return i0_arch
 
 
@@ -199,48 +218,48 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, scenario=None, **kwarg
 
     :returns: CommandTable
     """
-    scenario = os.environ.get('KADI_SCENARIO', scenario)
-    start = CxoTime('1999:001' if start is None else start)
+    scenario = os.environ.get("KADI_SCENARIO", scenario)
+    start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)
 
     # Default stop is either now (typically) or set by env var
-    default_stop = CxoTime(os.environ.get('KADI_COMMANDS_DEFAULT_STOP'))
+    default_stop = CxoTime(os.environ.get("KADI_COMMANDS_DEFAULT_STOP"))
 
     # For flight scenario or no internet or if the query stop time is guaranteed
     # to not require recent commands then just use the archive.
     before_recent_cmds = stop < default_stop - conf.default_lookback * u.day
-    if scenario == 'flight' or not HAS_INTERNET or before_recent_cmds:
+    if scenario == "flight" or not HAS_INTERNET or before_recent_cmds:
         cmds = IDX_CMDS
-        logger.info('Getting commands from archive only')
+        logger.info("Getting commands from archive only")
     else:
         if scenario not in CMDS_RECENT:
             cmds_recent = update_archive_and_get_cmds_recent(
-                scenario, cache=True,
-                pars_dict=PARS_DICT, rev_pars_dict=REV_PARS_DICT)
+                scenario, cache=True, pars_dict=PARS_DICT, rev_pars_dict=REV_PARS_DICT
+            )
         else:
             cmds_recent = CMDS_RECENT[scenario]
 
         # Get `cmds` as correct mix of recent and archive commands that contains
         # the requested date range.
-        if stop.date < cmds_recent['date'][0]:
+        if stop.date < cmds_recent["date"][0]:
             # Query does not overlap with recent commands, just use archive.
-            logger.info('Getting commands from archive only')
+            logger.info("Getting commands from archive only")
             cmds = IDX_CMDS
-        elif start < CxoTime(cmds_recent['date'][0]) + 3 * u.day:
+        elif start < CxoTime(cmds_recent["date"][0]) + 3 * u.day:
             # Query starts near beginning of recent commands and *might* need some
             # archive commands. The margin is set at 3 days to ensure that OBS
             # command continuity is maintained (there is at least one maneuver).
             cmds = _merge_cmds_archive_recent(start, scenario)
-            logger.info(f'Getting commands from archive + recent {scenario=}')
+            logger.info(f"Getting commands from archive + recent {scenario=}")
         else:
             # Query is strictly within recent commands.
             cmds = cmds_recent
-            logger.info(f'Getting commands from recent only {scenario=}')
+            logger.info(f"Getting commands from recent only {scenario=}")
 
     # Select the requested time range and make a copy. (Slicing is a view so
     # in theory bad things could happen without a copy).
     idx0 = cmds.find_date(start)
-    idx1 = cmds.find_date(stop, side=('right' if inclusive_stop else 'left'))
+    idx1 = cmds.find_date(stop, side=("right" if inclusive_stop else "left"))
     cmds = cmds[idx0:idx1].copy()
 
     if kwargs:
@@ -251,20 +270,26 @@ def get_cmds(start=None, stop=None, inclusive_stop=False, scenario=None, **kwarg
         # pars_dict for the matching search keys.
         # TODO: this step is only really required for kwargs that are not a column,
         # i.e. keys that are found only in params.
-        for ii in np.flatnonzero(cmds['idx'] == -1):
-            cmds[ii]['idx'] = get_par_idx_update_pars_dict(pars_dict, cmds[ii])
+        for ii in np.flatnonzero(cmds["idx"] == -1):
+            cmds[ii]["idx"] = get_par_idx_update_pars_dict(pars_dict, cmds[ii])
         cmds = _find(idx_cmds=cmds, pars_dict=pars_dict, **kwargs)
 
     cmds.rev_pars_dict = weakref.ref(REV_PARS_DICT)
 
-    cmds['time'].info.format = '.3f'
+    cmds["time"].info.format = ".3f"
 
     return cmds
 
 
-def update_archive_and_get_cmds_recent(scenario=None, *, lookback=None, stop=None,
-                                       cache=True,
-                                       pars_dict=None, rev_pars_dict=None):
+def update_archive_and_get_cmds_recent(
+    scenario=None,
+    *,
+    lookback=None,
+    stop=None,
+    cache=True,
+    pars_dict=None,
+    rev_pars_dict=None,
+):
     """Update local loads table and downloaded loads and return all recent cmds.
 
     This also caches the recent commands in the global CMDS_RECENT dict.
@@ -290,13 +315,12 @@ def update_archive_and_get_cmds_recent(scenario=None, *, lookback=None, stop=Non
     cmd_events = update_cmd_events(scenario)
 
     # Update loads table and download/archive backstop files from OCCweb
-    loads = update_loads(scenario, cmd_events=cmd_events,
-                         lookback=lookback, stop=stop)
+    loads = update_loads(scenario, cmd_events=cmd_events, lookback=lookback, stop=stop)
     logger.info(f'Including loads {", ".join(loads["name"])}')
 
     for load in loads:
-        loads_backstop_path = paths.LOADS_BACKSTOP_PATH(load['name'])
-        with gzip.open(loads_backstop_path, 'rb') as fh:
+        loads_backstop_path = paths.LOADS_BACKSTOP_PATH(load["name"])
+        with gzip.open(loads_backstop_path, "rb") as fh:
             cmds = pickle.load(fh)
 
         # Apply load interrupts (SCS-107, NSM) from the loads table to this
@@ -307,30 +331,28 @@ def update_archive_and_get_cmds_recent(scenario=None, *, lookback=None, stop=Non
         if len(cmds) > 0:
             logger.info(f'Load {load["name"]} has {len(cmds)} commands')
             cmds_list.append(cmds)
-            rltts.append(load['rltt'])
+            rltts.append(load["rltt"])
         else:
             logger.info(f'Load {load["name"]} has no commands, skipping')
 
     # Filter events outside the time interval, assuming command event cannot
     # last more than 2 weeks.
-    start = CxoTime(min(loads['cmd_start']))
-    stop = CxoTime(max(loads['cmd_stop']))
+    start = CxoTime(min(loads["cmd_start"]))
+    stop = CxoTime(max(loads["cmd_stop"]))
     # Allow for variations in input format of date
-    dates = np.array([CxoTime(date).date for date in cmd_events['Date']])
-    bad = ((dates < (start - 14 * u.day).date)
-           | (dates > stop.date))
+    dates = np.array([CxoTime(date).date for date in cmd_events["Date"]])
+    bad = (dates < (start - 14 * u.day).date) | (dates > stop.date)
     cmd_events = cmd_events[~bad]
-    cmd_events_ids = [evt['Event'] + ' at ' + evt['Date'] for evt in cmd_events]
+    cmd_events_ids = [evt["Event"] + " at " + evt["Date"] for evt in cmd_events]
     if len(cmd_events) > 0:
-        logger.info('Including cmd_events:\n  {}'.format("\n  ".join(cmd_events_ids)))
+        logger.info("Including cmd_events:\n  {}".format("\n  ".join(cmd_events_ids)))
     else:
-        logger.info('No cmd_events to include')
+        logger.info("No cmd_events to include")
 
     for cmd_event in cmd_events:
         cmds = get_cmds_from_event(
-            cmd_event['Date'],
-            cmd_event['Event'],
-            cmd_event['Params'])
+            cmd_event["Date"], cmd_event["Event"], cmd_event["Params"]
+        )
 
         # Events that do not generate commands (e.g. load interrupt) return
         # None from get_cmds_from_event.
@@ -339,7 +361,7 @@ def update_archive_and_get_cmds_recent(scenario=None, *, lookback=None, stop=Non
             rltts.append(None)
 
     # Sort cmds_list and rltts by the date of the first cmd in each cmds Table
-    cmds_starts = np.array([cmds['date'][0] for cmds in cmds_list])
+    cmds_starts = np.array([cmds["date"][0] for cmds in cmds_list])
     idx_sort = np.argsort(cmds_starts)
     cmds_list = [cmds_list[ii] for ii in idx_sort]
     rltts = [rltts[ii] for ii in idx_sort]
@@ -352,15 +374,17 @@ def update_archive_and_get_cmds_recent(scenario=None, *, lookback=None, stop=Non
             for jj in range(0, ii):
                 prev_cmds = cmds_list[jj]
                 # First check for any overlap since prev_cmds is sorted by date.
-                if prev_cmds['date'][-1] > rltt:
+                if prev_cmds["date"][-1] > rltt:
                     # Cut commands EXCEPT for ORBPOINT ones, which we leave as a
                     # special case to ensure availability of orbit events from
                     # commands. Otherwise RLTT can cut ORBPOINT commands that
                     # are not replaced by the subsquent loads.
-                    bad = (prev_cmds['date'] > rltt) & (prev_cmds['type'] != 'ORBPOINT')
+                    bad = (prev_cmds["date"] > rltt) & (prev_cmds["type"] != "ORBPOINT")
                     if np.any(bad):
                         n_bad = np.count_nonzero(bad)
-                        logger.info(f'Removing {n_bad} cmds from {prev_cmds["source"][0]}')
+                        logger.info(
+                            f'Removing {n_bad} cmds from {prev_cmds["source"][0]}'
+                        )
                     cmds_list[jj] = prev_cmds[~bad]
 
         if len(cmds) > 0:
@@ -402,7 +426,7 @@ def add_obs_cmds(cmds, pars_dict, rev_pars_dict, prev_att=None):
     """
     # Last command in cmds is the schedule stop time (i.e. obs_stop for the
     # last observation).
-    schedule_stop_time = cmds['date'][-1]
+    schedule_stop_time = cmds["date"][-1]
 
     # Get the subset of commands needed to determine the state for OBS cmds like
     # maneuver commanding, obsid, starcat, etc.
@@ -418,8 +442,9 @@ def add_obs_cmds(cmds, pars_dict, rev_pars_dict, prev_att=None):
     # start of the obs). This returns just the obs commands and updates
     # `pars_dict` and `rev_pars_dict` in place.
     cmds_state_obs = cmds_state.add_cmds(cmds_obs)
-    cmds_obs = get_cmds_obs_final(cmds_state_obs, pars_dict, rev_pars_dict,
-                                  schedule_stop_time)
+    cmds_obs = get_cmds_obs_final(
+        cmds_state_obs, pars_dict, rev_pars_dict, schedule_stop_time
+    )
 
     # Finally add the OBS cmds to the recent cmds table.
     cmds_out = cmds.add_cmds(cmds_obs)
@@ -433,21 +458,22 @@ def get_state_cmds(cmds):
     :returns: CommandTable of state-changing commands.
     """
     state_tlmsids = [
-        'AOSTRCAT',
-        'COAOSQID',
-        'AOMANUVR',
-        'AONMMODE',
-        'AONSMSAF',
-        'AOUPTARQ',
-        'AONM2NPE',
-        'AONM2NPD']
+        "AOSTRCAT",
+        "COAOSQID",
+        "AOMANUVR",
+        "AONMMODE",
+        "AONSMSAF",
+        "AOUPTARQ",
+        "AONM2NPE",
+        "AONM2NPD",
+    ]
 
-    if cmds['tlmsid'].dtype.kind == 'S':
-        vals = [val.encode('ascii') for val in state_tlmsids]
-    ok = np.isin(cmds['tlmsid'], vals)
-    ok |= cmds['type'] == 'SIMTRANS'
+    if cmds["tlmsid"].dtype.kind == "S":
+        vals = [val.encode("ascii") for val in state_tlmsids]
+    ok = np.isin(cmds["tlmsid"], vals)
+    ok |= cmds["type"] == "SIMTRANS"
     cmds = cmds[ok]
-    cmds.sort(['date', 'scs', 'tlmsid'])
+    cmds.sort(["date", "scs", "tlmsid"])
 
     # Note about sorting by 'tlmsid': this relates to an issue where the obsid
     # command COAOSQID is at exactly the same time as the AONMMODE commands
@@ -485,20 +511,22 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
     npnt_enab = False
 
     cmds_obs = []
-    times = CxoTime(cmds['date']).secs
+    times = CxoTime(cmds["date"]).secs
 
     for time, cmd in zip(times, cmds):
-        tlmsid = cmd['tlmsid']
-        if tlmsid == 'AOUPTARQ':
-            pars = cmd['params']
-            targ_att = (pars['q1'], pars['q2'], pars['q3'], pars['q4'])
-        elif tlmsid == 'AONM2NPE':
+        tlmsid = cmd["tlmsid"]
+        if tlmsid == "AOUPTARQ":
+            pars = cmd["params"]
+            targ_att = (pars["q1"], pars["q2"], pars["q3"], pars["q4"])
+        elif tlmsid == "AONM2NPE":
             npnt_enab = True
-        elif tlmsid == 'AONM2NPD':
+        elif tlmsid == "AONM2NPD":
             npnt_enab = False
-        elif tlmsid in ('AOMANUVR', 'AONSMSAF'):
-            if tlmsid == 'AONSMSAF':
-                targ_att = tuple(NSM_attitude(prev_att or (0, 0, 0, 1), cmd['date']).q.tolist())
+        elif tlmsid in ("AOMANUVR", "AONSMSAF"):
+            if tlmsid == "AONSMSAF":
+                targ_att = tuple(
+                    NSM_attitude(prev_att or (0, 0, 0, 1), cmd["date"]).q.tolist()
+                )
                 npnt_enab = False
             if targ_att is None:
                 # No target attitude is unexpected since we got to a MANVR cmd.
@@ -515,40 +543,45 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
                 prev_att = targ_att
                 continue
             dur = manvr_duration(prev_att, targ_att)
-            params = {'manvr_start': cmd['date'],
-                      'prev_att': prev_att,
-                      'targ_att': targ_att,
-                      'npnt_enab': npnt_enab}
-            cmd_obs = {'idx': -1,
-                       'type': 'LOAD_EVENT',
-                       'tlmsid': 'OBS',
-                       'scs': 0,
-                       'step': 0,
-                       'source': cmd['source'],
-                       'vcdu': -1,
-                       'time': time + dur,
-                       'params': params,
-                       }
+            params = {
+                "manvr_start": cmd["date"],
+                "prev_att": prev_att,
+                "targ_att": targ_att,
+                "npnt_enab": npnt_enab,
+            }
+            cmd_obs = {
+                "idx": -1,
+                "type": "LOAD_EVENT",
+                "tlmsid": "OBS",
+                "scs": 0,
+                "step": 0,
+                "source": cmd["source"],
+                "vcdu": -1,
+                "time": time + dur,
+                "params": params,
+            }
             cmds_obs.append(cmd_obs)
             prev_att = targ_att
             targ_att = None
 
     cmds_obs = CommandTable(rows=cmds_obs)
     # NB: much faster to do this vectorized than when defining cmd_obs above.
-    cmds_obs.add_column(CxoTime(cmds_obs['time']).date, name='date', index=0)
+    cmds_obs.add_column(CxoTime(cmds_obs["time"]).date, name="date", index=0)
 
     # If an NSM occurs within a maneuver then remove that obs
-    nsms = cmds['tlmsid'] == 'AONSMSAF'
+    nsms = cmds["tlmsid"] == "AONSMSAF"
     if np.any(nsms):
         bad_idxs = []
-        for nsm_date in cmds['date'][nsms]:
+        for nsm_date in cmds["date"][nsms]:
             for ii, cmd in enumerate(cmds_obs):
-                if nsm_date > cmd['params']['manvr_start'] and nsm_date <= cmd['date']:
-                    logger.info(f'NSM at {nsm_date} happened during maneuver preceding obs\n{cmd}')
+                if nsm_date > cmd["params"]["manvr_start"] and nsm_date <= cmd["date"]:
+                    logger.info(
+                        f"NSM at {nsm_date} happened during maneuver preceding obs\n{cmd}"
+                    )
                     log_context_obs(cmds, cmd)
                     bad_idxs.append(ii)
         if bad_idxs:
-            logger.info(f'Removing obss at {bad_idxs}')
+            logger.info(f"Removing obss at {bad_idxs}")
             cmds_obs.remove_rows(bad_idxs)
 
     # This is known to happen for cmds in AUG0103A, JAN2204B, JUL2604D due to
@@ -556,11 +589,11 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
     # migration script to see. The prev_att is wrong and the incorrect maneuver
     # timing results in overlaps. It should not happen for modern loads.
     for cmd0, cmd1 in zip(cmds_obs[:-1], cmds_obs[1:]):
-        if cmd1['params']['manvr_start'] <= cmd0['date'] < cmd1['date']:
-            logger.warning(f'WARNING: fixing overlapping OBS cmds: \n{cmd0} \n{cmd1}')
-            date0 = CxoTime(cmd1['params']['manvr_start']) - 15 * u.s
-            cmd0['date'] = date0.date
-            cmd0['time'] = date0.secs
+        if cmd1["params"]["manvr_start"] <= cmd0["date"] < cmd1["date"]:
+            logger.warning(f"WARNING: fixing overlapping OBS cmds: \n{cmd0} \n{cmd1}")
+            date0 = CxoTime(cmd1["params"]["manvr_start"]) - 15 * u.s
+            cmd0["date"] = date0.date
+            cmd0["time"] = date0.secs
 
     return cmds_obs
 
@@ -582,24 +615,24 @@ def manvr_duration(q1, q2):
     :returns: duration of maneuver in seconds
     """
     # Compute 4th element of delta quaternion q_manvr = q2 / q1
-    q_manvr_3 = abs(-q2[0] * q1[0]
-                    - q2[1] * q1[1]
-                    - q2[2] * q1[2]
-                    + q2[3] * -q1[3])
+    q_manvr_3 = abs(-q2[0] * q1[0] - q2[1] * q1[1] - q2[2] * q1[2] + q2[3] * -q1[3])
 
     # 4th component is cos(theta/2)
-    if (q_manvr_3 > 1):
+    if q_manvr_3 > 1:
         q_manvr_3 = 1
     phimax = 2 * math.acos(q_manvr_3)
 
     epsmax = MANVR_VMAX / MANVR_ALPHAMAX - MANVR_DELTA
     tau = phimax / MANVR_VMAX - epsmax - 2 * MANVR_DELTA
-    if (tau >= 0):
+    if tau >= 0:
         eps = epsmax
     else:
         tau = 0
-        eps = np.sqrt(MANVR_DELTA ** 2 + 4 * phimax / MANVR_ALPHAMAX) / 2 - 1.5 * MANVR_DELTA
-        if (eps < 0):
+        eps = (
+            np.sqrt(MANVR_DELTA**2 + 4 * phimax / MANVR_ALPHAMAX) / 2
+            - 1.5 * MANVR_DELTA
+        )
+        if eps < 0:
             eps = 0
 
     Tm = 4 * MANVR_DELTA + 2 * eps + tau
@@ -634,52 +667,55 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     cmd_obs_extras = []
 
     for cmd in cmds:
-        tlmsid = cmd['tlmsid']
-        if tlmsid == 'AOSTRCAT':
-            starcat_date = cmd['date']
-            if cmd['idx'] == -1:
+        tlmsid = cmd["tlmsid"]
+        if tlmsid == "AOSTRCAT":
+            starcat_date = cmd["date"]
+            if cmd["idx"] == -1:
                 # OBS command only stores the index of the starcat params, so at
                 # this point we need to put those params into the pars_dict and
                 # rev_pars_dict and get the index.
                 starcat_idx = get_par_idx_update_pars_dict(
-                    pars_dict, cmd, rev_pars_dict=rev_pars_dict)
+                    pars_dict, cmd, rev_pars_dict=rev_pars_dict
+                )
             else:
-                starcat_idx = cmd['idx']
-        elif tlmsid == 'COAOSQID':
-            obsid = cmd['params']['id']
+                starcat_idx = cmd["idx"]
+        elif tlmsid == "COAOSQID":
+            obsid = cmd["params"]["id"]
             # Look for obsid change within obs, likely an undercover
             # (target="cold blank ECS"). First stop the initial obs at the time
             # of the obsid command.
             if obs_params is not None:
-                obs_params['obs_stop'] = cmd['date']
+                obs_params["obs_stop"] = cmd["date"]
                 # Then start a new obs at the time of the next obsid command.
                 obs_params = obs_params.copy()
-                obs_params['obsid'] = obsid
-                obs_params['obs_start'] = cmd['date']
+                obs_params["obsid"] = obsid
+                obs_params["obs_start"] = cmd["date"]
                 # Collect these extra obs to a list to be added to cmds table later.
-                cmd_obs = {'idx': -1,
-                           'date': cmd['date'],
-                           'type': 'LOAD_EVENT',
-                           'tlmsid': 'OBS',
-                           'scs': 0,
-                           'step': 0,
-                           'time': CxoTime(cmd['date']).secs,
-                           'source': cmd['source'],
-                           'vcdu': -1,
-                           'params': obs_params,
-                           }
+                cmd_obs = {
+                    "idx": -1,
+                    "date": cmd["date"],
+                    "type": "LOAD_EVENT",
+                    "tlmsid": "OBS",
+                    "scs": 0,
+                    "step": 0,
+                    "time": CxoTime(cmd["date"]).secs,
+                    "source": cmd["source"],
+                    "vcdu": -1,
+                    "params": obs_params,
+                }
                 cmd_obs_extras.append(cmd_obs)
-        elif tlmsid == 'OBS':
-            obs_params = cmd['params']
-            obs_params['obsid'] = obsid
-            obs_params['simpos'] = sim_pos  # matches states 'simpos'
-            obs_params['obs_start'] = cmd['date']
-            if obs_params['npnt_enab']:
-                obs_params['starcat_idx'] = starcat_idx
-                obs_params['starcat_date'] = starcat_date
+        elif tlmsid == "OBS":
+            obs_params = cmd["params"]
+            obs_params["obsid"] = obsid
+            obs_params["simpos"] = sim_pos  # matches states 'simpos'
+            obs_params["obs_start"] = cmd["date"]
+            if obs_params["npnt_enab"]:
+                obs_params["starcat_idx"] = starcat_idx
+                obs_params["starcat_date"] = starcat_date
 
-        elif (tlmsid in ('AONMMODE', 'AONSMSAF')
-              or (tlmsid == 'AONM2NPE' and cmd['vcdu'] == -1)):
+        elif tlmsid in ("AONMMODE", "AONSMSAF") or (
+            tlmsid == "AONM2NPE" and cmd["vcdu"] == -1
+        ):
             # Stop current obs at next maneuver. In some v1 commands (for
             # migration) there are cases of non-load maneuvers without an
             # AONMMODE command and only the AONM2NPE and AOMANUVR commands.
@@ -687,14 +723,14 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
             # is OK since AONM2NPE always comes after the AONMMODE command and
             # obs_params will be None at that point.
             if obs_params is not None:
-                obs_params['obs_stop'] = cmd['date']
+                obs_params["obs_stop"] = cmd["date"]
             # This closes out the observation
             obs_params = None
-        elif cmd['type'] == 'SIMTRANS':
-            sim_pos = cmd['params']['pos']
+        elif cmd["type"] == "SIMTRANS":
+            sim_pos = cmd["params"]["pos"]
 
     # Filter down to just the observation commands
-    cmds_obs = cmds[cmds['tlmsid'] == 'OBS']
+    cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
 
     # Potentially add extra obs commands (typically undercovers) to cmds table
     if cmd_obs_extras:
@@ -704,23 +740,24 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     # subsequent maneuver. Fix that for the expected case but warn if an obs
     # before the end is missing obs_stop.
     for cmd in cmds_obs:
-        if 'obs_stop' not in cmd['params']:
-            cmd['params']['obs_stop'] = schedule_stop_time
+        if "obs_stop" not in cmd["params"]:
+            cmd["params"]["obs_stop"] = schedule_stop_time
             if cmd.index != len(cmds_obs) - 1:
-                logger.warning(f'OBS command missing obs_stop\n{cmd}')
+                logger.warning(f"OBS command missing obs_stop\n{cmd}")
                 log_context_obs(cmds, cmd)
-        cmd['idx'] = get_par_idx_update_pars_dict(
-            pars_dict, cmd, rev_pars_dict=rev_pars_dict)
+        cmd["idx"] = get_par_idx_update_pars_dict(
+            pars_dict, cmd, rev_pars_dict=rev_pars_dict
+        )
 
     return cmds_obs
 
 
 def log_context_obs(cmds, cmd, before=3600, after=3600):
     """Log commands before and after ``cmd``"""
-    date_before = (CxoTime(cmd['date']) - before * u.s).date
-    date_after = (CxoTime(cmd['date']) + after * u.s).date
-    ok = (cmds['date'] >= date_before) & (cmds['date'] <= date_after)
-    logger.warning(f'\n{cmds[ok]}')
+    date_before = (CxoTime(cmd["date"]) - before * u.s).date
+    date_after = (CxoTime(cmd["date"]) + after * u.s).date
+    ok = (cmds["date"] >= date_before) & (cmds["date"] <= date_after)
+    logger.warning(f"\n{cmds[ok]}")
 
 
 def is_google_id(scenario):
@@ -743,7 +780,7 @@ def update_cmd_events(scenario=None):
     """
     # Named scenarios with a name that isn't "flight" and does not look like a
     # google sheet ID are local files.
-    use_local = scenario not in (None, 'flight') and not is_google_id(scenario)
+    use_local = scenario not in (None, "flight") and not is_google_id(scenario)
     if use_local or not HAS_INTERNET:
         return get_cmd_events(scenario)
 
@@ -754,17 +791,17 @@ def update_cmd_events(scenario=None):
 
     doc_id = scenario if is_google_id(scenario) else conf.cmd_events_flight_id
     url = CMD_EVENTS_SHEET_URL.format(doc_id=doc_id)
-    logger.info(f'Getting cmd_events from {url}')
+    logger.info(f"Getting cmd_events from {url}")
     req = requests.get(url, timeout=30)
     if req.status_code != 200:
-        raise ValueError(f'Failed to get cmd events sheet: {req.status_code}')
+        raise ValueError(f"Failed to get cmd events sheet: {req.status_code}")
 
-    cmd_events = Table.read(req.text, format='csv')
-    ok = np.isin(cmd_events['State'], ('Predictive', 'Definitive'))
+    cmd_events = Table.read(req.text, format="csv")
+    ok = np.isin(cmd_events["State"], ("Predictive", "Definitive"))
     cmd_events = cmd_events[ok]
 
-    logger.info(f'Writing {len(cmd_events)} cmd_events to {cmd_events_path}')
-    cmd_events.write(cmd_events_path, format='csv', overwrite=True)
+    logger.info(f"Writing {len(cmd_events)} cmd_events to {cmd_events_path}")
+    cmd_events.write(cmd_events_path, format="csv", overwrite=True)
     return cmd_events
 
 
@@ -777,15 +814,15 @@ def get_cmd_events(scenario=None):
         Command events table
     """
     cmd_events_path = paths.CMD_EVENTS_PATH(scenario)
-    logger.info(f'Reading command events {cmd_events_path}')
-    cmd_events = Table.read(str(cmd_events_path), format='csv', fill_values=[])
+    logger.info(f"Reading command events {cmd_events_path}")
+    cmd_events = Table.read(str(cmd_events_path), format="csv", fill_values=[])
     return cmd_events
 
 
 def get_loads(scenario=None):
     loads_path = paths.LOADS_TABLE_PATH(scenario)
-    logger.info(f'Reading loads file {loads_path}')
-    loads = Table.read(str(loads_path), format='csv')
+    logger.info(f"Reading loads file {loads_path}")
+    loads = Table.read(str(loads_path), format="csv")
     return loads
 
 
@@ -803,7 +840,7 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
     """
     # For testing allow override of default `stop` value
     if stop is None:
-        stop = os.environ.get('KADI_COMMANDS_DEFAULT_STOP')
+        stop = os.environ.get("KADI_COMMANDS_DEFAULT_STOP")
 
     if lookback is None:
         lookback = conf.default_lookback
@@ -856,8 +893,8 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
         try:
             contents = occweb.get_occweb_dir(dir_year_month)
         except requests.exceptions.HTTPError as exc:
-            if str(exc).startswith('404'):
-                logger.debug(f'No OCCweb directory for {dir_year_month}')
+            if str(exc).startswith("404"):
+                logger.debug(f"No OCCweb directory for {dir_year_month}")
                 continue
             else:
                 raise
@@ -868,12 +905,14 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
         #   pickle file
         # - Add the load to the table
         for content in contents:
-            if re.match(r'[A-Z]{3}\d{4}[A-Z]/', content['Name']):
-                load_name = content['Name'][:8]  # chop the /
+            if re.match(r"[A-Z]{3}\d{4}[A-Z]/", content["Name"]):
+                load_name = content["Name"][:8]  # chop the /
                 load_date = load_name_to_cxotime(load_name)
                 if load_date < RLTT_ERA_START:
-                    logger.warning(f'Skipping {load_name} which is before '
-                                   f'{RLTT_ERA_START} start of RLTT era')
+                    logger.warning(
+                        f"Skipping {load_name} which is before "
+                        f"{RLTT_ERA_START} start of RLTT era"
+                    )
                     continue
                 if load_date >= start and load_date <= stop:
                     cmds = get_load_cmds_from_occweb_or_local(dir_year_month, load_name)
@@ -881,15 +920,16 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
                     loads_rows.append(load)
 
     if not loads_rows:
-        raise ValueError(f'No loads found in {lookback} days')
+        raise ValueError(f"No loads found in {lookback} days")
 
     # Finally, save the table to file
     loads_table = Table(loads_rows)
-    logger.info(f'Saving {len(loads_table)} loads to {loads_table_path}')
-    loads_table.sort('cmd_start')
-    loads_table.write(loads_table_path, format='csv', overwrite=True)
-    loads_table.write(loads_table_path.with_suffix('.dat'), format='ascii.fixed_width',
-                      overwrite=True)
+    logger.info(f"Saving {len(loads_table)} loads to {loads_table_path}")
+    loads_table.sort("cmd_start")
+    loads_table.write(loads_table_path, format="csv", overwrite=True)
+    loads_table.write(
+        loads_table_path.with_suffix(".dat"), format="ascii.fixed_width", overwrite=True
+    )
 
     if conf.clean_loads_dir:
         clean_loads_dir(loads_table)
@@ -899,56 +939,72 @@ def update_loads(scenario=None, *, cmd_events=None, lookback=None, stop=None):
 
 def clean_loads_dir(loads):
     """Remove load-like files from loads directory if not in ``loads``"""
-    for file in Path(paths.LOADS_ARCHIVE_DIR()).glob('*.pkl.gz'):
-        if (re.match(r'[A-Z]{3}\d{4}[A-Z]\.pkl\.gz', file.name)
-                and file.name[:8] not in loads['name']):
-            logger.info(f'Removing load file {file}')
+    for file in Path(paths.LOADS_ARCHIVE_DIR()).glob("*.pkl.gz"):
+        if (
+            re.match(r"[A-Z]{3}\d{4}[A-Z]\.pkl\.gz", file.name)
+            and file.name[:8] not in loads["name"]
+        ):
+            logger.info(f"Removing load file {file}")
             file.unlink()
 
 
 def get_load_dict_from_cmds(load_name, cmds, cmd_events):
-    """Update ``load`` dict in place from the backstop commands.
-    """
-    vehicle_stop_events = ('NSM', 'Safe mode', 'Bright star hold')
-    observing_stop_events = vehicle_stop_events + ('SCS-107',)
+    """Update ``load`` dict in place from the backstop commands."""
+    vehicle_stop_events = ("NSM", "Safe mode", "Bright star hold")
+    observing_stop_events = vehicle_stop_events + ("SCS-107",)
 
-    load = {'name': load_name,
-            'cmd_start': cmds['date'][0],
-            'cmd_stop': cmds['date'][-1],
-            'observing_stop': '',
-            'vehicle_stop': ''}
+    load = {
+        "name": load_name,
+        "cmd_start": cmds["date"][0],
+        "cmd_stop": cmds["date"][-1],
+        "observing_stop": "",
+        "vehicle_stop": "",
+    }
 
-    load['rltt'] = cmds.get_rltt()
-    load['scheduled_stop_time'] = cmds.get_scheduled_stop_time()
+    load["rltt"] = cmds.get_rltt()
+    load["scheduled_stop_time"] = cmds.get_scheduled_stop_time()
 
     # CHANGE THIS to use LOAD_EVENT entries in commands. Or NOT?? Probably
     # provides good visibility into what's going on. But this hard-coding is
     # annoying.
     for cmd_event in cmd_events:
-        cmd_event_date = cmd_event['Date']
+        cmd_event_date = cmd_event["Date"]
 
-        if (cmd_event_date >= load['cmd_start']
-                and cmd_event_date <= load['cmd_stop']
-                and cmd_event['Event'] in observing_stop_events):
-            logger.info(f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}')
-            load['observing_stop'] = cmd_event['Date']
+        if (
+            cmd_event_date >= load["cmd_start"]
+            and cmd_event_date <= load["cmd_stop"]
+            and cmd_event["Event"] in observing_stop_events
+        ):
+            logger.info(
+                f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}'
+            )
+            load["observing_stop"] = cmd_event["Date"]
 
-            if cmd_event['Event'] in vehicle_stop_events:
-                load['vehicle_stop'] = cmd_event['Date']
+            if cmd_event["Event"] in vehicle_stop_events:
+                load["vehicle_stop"] = cmd_event["Date"]
 
-        if cmd_event['Event'] == 'Load not run' and cmd_event['Params'] == load_name:
-            logger.info(f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}')
-            load['observing_stop'] = '1998:001'
-            load['vehicle_stop'] = '1998:001'
+        if cmd_event["Event"] == "Load not run" and cmd_event["Params"] == load_name:
+            logger.info(
+                f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}'
+            )
+            load["observing_stop"] = "1998:001"
+            load["vehicle_stop"] = "1998:001"
 
-        if cmd_event['Event'] == 'Observing not run' and cmd_event['Params'] == load_name:
-            logger.info(f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}')
-            load['observing_stop'] = '1998:001'
+        if (
+            cmd_event["Event"] == "Observing not run"
+            and cmd_event["Params"] == load_name
+        ):
+            logger.info(
+                f'{cmd_event["Event"]} at {cmd_event_date} found for {load_name}'
+            )
+            load["observing_stop"] = "1998:001"
 
     return load
 
 
-def get_load_cmds_from_occweb_or_local(dir_year_month=None, load_name=None, use_ska_dir=False):
+def get_load_cmds_from_occweb_or_local(
+    dir_year_month=None, load_name=None, use_ska_dir=False
+):
     """Get the load cmds (backstop) for ``load_name`` within ``dir_year_month``
 
     If the backstop file is already available locally, use that. Otherwise, the
@@ -965,38 +1021,41 @@ def get_load_cmds_from_occweb_or_local(dir_year_month=None, load_name=None, use_
     # Determine output file name and make directory if necessary.
     loads_dir = paths.LOADS_ARCHIVE_DIR()
     loads_dir.mkdir(parents=True, exist_ok=True)
-    cmds_filename = loads_dir / f'{load_name}.pkl.gz'
+    cmds_filename = loads_dir / f"{load_name}.pkl.gz"
 
     # If the output file already exists, read the commands and return them.
     if cmds_filename.exists():
-        logger.info(f'Already have {cmds_filename}')
-        with gzip.open(cmds_filename, 'rb') as fh:
+        logger.info(f"Already have {cmds_filename}")
+        with gzip.open(cmds_filename, "rb") as fh:
             cmds = pickle.load(fh)
         return cmds
 
     if use_ska_dir:
         ska_dir = ska_load_dir(load_name)
-        for filename in ska_dir.glob('CR????????.backstop'):
+        for filename in ska_dir.glob("CR????????.backstop"):
             backstop_text = filename.read_text()
-            logger.info(f'Got backstop from {filename}')
+            logger.info(f"Got backstop from {filename}")
             cmds = parse_backstop_and_write(load_name, cmds_filename, backstop_text)
             break
         else:
-            raise ValueError(f'No backstop file found in {ska_dir}')
+            raise ValueError(f"No backstop file found in {ska_dir}")
 
     else:  # use OCCweb
         load_dir_contents = occweb.get_occweb_dir(dir_year_month / load_name)
-        for filename in load_dir_contents['Name']:
-            if re.match(r'CR\d{3}.\d{4}\.backstop', filename):
+        for filename in load_dir_contents["Name"]:
+            if re.match(r"CR\d{3}.\d{4}\.backstop", filename):
 
                 # Download the backstop file from OCCweb
                 backstop_text = occweb.get_occweb_page(
                     dir_year_month / load_name / filename,
-                    cache=conf.cache_loads_in_astropy_cache)
+                    cache=conf.cache_loads_in_astropy_cache,
+                )
                 cmds = parse_backstop_and_write(load_name, cmds_filename, backstop_text)
                 break
         else:
-            raise ValueError(f'Could not find backstop file in {dir_year_month / load_name}')
+            raise ValueError(
+                f"Could not find backstop file in {dir_year_month / load_name}"
+            )
 
     return cmds
 
@@ -1011,18 +1070,25 @@ def parse_backstop_and_write(load_name, cmds_filename, backstop_text):
     cmds = get_cmds_from_backstop(backstop_lines)
 
     # Fix up the commands to be in the right format
-    idx = cmds.colnames.index('timeline_id')
-    cmds.add_column(load_name, index=idx, name='source')
-    del cmds['timeline_id']
+    idx = cmds.colnames.index("timeline_id")
+    cmds.add_column(load_name, index=idx, name="source")
+    del cmds["timeline_id"]
 
-    logger.info(f'Saving {cmds_filename}')
-    with gzip.open(cmds_filename, 'wb') as fh:
+    logger.info(f"Saving {cmds_filename}")
+    with gzip.open(cmds_filename, "wb") as fh:
         pickle.dump(cmds, fh)
     return cmds
 
 
-def update_cmds_archive(*, lookback=None, stop=None, log_level=logging.INFO,
-                        scenario=None, data_root='.', match_prev_cmds=True):
+def update_cmds_archive(
+    *,
+    lookback=None,
+    stop=None,
+    log_level=logging.INFO,
+    scenario=None,
+    data_root=".",
+    match_prev_cmds=True,
+):
     """Update cmds2.h5 and cmds2.pkl archive files.
 
     This updates the archive though ``stop`` date, where is required that the
@@ -1046,12 +1112,12 @@ def update_cmds_archive(*, lookback=None, stop=None, log_level=logging.INFO,
     """
     # For testing allow override of default `stop` value
     if stop is None:
-        stop = os.environ.get('KADI_COMMANDS_DEFAULT_STOP')
+        stop = os.environ.get("KADI_COMMANDS_DEFAULT_STOP")
 
     # Local context manager for log_level and data_root
-    kadi_logger = logging.getLogger('kadi')
+    kadi_logger = logging.getLogger("kadi")
     log_level_orig = kadi_logger.level
-    with conf.set_temp('commands_dir', data_root):
+    with conf.set_temp("commands_dir", data_root):
         try:
             kadi_logger.setLevel(log_level)
             _update_cmds_archive(lookback, stop, match_prev_cmds, scenario, data_root)
@@ -1061,23 +1127,29 @@ def update_cmds_archive(*, lookback=None, stop=None, log_level=logging.INFO,
 
 def _update_cmds_archive(lookback, stop, match_prev_cmds, scenario, data_root):
     """Do the real work of updating the cmds archive"""
-    idx_cmds_path = Path(data_root) / 'cmds2.h5'
-    pars_dict_path = Path(data_root) / 'cmds2.pkl'
+    idx_cmds_path = Path(data_root) / "cmds2.h5"
+    pars_dict_path = Path(data_root) / "cmds2.pkl"
 
     if idx_cmds_path.exists():
         cmds_arch = load_idx_cmds(version=2, file=idx_cmds_path)
         pars_dict = load_pars_dict(version=2, file=pars_dict_path)
     else:
         # Make an empty cmds archive table and pars dict
-        cmds_arch = CommandTable(names=list(CommandTable.COL_TYPES),
-                                 dtype=list(CommandTable.COL_TYPES.values()))
-        del cmds_arch['timeline_id']
+        cmds_arch = CommandTable(
+            names=list(CommandTable.COL_TYPES),
+            dtype=list(CommandTable.COL_TYPES.values()),
+        )
+        del cmds_arch["timeline_id"]
         pars_dict = {}
         match_prev_cmds = False  # No matching of previous commands
 
     cmds_recent = update_archive_and_get_cmds_recent(
-        scenario=scenario, stop=stop, lookback=lookback, cache=False,
-        pars_dict=pars_dict)
+        scenario=scenario,
+        stop=stop,
+        lookback=lookback,
+        cache=False,
+        pars_dict=pars_dict,
+    )
 
     if match_prev_cmds:
         idx0_arch, idx0_recent = get_matching_block_idx(cmds_arch, cmds_recent)
@@ -1087,69 +1159,80 @@ def _update_cmds_archive(lookback, stop, match_prev_cmds, scenario, data_root):
 
     # Convert from `params` col of dicts to index into same params in pars_dict.
     for cmd in cmds_recent:
-        cmd['idx'] = get_par_idx_update_pars_dict(pars_dict, cmd)
+        cmd["idx"] = get_par_idx_update_pars_dict(pars_dict, cmd)
 
     # If the length of the updated table will be the same as the existing table.
     # For the command below the no-op logic should be clear:
     # cmds_arch = vstack([cmds_arch[:idx0_arch], cmds_recent[idx0_recent:]])
     if idx0_arch == len(cmds_arch) and idx0_recent == len(cmds_recent):
-        logger.info(f'No new commands found, skipping writing {idx_cmds_path}')
+        logger.info(f"No new commands found, skipping writing {idx_cmds_path}")
         return
 
     # Merge the recent commands with the existing archive.
-    logger.info(f'Appending {len(cmds_recent) - idx0_recent} new commands after '
-                f'removing {len(cmds_arch) - idx0_arch} from existing archive')
-    logger.info(f' starting with cmds_arch[:{idx0_arch}] and adding '
-                f'cmds_recent[{idx0_recent}:{len(cmds_recent)}]')
+    logger.info(
+        f"Appending {len(cmds_recent) - idx0_recent} new commands after "
+        f"removing {len(cmds_arch) - idx0_arch} from existing archive"
+    )
+    logger.info(
+        f" starting with cmds_arch[:{idx0_arch}] and adding "
+        f"cmds_recent[{idx0_recent}:{len(cmds_recent)}]"
+    )
 
     # Remove params column before stacking and saving
-    del cmds_recent['params']
-    del cmds_arch['params']
+    del cmds_recent["params"]
+    del cmds_arch["params"]
 
     # Save the updated archive and pars_dict.
     cmds_arch_new = vstack_exact([cmds_arch[:idx0_arch], cmds_recent[idx0_recent:]])
-    logger.info(f'Writing {len(cmds_arch_new)} commands to {idx_cmds_path}')
-    cmds_arch_new.write(str(idx_cmds_path), path='data', format='hdf5', overwrite=True)
+    logger.info(f"Writing {len(cmds_arch_new)} commands to {idx_cmds_path}")
+    cmds_arch_new.write(str(idx_cmds_path), path="data", format="hdf5", overwrite=True)
 
-    logger.info(f'Writing updated pars_dict to {pars_dict_path}')
-    pickle.dump(pars_dict, open(pars_dict_path, 'wb'))
+    logger.info(f"Writing updated pars_dict to {pars_dict_path}")
+    pickle.dump(pars_dict, open(pars_dict_path, "wb"))
 
 
 def get_matching_block_idx(cmds_arch, cmds_recent):
     # Find place in archive where the recent commands start.
-    idx_arch_recent = cmds_arch.find_date(cmds_recent['date'][0])
-    logger.info('Selecting commands from cmds_arch[{}:]'.format(idx_arch_recent))
+    idx_arch_recent = cmds_arch.find_date(cmds_recent["date"][0])
+    logger.info("Selecting commands from cmds_arch[{}:]".format(idx_arch_recent))
     cmds_arch_recent = cmds_arch[idx_arch_recent:]
 
     # Define the column names that specify a complete and unique row
-    key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'source', 'vcdu')
+    key_names = ("date", "type", "tlmsid", "scs", "step", "source", "vcdu")
 
-    recent_vals = [tuple(
-        row[x].decode('ascii') if isinstance(row[x], bytes) else str(row[x])
-        for x in key_names)
-        for row in cmds_arch_recent]
-    arch_vals = [tuple(
-        row[x].decode('ascii') if isinstance(row[x], bytes) else str(row[x])
-        for x in key_names)
-        for row in cmds_recent]
+    recent_vals = [
+        tuple(
+            row[x].decode("ascii") if isinstance(row[x], bytes) else str(row[x])
+            for x in key_names
+        )
+        for row in cmds_arch_recent
+    ]
+    arch_vals = [
+        tuple(
+            row[x].decode("ascii") if isinstance(row[x], bytes) else str(row[x])
+            for x in key_names
+        )
+        for row in cmds_recent
+    ]
 
     diff = difflib.SequenceMatcher(a=recent_vals, b=arch_vals, autojunk=False)
 
     matching_blocks = diff.get_matching_blocks()
-    logger.info('Matching blocks for (a) recent commands and (b) existing HDF5')
+    logger.info("Matching blocks for (a) recent commands and (b) existing HDF5")
     for block in matching_blocks:
-        logger.info('  {}'.format(block))
+        logger.info("  {}".format(block))
     opcodes = diff.get_opcodes()
-    logger.info('Diffs between (a) recent commands and (b) existing HDF5')
+    logger.info("Diffs between (a) recent commands and (b) existing HDF5")
     for opcode in opcodes:
-        logger.info('  {}'.format(opcode))
+        logger.info("  {}".format(opcode))
     # Find the first matching block that is sufficiently long
     for block in matching_blocks:
         if block.size > MATCHING_BLOCK_SIZE:
             break
     else:
-        raise ValueError('No matching blocks at least {} long'
-                         .format(MATCHING_BLOCK_SIZE))
+        raise ValueError(
+            "No matching blocks at least {} long".format(MATCHING_BLOCK_SIZE)
+        )
 
     # Index into idx_cmds at the end of the large matching block.  block.b is the
     # beginning of the match.
@@ -1159,17 +1242,17 @@ def get_matching_block_idx(cmds_arch, cmds_recent):
     return idx0_arch, idx0_recent
 
 
-TYPE_MAP = ['ACQ', 'GUI', 'BOT', 'FID', 'MON']
-IMGSZ_MAP = ['4x4', '6x6', '8x8']
+TYPE_MAP = ["ACQ", "GUI", "BOT", "FID", "MON"]
+IMGSZ_MAP = ["4x4", "6x6", "8x8"]
 PAR_MAPS = [
-    ('imnum', 'slot', int),
-    ('type', 'type', lambda n: TYPE_MAP[n]),
-    ('imgsz', 'sz', lambda n: IMGSZ_MAP[n]),
-    ('maxmag', 'maxmag', float),
-    ('yang', 'yang', lambda x: np.degrees(x) * 3600),
-    ('zang', 'zang', lambda x: np.degrees(x) * 3600),
-    ('dimdts', 'dim', int),
-    ('restrk', 'res', int),
+    ("imnum", "slot", int),
+    ("type", "type", lambda n: TYPE_MAP[n]),
+    ("imgsz", "sz", lambda n: IMGSZ_MAP[n]),
+    ("maxmag", "maxmag", float),
+    ("yang", "yang", lambda x: np.degrees(x) * 3600),
+    ("zang", "zang", lambda x: np.degrees(x) * 3600),
+    ("dimdts", "dim", int),
+    ("restrk", "res", int),
 ]
 
 
@@ -1199,7 +1282,7 @@ def convert_aostrcat_to_acatable(params):
     from proseco.catalog import ACATable
 
     for idx in range(1, 17):
-        if params[f'minmag{idx}'] == params[f'maxmag{idx}'] == 0:
+        if params[f"minmag{idx}"] == params[f"maxmag{idx}"] == 0:
             break
 
     max_idx = idx
@@ -1209,6 +1292,6 @@ def convert_aostrcat_to_acatable(params):
             cols[col_name].append(func(params[par_name + str(idx)]))
 
     out = ACATable(cols)
-    out.add_column(np.arange(1, max_idx), index=1, name='idx')
+    out.add_column(np.arange(1, max_idx), index=1, name="idx")
 
     return out

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1,41 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import defaultdict
-import math
-import difflib
-import os
-from pathlib import Path
 import calendar
-import re
-import gzip
-import pickle
-import itertools
+import difflib
 import functools
-import weakref
+import gzip
+import itertools
 import logging
+import math
+import os
+import pickle
+import re
+import weakref
+from collections import defaultdict
+from pathlib import Path
 
-import numpy as np
-from astropy.table import Table
 import astropy.units as u
+import numpy as np
 import requests
+from astropy.table import Table
+from Chandra.Maneuver import NSM_attitude
 from cxotime import CxoTime
 from testr.test_helper import has_internet
-from Chandra.Maneuver import NSM_attitude
 
-
-from kadi.commands import get_cmds_from_backstop, conf
-from kadi.commands.core import (
-    load_idx_cmds,
-    load_pars_dict,
-    LazyVal,
-    get_par_idx_update_pars_dict,
-    _find,
-    vstack_exact,
-    ska_load_dir,
-    CommandTable,
-    load_name_to_cxotime,
-)
-from kadi.commands.command_sets import get_cmds_from_event
 from kadi import occweb, paths
+from kadi.commands import conf, get_cmds_from_backstop
+from kadi.commands.command_sets import get_cmds_from_event
+from kadi.commands.core import (CommandTable, LazyVal, _find,
+                                get_par_idx_update_pars_dict, load_idx_cmds,
+                                load_name_to_cxotime, load_pars_dict,
+                                ska_load_dir, vstack_exact)
 
 # TODO configuration options, but use DEFAULT_* in the mean time
 # - commands_version (v1, v2)

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -1,18 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import calendar
 import functools
-import os
-import tables
-from pathlib import Path
 import logging
+import os
 import pickle
 import struct
+from pathlib import Path
 
 import numpy as np
-from ska_helpers import retry
-
-from astropy.table import Table, Row, Column, vstack, TableAttribute
+import tables
+from astropy.table import Column, Row, Table, TableAttribute, vstack
 from cxotime import CxoTime
+from ska_helpers import retry
 
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
@@ -423,6 +422,7 @@ class CommandTable(Table):
 
         elif isinstance(item, (tuple, list)) and all(x in self.colnames for x in item):
             from copy import deepcopy
+
             from astropy.table import groups
 
             out = self.__class__([self[x] for x in item], meta=deepcopy(self.meta))

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -16,7 +16,7 @@ from cxotime import CxoTime
 
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
-__all__ = ['read_backstop', 'get_cmds_from_backstop', 'CommandTable']
+__all__ = ["read_backstop", "get_cmds_from_backstop", "CommandTable"]
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +27,12 @@ class LazyVal(object):
 
     def __getattribute__(self, name):
         try:
-            val = object.__getattribute__(self, '_val')
+            val = object.__getattribute__(self, "_val")
         except AttributeError:
-            val = object.__getattribute__(self, '_load_func')()
+            val = object.__getattribute__(self, "_load_func")()
             self._val = val
 
-        if name == '_val':
+        if name == "_val":
             return val
         else:
             return val.__getattribute__(name)
@@ -57,23 +57,23 @@ class LazyVal(object):
 def load_idx_cmds(version=None, file=None):
     """Load the cmds.h5 file, trying up to 3 times
 
-    It seems that one can occasionally get:
+        It seems that one can occasionally get:
 
-    File "tables/hdf5extension.pyx", line 492, in tables.hdf5extension.File._g_new
-tables.exceptions.HDF5ExtError: HDF5 error back trace
-     ...
-    File "H5FDsec2.c", line 941, in H5FD_sec2_lock
-    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+        File "tables/hdf5extension.pyx", line 492, in tables.hdf5extension.File._g_new
+    tables.exceptions.HDF5ExtError: HDF5 error back trace
+         ...
+        File "H5FDsec2.c", line 941, in H5FD_sec2_lock
+        unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
     """
     if file is None:
         file = IDX_CMDS_PATH(version)
-    with tables.open_file(file, mode='r') as h5:
+    with tables.open_file(file, mode="r") as h5:
         idx_cmds = CommandTable(h5.root.data[:])
-    logger.info(f'Loaded {file} with {len(idx_cmds)} commands')
+    logger.info(f"Loaded {file} with {len(idx_cmds)} commands")
 
     # For V2 add the params column here to make IDX_CMDS be same as regular cmds
     if version == 2:
-        idx_cmds['params'] = None
+        idx_cmds["params"] = None
 
     return idx_cmds
 
@@ -82,9 +82,9 @@ tables.exceptions.HDF5ExtError: HDF5 error back trace
 def load_pars_dict(version=None, file=None):
     if file is None:
         file = PARS_DICT_PATH(version)
-    with open(file, 'rb') as fh:
-        pars_dict = pickle.load(fh, encoding='ascii')
-    logger.info(f'Loaded {file} with {len(pars_dict)} pars')
+    with open(file, "rb") as fh:
+        pars_dict = pickle.load(fh, encoding="ascii")
+    logger.info(f"Loaded {file} with {len(pars_dict)} pars")
     return pars_dict
 
 
@@ -96,11 +96,11 @@ def load_name_to_cxotime(name):
     day = name[3:5]
     yr = name[5:7]
     if int(yr) > 50:
-        year = f'19{yr}'
+        year = f"19{yr}"
     else:
-        year = f'20{yr}'
-    out = CxoTime(f'{year}-{imon:02d}-{day}')
-    out.format = 'date'
+        year = f"20{yr}"
+    out = CxoTime(f"{year}-{imon:02d}-{day}")
+    out.format = "date"
     return out
 
 
@@ -115,7 +115,9 @@ def vstack_exact(tables):
     names0 = table0.colnames
     for table in tables[1:]:
         if set(table.colnames) != set(names0):
-            raise ValueError(f'Tables have different column names: {names0} != {table.colnames}')
+            raise ValueError(
+                f"Tables have different column names: {names0} != {table.colnames}"
+            )
     for name in table0.colnames:
         new_col = np.concatenate([t[name] for t in tables])
         new_cols.append(new_col)
@@ -153,52 +155,55 @@ def get_cmds_from_backstop(backstop, remove_starcat=False):
 
     if isinstance(backstop, (str, list)):
         from parse_cm import read_backstop
+
         bs = read_backstop(backstop)
     elif isinstance(backstop, Table):
         bs = backstop
     else:
-        raise ValueError(f'`backstop` arg must be a string filename or '
-                         f'a backstop Table')
+        raise ValueError(
+            f"`backstop` arg must be a string filename or " f"a backstop Table"
+        )
 
     n_bs = len(bs)
     out = {}
     # Set idx to -1 so it does not match any real idx
-    out['idx'] = np.full(n_bs, fill_value=-1, dtype=np.int32)
-    out['date'] = np.chararray.encode(bs['date'])
-    out['type'] = np.chararray.encode(bs['type'])
-    out['tlmsid'] = np.chararray.encode(bs['tlmsid'])
-    out['scs'] = bs['scs'].astype(np.uint8)
-    out['step'] = bs['step'].astype(np.uint16)
-    out['time'] = CxoTime(bs['date'], format='date').secs
+    out["idx"] = np.full(n_bs, fill_value=-1, dtype=np.int32)
+    out["date"] = np.chararray.encode(bs["date"])
+    out["type"] = np.chararray.encode(bs["type"])
+    out["tlmsid"] = np.chararray.encode(bs["tlmsid"])
+    out["scs"] = bs["scs"].astype(np.uint8)
+    out["step"] = bs["step"].astype(np.uint16)
+    out["time"] = CxoTime(bs["date"], format="date").secs
     # Set timeline_id to 0, does not match any real timeline id
-    out['timeline_id'] = np.zeros(n_bs, dtype=np.uint32)
-    out['vcdu'] = bs['vcdu'].astype(np.int32)
-    out['params'] = bs['params']
+    out["timeline_id"] = np.zeros(n_bs, dtype=np.uint32)
+    out["vcdu"] = bs["vcdu"].astype(np.int32)
+    out["params"] = bs["params"]
 
     if remove_starcat:
         # Remove the lengthy parameters in star catalog but leave the command
-        for idx in np.flatnonzero(bs['type'] == 'MP_STARCAT'):
-            out['params'][idx] = {}
+        for idx in np.flatnonzero(bs["type"] == "MP_STARCAT"):
+            out["params"][idx] = {}
 
     # Backstop has redundant param keys, get rid of them here
-    for params in out['params']:
-        for key in ('tlmsid', 'step', 'scs'):
+    for params in out["params"]:
+        for key in ("tlmsid", "step", "scs"):
             params.pop(key, None)
 
         # Match the hack in update_commands which swaps in "event_type" for "type"
         # for orbit event commands
-        if 'type' in params:
-            params['event_type'] = params['type']
-            del params['type']
+        if "type" in params:
+            params["event_type"] = params["type"]
+            del params["type"]
 
     out = CommandTable(out)
-    out['time'].info.format = '.3f'
+    out["time"].info.format = ".3f"
 
     return out
 
 
-def _find(start=None, stop=None, inclusive_stop=False, idx_cmds=None,
-          pars_dict=None, **kwargs):
+def _find(
+    start=None, stop=None, inclusive_stop=False, idx_cmds=None, pars_dict=None, **kwargs
+):
     """
     Get commands beteween ``start`` and ``stop``.
 
@@ -242,17 +247,17 @@ def _find(start=None, stop=None, inclusive_stop=False, idx_cmds=None,
     ok = np.ones(len(idx_cmds), dtype=bool)
     par_ok = np.zeros(len(idx_cmds), dtype=bool)
 
-    date = kwargs.pop('date', None)
+    date = kwargs.pop("date", None)
     if date:
-        ok &= idx_cmds['date'] == CxoTime(date).date
+        ok &= idx_cmds["date"] == CxoTime(date).date
     else:
         if start:
-            ok &= idx_cmds['date'] >= CxoTime(start).date
+            ok &= idx_cmds["date"] >= CxoTime(start).date
         if stop:
             if inclusive_stop:
-                ok &= idx_cmds['date'] <= CxoTime(stop).date
+                ok &= idx_cmds["date"] <= CxoTime(stop).date
             else:
-                ok &= idx_cmds['date'] < CxoTime(stop).date
+                ok &= idx_cmds["date"] < CxoTime(stop).date
 
     for key, val in kwargs.items():
         key = key.lower()
@@ -269,7 +274,7 @@ def _find(start=None, stop=None, inclusive_stop=False, idx_cmds=None,
                     continue
                 pars = dict(pars_tuple)
                 if pars.get(key) == val:
-                    par_ok |= (idx_cmds['idx'] == idx)
+                    par_ok |= idx_cmds["idx"] == idx
             ok &= par_ok
     cmds = idx_cmds[ok]
 
@@ -277,16 +282,26 @@ def _find(start=None, stop=None, inclusive_stop=False, idx_cmds=None,
 
 
 def get_starcat_keys_types():
-    cat_keys = ['dimdts', 'imgsz', 'imnum', 'maxmag', 'minmag', 'restrk', 'type', 'yang', 'zang']
+    cat_keys = [
+        "dimdts",
+        "imgsz",
+        "imnum",
+        "maxmag",
+        "minmag",
+        "restrk",
+        "type",
+        "yang",
+        "zang",
+    ]
     # Unsigned char (uint8) and float (np.float32)
-    cat_types = ['B', 'B', 'B', 'f', 'f', 'B', 'B', 'f', 'f']
-    keys = ['cmds']
-    types = ['B']
+    cat_types = ["B", "B", "B", "f", "f", "B", "B", "f", "f"]
+    keys = ["cmds"]
+    types = ["B"]
     for idx in range(1, 17):
         for cat_key, cat_type in zip(cat_keys, cat_types):
-            keys.append(f'{cat_key}{idx}')
+            keys.append(f"{cat_key}{idx}")
             types.append(cat_type)
-    return keys, ''.join(types)
+    return keys, "".join(types)
 
 
 STARCAT_KEYS, STARCAT_TYPES = get_starcat_keys_types()
@@ -305,10 +320,10 @@ def decode_starcat_params(params_bytes):
 
 class CommandRow(Row):
     def __getitem__(self, item):
-        if item == 'params':
+        if item == "params":
             out = super().__getitem__(item)
             if out is None:
-                idx = super().__getitem__('idx')
+                idx = super().__getitem__("idx")
                 # self.parent.rev_pars_dict should be a weakref to the reverse
                 # pars dict for this CommandTable. But it might not be defined,
                 # in which case just leave it as None.
@@ -319,20 +334,22 @@ class CommandRow(Row):
                     else:
                         params = dict(parvals)
                 else:
-                    raise KeyError('params cannot be mapped because the rev_pars_dict '
-                                   'attribute is not defined (needs to be a weakref.ref '
-                                   'of REV_PARS_DICT)')
-                out = self['params'] = params
+                    raise KeyError(
+                        "params cannot be mapped because the rev_pars_dict "
+                        "attribute is not defined (needs to be a weakref.ref "
+                        "of REV_PARS_DICT)"
+                    )
+                out = self["params"] = params
         elif item not in self.colnames:
-            out = self['params'][item]
+            out = self["params"][item]
         else:
             out = super().__getitem__(item)
         return out
 
     def keys(self):
-        out = [name for name in self.colnames if name != 'params']
-        if 'params' in self.colnames:
-            params = [key.lower() for key in sorted(self['params'])]
+        out = [name for name in self.colnames if name != "params"]
+        if "params" in self.colnames:
+            params = [key.lower() for key in sorted(self["params"])]
         else:
             params = []
 
@@ -345,23 +362,25 @@ class CommandRow(Row):
         return [(key, value) for key, value in zip(self.keys(), self.values())]
 
     def __repr__(self):
-        out = (f'<Cmd {str(self)}>')
+        out = f"<Cmd {str(self)}>"
         return out
 
     def __str__(self):
         keys = self.keys()
-        keys.remove('date')
-        keys.remove('type')
-        if 'idx' in keys:
-            keys.remove('idx')
+        keys.remove("date")
+        keys.remove("type")
+        if "idx" in keys:
+            keys.remove("idx")
 
-        out = ('{} {} '.format(self['date'], self['type'])
-               + ' '.join('{}={}'.format(key, self[key]) for key in keys
-                          if key not in ('type', 'date', 'time')))
+        out = "{} {} ".format(self["date"], self["type"]) + " ".join(
+            "{}={}".format(key, self[key])
+            for key in keys
+            if key not in ("type", "date", "time")
+        )
         return out
 
     def __sstr__(self):
-        return str(self._table[self.index:self.index + 1])
+        return str(self._table[self.index : self.index + 1])
 
 
 class CommandTable(Table):
@@ -369,19 +388,22 @@ class CommandTable(Table):
     Astropy Table subclass that is specialized to handle commands via a
     ``params`` column that is expected to be ``None`` or a dict of params.
     """
+
     rev_pars_dict = TableAttribute()
 
-    COL_TYPES = {'idx': np.int32,
-                 'date': 'S21',
-                 'type': 'S12',
-                 'tlmsid': 'S10',
-                 'scs': np.uint8,
-                 'step': np.uint16,
-                 'source': 'S8',
-                 'timeline_id': np.uint32,
-                 'vcdu': np.int32,
-                 'time': np.float64,
-                 'params': object}
+    COL_TYPES = {
+        "idx": np.int32,
+        "date": "S21",
+        "type": "S12",
+        "tlmsid": "S10",
+        "scs": np.uint8,
+        "step": np.uint16,
+        "source": "S8",
+        "timeline_id": np.uint32,
+        "vcdu": np.int32,
+        "time": np.float64,
+        "params": object,
+    }
 
     def _convert_data_to_col(self, *args, **kwargs):
         col = super()._convert_data_to_col(*args, **kwargs)
@@ -394,39 +416,43 @@ class CommandTable(Table):
             if item in self.colnames:
                 return self.columns[item]
             else:
-                return Column([cmd['params'].get(item) for cmd in self], name=item)
+                return Column([cmd["params"].get(item) for cmd in self], name=item)
 
         elif isinstance(item, (int, np.integer)):
             return CommandRow(self, item)
 
-        elif isinstance(item, (tuple, list)) and all(x in self.colnames
-                                                     for x in item):
+        elif isinstance(item, (tuple, list)) and all(x in self.colnames for x in item):
             from copy import deepcopy
             from astropy.table import groups
+
             out = self.__class__([self[x] for x in item], meta=deepcopy(self.meta))
-            out._groups = groups.TableGroups(out, indices=self.groups._indices,
-                                             keys=self.groups._keys)
+            out._groups = groups.TableGroups(
+                out, indices=self.groups._indices, keys=self.groups._keys
+            )
             return out
 
-        elif (isinstance(item, slice)
-              or isinstance(item, np.ndarray)
-              or isinstance(item, list)
-              or isinstance(item, tuple) and all(isinstance(x, np.ndarray)
-                                                 for x in item)):
+        elif (
+            isinstance(item, slice)
+            or isinstance(item, np.ndarray)
+            or isinstance(item, list)
+            or isinstance(item, tuple)
+            and all(isinstance(x, np.ndarray) for x in item)
+        ):
             # here for the many ways to give a slice; a tuple of ndarray
             # is produced by np.where, as in t[np.where(t['a'] > 2)]
             # For all, a new table is constructed with slice of all columns
             return self._new_from_slice(item)
 
         else:
-            raise ValueError('Illegal type {0} for table item access'
-                             .format(type(item)))
+            raise ValueError(
+                "Illegal type {0} for table item access".format(type(item))
+            )
 
     def __str__(self):
         # Cut out index column for printing
         colnames = self.colnames
-        if 'idx' in colnames:
-            colnames.remove('idx')
+        if "idx" in colnames:
+            colnames.remove("idx")
         return self.__repr__(colnames)
 
     def __repr__(self, colnames=None):
@@ -435,31 +461,33 @@ class CommandTable(Table):
 
         # Nice repr of parameters.
         tmp_params = None
-        if 'params' in colnames:
+        if "params" in colnames:
             params_list = []
-            for params in self['params']:
+            for params in self["params"]:
                 if params is None:
-                    params_list.append('N/A')
+                    params_list.append("N/A")
                 else:
-                    param_strs = ['{}={}'.format(key, val) for key, val in params.items()]
-                    params_str = ' '.join(param_strs)
+                    param_strs = [
+                        "{}={}".format(key, val) for key, val in params.items()
+                    ]
+                    params_str = " ".join(param_strs)
                     if len(params_str) > 40:
-                        params_str = params_str[:40] + ' ...'
+                        params_str = params_str[:40] + " ..."
                     params_list.append(params_str)
             tmp_params = params_list
-            colnames.remove('params')
+            colnames.remove("params")
 
         tmp = self[colnames]
         if tmp_params:
-            tmp['params'] = tmp_params
+            tmp["params"] = tmp_params
 
         lines = tmp.pformat(max_width=-1)
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     def __bytes__(self):
-        return str(self).encode('utf-8')
+        return str(self).encode("utf-8")
 
-    def find_date(self, date, side='left'):
+    def find_date(self, date, side="left"):
         """Find row in table corresponding to ``date``.
 
         This is a thin wrapper around np.searchsorted that converts ``date`` to
@@ -478,8 +506,8 @@ class CommandTable(Table):
         """
         if isinstance(date, CxoTime):
             date = date.date
-        date = np.char.encode(date, encoding='ascii')
-        idxs = np.searchsorted(self['date'], date, side=side)
+        date = np.char.encode(date, encoding="ascii")
+        idxs = np.searchsorted(self["date"], date, side=side)
         return idxs
 
     def fetch_params(self):
@@ -488,28 +516,32 @@ class CommandTable(Table):
 
         This is handy for printing a command table and seeing all the parameters at once.
         """
-        if 'params' not in self.colnames:
-            self['params'] = None
+        if "params" not in self.colnames:
+            self["params"] = None
         for cmd in self:
-            cmd['params']
+            cmd["params"]
 
     def get_rltt(self):
         # Find the RLTT, which should be near the start of the table.
         for cmd in self:
-            if (cmd['type'] == 'LOAD_EVENT'
-                    and cmd['params']['event_type'] == 'RUNNING_LOAD_TERMINATION_TIME'):
-                return cmd['date']
+            if (
+                cmd["type"] == "LOAD_EVENT"
+                and cmd["params"]["event_type"] == "RUNNING_LOAD_TERMINATION_TIME"
+            ):
+                return cmd["date"]
         else:
-            raise ValueError(f'No RLTT found')
+            raise ValueError(f"No RLTT found")
 
     def get_scheduled_stop_time(self):
         for idx in range(len(self), 0, -1):
             cmd = self[idx - 1]
-            if (cmd['type'] == 'LOAD_EVENT'
-                    and cmd['params']['event_type'] == 'SCHEDULED_STOP_TIME'):
-                return cmd['date']
+            if (
+                cmd["type"] == "LOAD_EVENT"
+                and cmd["params"]["event_type"] == "SCHEDULED_STOP_TIME"
+            ):
+                return cmd["date"]
         else:
-            raise ValueError(f'No scheduled stop time found')
+            raise ValueError(f"No scheduled stop time found")
 
     def add_cmds(self, cmds, rltt=None):
         """
@@ -522,7 +554,7 @@ class CommandTable(Table):
         :returns: :class:`~kadi.commands.commands.CommandTable` of commands
         """
         if rltt is not None:
-            remove_idxs = np.where(self['date'] > rltt)[0]
+            remove_idxs = np.where(self["date"] > rltt)[0]
             self.remove_rows(remove_idxs)
 
         try:
@@ -542,17 +574,17 @@ class CommandTable(Table):
         This matches the order in backstop.
         """
         # Legacy sort for V1 commands archive
-        if 'timeline_id' in self.colnames:
-            self.sort(['date', 'step', 'scs'])
+        if "timeline_id" in self.colnames:
+            self.sort(["date", "step", "scs"])
             return
 
         # For V2 use stable sort just on date, preserving the existing order.
         # Copied verbatim from astropy.table.Table.sort except 'stable' sort.
         # (Astropy sort does not provide `kind` argument for .sort(), hopefully
         # fixed by astropy 5.1).
-        indexes = self.argsort(['date'], kind='stable')
+        indexes = self.argsort(["date"], kind="stable")
 
-        with self.index_mode('freeze'):
+        with self.index_mode("freeze"):
             for name, col in self.columns.items():
                 # Make a new sorted column.  This requires that take() also copies
                 # relevant info attributes for mixin columns.
@@ -590,19 +622,22 @@ class CommandTable(Table):
 
         if ska_parsecm:
             for cmd in cmds_list:
-                if 'type' in cmd:
-                    cmd['cmd'] = cmd['type']
-                if 'params' in cmd:
-                    cmd['params'] = {key.upper(): val for key, val in cmd['params'].items()}
+                if "type" in cmd:
+                    cmd["cmd"] = cmd["type"]
+                if "params" in cmd:
+                    cmd["params"] = {
+                        key.upper(): val for key, val in cmd["params"].items()
+                    }
 
         return cmds_list
 
-    def pformat_like_backstop(self,
-                              show_source=True,
-                              show_nonload_meta=True,
-                              sort_orbit_events=False,
-                              max_params_width=80,
-                              ):
+    def pformat_like_backstop(
+        self,
+        show_source=True,
+        show_nonload_meta=True,
+        sort_orbit_events=False,
+        max_params_width=80,
+    ):
         """Format the table in a human-readable format that is similar to backstop.
 
         :param show_source: bool, optional
@@ -616,21 +651,23 @@ class CommandTable(Table):
         :returns: list of lines
         """
         lines = []
-        has_params = 'params' in self.colnames
+        has_params = "params" in self.colnames
 
         if has_params and sort_orbit_events:
             cmds = self.copy()
-            cmds['cmd_idx'] = np.arange(len(cmds))
-            orb_cmds = cmds[cmds['type'] == 'ORBPOINT']
-            cg = orb_cmds.group_by('date')
+            cmds["cmd_idx"] = np.arange(len(cmds))
+            orb_cmds = cmds[cmds["type"] == "ORBPOINT"]
+            cg = orb_cmds.group_by("date")
             for i0, i1 in zip(cg.groups.indices[:-1], cg.groups.indices[1:]):
                 # For multiple orbit events at the same date, pull them out and
                 # sort the event_type and index and update in place.
                 if i1 - i0 > 1:
-                    vals = sorted([cg[ii]['params']['event_type'] for ii in range(i0, i1)])
-                    idxs = sorted(cg['cmd_idx'][i0:i1])
+                    vals = sorted(
+                        [cg[ii]["params"]["event_type"] for ii in range(i0, i1)]
+                    )
+                    idxs = sorted(cg["cmd_idx"][i0:i1])
                     for idx, val in zip(idxs, vals):
-                        cmds[idx]['params']['event_type'] = val
+                        cmds[idx]["params"]["event_type"] = val
         else:
             cmds = self
 
@@ -638,55 +675,59 @@ class CommandTable(Table):
             if has_params:
                 # Make a single string of params like POS= 75624, SCS= 130, STEP= 9
                 fmtvals = []
-                keys = cmd['params']
+                keys = cmd["params"]
                 for key in keys:
-                    if (not show_nonload_meta
-                            and key in ('nonload_id', 'event', 'event_date')):
+                    if not show_nonload_meta and key in (
+                        "nonload_id",
+                        "event",
+                        "event_date",
+                    ):
                         continue
-                    val = cmd['params'][key]
-                    if key == 'aoperige':
-                        fmt = '{}={:.13e}'
+                    val = cmd["params"][key]
+                    if key == "aoperige":
+                        fmt = "{}={:.13e}"
                     elif isinstance(val, float):
-                        fmt = '{}={:.8e}'
-                    elif key == 'packet(40)':
+                        fmt = "{}={:.8e}"
+                    elif key == "packet(40)":
                         continue
-                    elif (key.startswith('aopcads') or
-                          key.startswith('co')
-                          or key.startswith('afl')
-                          or key.startswith('2s1s')
-                          or key.startswith('2s2s')
-                          ):
-                        fmt = '{}={:d} '
+                    elif (
+                        key.startswith("aopcads")
+                        or key.startswith("co")
+                        or key.startswith("afl")
+                        or key.startswith("2s1s")
+                        or key.startswith("2s2s")
+                    ):
+                        fmt = "{}={:d} "
                     else:
-                        fmt = '{}={}'
+                        fmt = "{}={}"
                     fmtvals.append(fmt.format(key, val))
 
                 fmtvals.append(f'scs={cmd["scs"]}')
 
-                params_str = ', '.join(fmtvals)
+                params_str = ", ".join(fmtvals)
             else:
-                params_str = 'N/A'
+                params_str = "N/A"
 
             if max_params_width is not None:
                 params_str = params_str[:max_params_width]
 
-            fmts = ('{}', '{:16s}', '{:10s}')
-            args = (cmd['date'], cmd['type'], cmd['tlmsid'])
+            fmts = ("{}", "{:16s}", "{:10s}")
+            args = (cmd["date"], cmd["type"], cmd["tlmsid"])
             if show_source:
-                if 'source' in self.colnames:
-                    fmts += ('{:8s}',)
-                    args += (cmd['source'],)
-                elif 'timeline_id' in self.colnames:
-                    fmts += ('{:8d}',)
-                    args += (cmd['timeline_id'],)
-            fmts += ('{}',)
+                if "source" in self.colnames:
+                    fmts += ("{:8s}",)
+                    args += (cmd["source"],)
+                elif "timeline_id" in self.colnames:
+                    fmts += ("{:8d}",)
+                    args += (cmd["timeline_id"],)
+            fmts += ("{}",)
             args += (params_str,)
-            fmt = ' | '.join(fmts)
+            fmt = " | ".join(fmts)
             lines.append(fmt.format(*args))
 
         return lines
 
-    def pprint_like_backstop(self, *, logger_func=None, logger_text='', **kwargs):
+    def pprint_like_backstop(self, *, logger_func=None, logger_text="", **kwargs):
         """Format the table in a human-readable format that is similar to backstop.
 
         :param logger_func: function, optional
@@ -706,7 +747,7 @@ class CommandTable(Table):
             for line in lines:
                 print(line)
         else:
-            logger_func(logger_text + '\n' + '\n'.join(lines) + '\n')
+            logger_func(logger_text + "\n" + "\n".join(lines) + "\n")
 
     def deduplicate_orbit_cmds(self):
         """Remove duplicate orbit commands (ORBPOINT type) in place.
@@ -717,33 +758,35 @@ class CommandTable(Table):
         is within 3 minutes. This code chooses the cmd from the latest loads in
         this case.
         """
-        idxs = np.where(self['type'] == 'ORBPOINT')[0]
+        idxs = np.where(self["type"] == "ORBPOINT")[0]
         orbit_cmds = self[idxs]
-        orbit_cmds['idx'] = idxs
-        orbit_cmds['time'] = CxoTime(orbit_cmds['date']).secs
+        orbit_cmds["idx"] = idxs
+        orbit_cmds["time"] = CxoTime(orbit_cmds["date"]).secs
 
         # Turn into a list of Row's and sort by (event_type, date)
         orbit_cmds = list(orbit_cmds)
-        orbit_cmds.sort(key=lambda y: (y['params']['event_type'], y['date']))
+        orbit_cmds.sort(key=lambda y: (y["params"]["event_type"], y["date"]))
 
         uniq_cmds = [orbit_cmds[0]]
         # Step through one at a time and add to uniq_cmds only if the candidate is
         # "different" from uniq_cmds[-1].
         for cmd in orbit_cmds:
             last_cmd = uniq_cmds[-1]
-            if (cmd['params']['event_type'] == last_cmd['params']['event_type']
-                    and abs(cmd['time'] - last_cmd['time']) < 180):
+            if (
+                cmd["params"]["event_type"] == last_cmd["params"]["event_type"]
+                and abs(cmd["time"] - last_cmd["time"]) < 180
+            ):
                 # Same event as last (even if date is a bit different).  Now if this one
                 # has a larger timeline_id that means it is from a more recent schedule, so
                 # use that one.
-                load_date = load_name_to_cxotime(cmd['source'])
-                load_date_last = load_name_to_cxotime(last_cmd['source'])
+                load_date = load_name_to_cxotime(cmd["source"])
+                load_date_last = load_name_to_cxotime(last_cmd["source"])
                 if load_date > load_date_last:
                     uniq_cmds[-1] = cmd
             else:
                 uniq_cmds.append(cmd)
 
-        uniq_idxs = [uniq_cmd['idx'] for uniq_cmd in uniq_cmds]
+        uniq_idxs = [uniq_cmd["idx"] for uniq_cmd in uniq_cmds]
         remove_idxs = set(idxs) - set(uniq_idxs)
         self.remove_rows(list(remove_idxs))
 
@@ -756,13 +799,13 @@ class CommandTable(Table):
         LETG retract command in the loads after the LETG insert anomaly.
         """
         idxs_remove = set()
-        idxs_not_run = np.where(self['type'] == 'NOT_RUN')[0]
+        idxs_not_run = np.where(self["type"] == "NOT_RUN")[0]
         for idx in idxs_not_run:
             cmd = self[idx]
-            ok = (self['date'] == cmd['date']) & (self['tlmsid'] == cmd['tlmsid'])
+            ok = (self["date"] == cmd["date"]) & (self["tlmsid"] == cmd["tlmsid"])
             idxs_remove.update(np.where(ok)[0])
         if idxs_remove:
-            logger.info(f'Removing {len(idxs_remove)} NOT_RUN cmds')
+            logger.info(f"Removing {len(idxs_remove)} NOT_RUN cmds")
             self.remove_rows(list(idxs_remove))
 
 
@@ -786,16 +829,16 @@ def get_par_idx_update_pars_dict(pars_dict, cmd, params=None, rev_pars_dict=None
     """
     # Define a consistently ordered tuple that has all command parameter information
     if params is None:
-        params = cmd['params']
-    keys = set(params.keys()) - set(('SCS', 'STEP', 'TLMSID'))
+        params = cmd["params"]
+    keys = set(params.keys()) - set(("SCS", "STEP", "TLMSID"))
 
-    if cmd['tlmsid'] == 'AOSTRCAT':
+    if cmd["tlmsid"] == "AOSTRCAT":
         pars_tup = encode_starcat_params(params) if params else ()
     else:
-        if cmd['tlmsid'] == 'OBS':
+        if cmd["tlmsid"] == "OBS":
             # Re-order parameters to a priority order.
-            new_keys = ['obsid', 'simpos', 'obs_stop', 'manvr_start', 'targ_att']
-            for key in sorted(cmd['params']):
+            new_keys = ["obsid", "simpos", "obs_stop", "manvr_start", "targ_att"]
+            for key in sorted(cmd["params"]):
                 if key not in new_keys:
                     new_keys.append(key)
             keys = new_keys
@@ -822,13 +865,13 @@ def get_par_idx_update_pars_dict(pars_dict, cmd, params=None, rev_pars_dict=None
 
 
 def ska_load_dir(load_name):
-    root = Path(os.environ['SKA']) / 'data' / 'mpcrit1' / 'mplogs'
+    root = Path(os.environ["SKA"]) / "data" / "mpcrit1" / "mplogs"
     year = load_name[5:7]
-    if year == '99':
+    if year == "99":
         year = 1999
     else:
         year = 2000 + int(year)
     load_rev = load_name[-1].lower()
     load_dir = load_name[:-1]
-    load_dir = root / str(year) / load_dir / f'ofls{load_rev}'
+    load_dir = root / str(year) / load_dir / f"ofls{load_rev}"
     return load_dir

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -1,13 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import os
 from collections import defaultdict
-import logging
 from pathlib import Path
 
-import numpy as np
-from cxotime import CxoTime
 import astropy.units as u
-from astropy.table import Table, unique as table_unique
+import numpy as np
+from astropy.table import Table
+from astropy.table import unique as table_unique
+from cxotime import CxoTime
 
 # kadi.commands.commands_v2 is also a dependency but encapsulated in the
 # functions to reduce top-level imports for v1-compatibility
@@ -62,6 +63,7 @@ def set_detector_and_sim_offset(aca, simpos):
 
 def set_fid_ids(aca):
     from proseco.fid import get_fid_positions
+
     from kadi.commands import conf
 
     fid_yangs, fid_zangs = get_fid_positions(
@@ -103,6 +105,7 @@ def set_star_ids(aca):
     """
     from chandra_aca.transform import radec_to_yagzag
     from Quaternion import Quat
+
     from kadi.commands import conf
 
     q_att = Quat(aca.att)
@@ -155,10 +158,10 @@ def convert_aostrcat_to_acatable(obs, params, as_dict=False):
     :param params: dict of AOSTRCAT parameters
     :returns: ACATable
     """
-    from proseco.catalog import ACATable
-    from proseco.acq import AcqTable
-    from proseco.guide import GuideTable
     from Chandra.Time import date2secs
+    from proseco.acq import AcqTable
+    from proseco.catalog import ACATable
+    from proseco.guide import GuideTable
 
     for idx in range(1, 17):
         if params[f"minmag{idx}"] == params[f"maxmag{idx}"] == 0:
@@ -343,13 +346,15 @@ def get_starcats(
     """
     import shelve
     from contextlib import ExitStack
+
+    from proseco.acq import AcqTable
+    from proseco.catalog import ACATable
+    from proseco.guide import GuideTable
+
+    from kadi.commands import conf
     from kadi.commands.commands_v2 import REV_PARS_DICT
     from kadi.commands.core import decode_starcat_params
     from kadi.paths import STARCATS_CACHE_PATH
-    from kadi.commands import conf
-    from proseco.catalog import ACATable
-    from proseco.acq import AcqTable
-    from proseco.guide import GuideTable
 
     obss = get_observations(
         obsid=obsid,
@@ -561,8 +566,8 @@ def get_agasc_cone_fast(ra, dec, radius=1.5, date=None):
     global STARS_AGASC
 
     agasc_file = AGASC_FILE
-    from agasc.agasc import get_ra_decs, sphere_dist, add_pmcorr_columns
     import tables
+    from agasc.agasc import add_pmcorr_columns, get_ra_decs, sphere_dist
 
     ra_decs = get_ra_decs(agasc_file)
 

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -15,22 +15,22 @@ from astropy.table import Table, unique as table_unique
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['get_starcats', 'get_observations', 'get_starcats_as_table']
+__all__ = ["get_starcats", "get_observations", "get_starcats_as_table"]
 
-AGASC_FILE = Path(os.environ['SKA'], 'data', 'agasc', 'proseco_agasc_1p7.h5')
+AGASC_FILE = Path(os.environ["SKA"], "data", "agasc", "proseco_agasc_1p7.h5")
 
-TYPE_MAP = ['ACQ', 'GUI', 'BOT', 'FID', 'MON']
-IMGSZ_MAP = ['4x4', '6x6', '8x8']
+TYPE_MAP = ["ACQ", "GUI", "BOT", "FID", "MON"]
+IMGSZ_MAP = ["4x4", "6x6", "8x8"]
 RAD_TO_DEG = 180 / np.pi * 3600
 PAR_MAPS = [
-    ('imnum', 'slot', int),
-    ('type', 'type', lambda n: TYPE_MAP[n]),
-    ('imgsz', 'sz', lambda n: IMGSZ_MAP[n]),
-    ('maxmag', 'maxmag', float),
-    ('yang', 'yang', lambda x: x * RAD_TO_DEG),
-    ('zang', 'zang', lambda x: x * RAD_TO_DEG),
-    ('dimdts', 'dim', int),
-    ('restrk', 'res', int),
+    ("imnum", "slot", int),
+    ("type", "type", lambda n: TYPE_MAP[n]),
+    ("imgsz", "sz", lambda n: IMGSZ_MAP[n]),
+    ("maxmag", "maxmag", float),
+    ("yang", "yang", lambda x: x * RAD_TO_DEG),
+    ("zang", "zang", lambda x: x * RAD_TO_DEG),
+    ("dimdts", "dim", int),
+    ("restrk", "res", int),
 ]
 
 # Cache of observations by scenario
@@ -51,6 +51,7 @@ def set_detector_and_sim_offset(aca, simpos):
     :param simpos: int, SIM position (steps)
     """
     from proseco import characteristics_fid as FID
+
     sim_offsets = [simpos - simpos_nom for simpos_nom in FID.simpos.values()]
     idx = np.argmin(np.abs(sim_offsets))
     detector = list(FID.simpos.keys())[idx]
@@ -62,13 +63,15 @@ def set_detector_and_sim_offset(aca, simpos):
 def set_fid_ids(aca):
     from proseco.fid import get_fid_positions
     from kadi.commands import conf
-    fid_yangs, fid_zangs = get_fid_positions(
-        detector=aca.detector, focus_offset=0, sim_offset=aca.sim_offset)
 
-    idxs_aca = np.where(aca['type'] == 'FID')[0]
+    fid_yangs, fid_zangs = get_fid_positions(
+        detector=aca.detector, focus_offset=0, sim_offset=aca.sim_offset
+    )
+
+    idxs_aca = np.where(aca["type"] == "FID")[0]
     for idx_aca in idxs_aca:
-        yang = aca['yang'][idx_aca]
-        zang = aca['zang'][idx_aca]
+        yang = aca["yang"][idx_aca]
+        zang = aca["zang"][idx_aca]
         dys = np.abs(yang - fid_yangs)
         dzs = np.abs(zang - fid_zangs)
         # Match fid positions in a box. Default is a very loose tolerance of 40
@@ -78,11 +81,13 @@ def set_fid_ids(aca):
         idxs_fid = np.where((dys < halfw) & (dzs < halfw))[0]
         n_idxs_fid = len(idxs_fid)
         if n_idxs_fid == 1:
-            aca[idx_aca]['id'] = idxs_fid[0] + 1
-            aca[idx_aca]['mag'] = 7.0
+            aca[idx_aca]["id"] = idxs_fid[0] + 1
+            aca[idx_aca]["mag"] = 7.0
         elif n_idxs_fid > 1:
-            logger.warning(f'WARNING: found {n_idxs_fid} fids in obsid {aca.obsid} at '
-                           f'{aca.date}\n{aca[idx_aca]}')
+            logger.warning(
+                f"WARNING: found {n_idxs_fid} fids in obsid {aca.obsid} at "
+                f"{aca.date}\n{aca[idx_aca]}"
+            )
         # Note that no fids found happens normally for post SCS-107 observations
         # because the SIM is translated so don't warn in this case.
 
@@ -99,13 +104,16 @@ def set_star_ids(aca):
     from chandra_aca.transform import radec_to_yagzag
     from Quaternion import Quat
     from kadi.commands import conf
+
     q_att = Quat(aca.att)
     stars = get_agasc_cone_fast(q_att.ra, q_att.dec, radius=1.2, date=aca.date)
-    yang_stars, zang_stars = radec_to_yagzag(stars['RA_PMCORR'], stars['DEC_PMCORR'], q_att)
-    idxs_aca = np.where(np.isin(aca['type'], ('ACQ', 'GUI', 'BOT')))[0]
+    yang_stars, zang_stars = radec_to_yagzag(
+        stars["RA_PMCORR"], stars["DEC_PMCORR"], q_att
+    )
+    idxs_aca = np.where(np.isin(aca["type"], ("ACQ", "GUI", "BOT")))[0]
     for idx_aca in idxs_aca:
-        yang = aca['yang'][idx_aca]
-        zang = aca['zang'][idx_aca]
+        yang = aca["yang"][idx_aca]
+        zang = aca["zang"][idx_aca]
         dys = np.abs(yang - yang_stars)
         dzs = np.abs(zang - zang_stars)
 
@@ -113,12 +121,14 @@ def set_star_ids(aca):
         halfw = conf.star_id_match_halfwidth
         ok = (dys < halfw) & (dzs < halfw)
         if np.any(ok):
-            idx = np.argmin(stars['MAG_ACA'][ok])
-            aca[idx_aca]['id'] = stars['AGASC_ID'][ok][idx]
-            aca[idx_aca]['mag'] = stars['MAG_ACA'][ok][idx]
+            idx = np.argmin(stars["MAG_ACA"][ok])
+            aca[idx_aca]["id"] = stars["AGASC_ID"][ok][idx]
+            aca[idx_aca]["mag"] = stars["MAG_ACA"][ok][idx]
         else:
-            logger.info(f'WARNING: star idx {idx_aca + 1} not found in obsid {aca.obsid} at '
-                        f'{aca.date}')
+            logger.info(
+                f"WARNING: star idx {idx_aca + 1} not found in obsid {aca.obsid} at "
+                f"{aca.date}"
+            )
 
 
 def convert_aostrcat_to_acatable(obs, params, as_dict=False):
@@ -151,7 +161,7 @@ def convert_aostrcat_to_acatable(obs, params, as_dict=False):
     from Chandra.Time import date2secs
 
     for idx in range(1, 17):
-        if params[f'minmag{idx}'] == params[f'maxmag{idx}'] == 0:
+        if params[f"minmag{idx}"] == params[f"maxmag{idx}"] == 0:
             break
 
     max_idx = idx
@@ -163,27 +173,35 @@ def convert_aostrcat_to_acatable(obs, params, as_dict=False):
     aca = ACATable(cols)
     aca.acqs = AcqTable()
     aca.guides = GuideTable()
-    aca.add_column(np.arange(1, max_idx), index=1, name='idx')
+    aca.add_column(np.arange(1, max_idx), index=1, name="idx")
 
-    aca.obsid = obs['obsid']
-    aca.att = obs['targ_att']
-    aca.date = obs['starcat_date']
-    aca.duration = date2secs(obs['obs_stop']) - date2secs(obs['obs_start'])
+    aca.obsid = obs["obsid"]
+    aca.att = obs["targ_att"]
+    aca.date = obs["starcat_date"]
+    aca.duration = date2secs(obs["obs_stop"]) - date2secs(obs["obs_start"])
 
     # Make the catalog more complete and provide stuff temps needed for plot()
     aca.t_ccd = -20.0
     aca.acqs.t_ccd = -20.0
     aca.guides.t_ccd = -20.0
 
-    halfws = 20 + np.where(aca['res'], 5, 40) * aca['dim']
-    halfws[aca['type'] == 'MON'] = 25
-    aca['halfw'] = halfws
+    halfws = 20 + np.where(aca["res"], 5, 40) * aca["dim"]
+    halfws[aca["type"] == "MON"] = 25
+    aca["halfw"] = halfws
 
     return aca
 
 
-def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
-                          scenario=None, cmds=None, starcat_date=None):
+def get_starcats_as_table(
+    start=None,
+    stop=None,
+    *,
+    obsid=None,
+    unique=False,
+    scenario=None,
+    cmds=None,
+    starcat_date=None,
+):
     """Get a single table of star catalog entries corresponding to input parameters.
 
     This function calls ``get_starcats`` with the same parameters and then
@@ -222,15 +240,22 @@ def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
     :returns: astropy ``Table`` star catalog entries for matching observations.
 
     """
-    starcats = get_starcats(obsid=obsid, start=start, stop=stop, scenario=scenario,
-                            cmds=cmds, starcat_date=starcat_date, as_dict=True)
+    starcats = get_starcats(
+        obsid=obsid,
+        start=start,
+        stop=stop,
+        scenario=scenario,
+        cmds=cmds,
+        starcat_date=starcat_date,
+        as_dict=True,
+    )
     out = defaultdict(list)
     for starcat in starcats:
-        n_cat = len(starcat['slot'])
-        out['obsid'].append([starcat['meta']['obsid']] * n_cat)
-        out['starcat_date'].append([starcat['meta']['date']] * n_cat)
+        n_cat = len(starcat["slot"])
+        out["obsid"].append([starcat["meta"]["obsid"]] * n_cat)
+        out["starcat_date"].append([starcat["meta"]["date"]] * n_cat)
         for name, vals in starcat.items():
-            if name != 'meta':
+            if name != "meta":
                 out[name].append(vals)
 
     for name in out:
@@ -238,13 +263,21 @@ def get_starcats_as_table(start=None, stop=None, *, obsid=None, unique=False,
 
     out = Table(out)
     if unique:
-        out = table_unique(out, keys=['starcat_date', 'idx'])
+        out = table_unique(out, keys=["starcat_date", "idx"])
 
     return out
 
 
-def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
-                 cmds=None, as_dict=False, starcat_date=None):
+def get_starcats(
+    start=None,
+    stop=None,
+    *,
+    obsid=None,
+    scenario=None,
+    cmds=None,
+    as_dict=False,
+    starcat_date=None,
+):
     """Get a list of star catalogs corresponding to input parameters.
 
     The ``start``, ``stop`` and ``obsid`` parameters serve as matching filters
@@ -318,33 +351,41 @@ def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
     from proseco.acq import AcqTable
     from proseco.guide import GuideTable
 
-    obss = get_observations(obsid=obsid, start=start, stop=stop,
-                            scenario=scenario, cmds=cmds, starcat_date=starcat_date)
+    obss = get_observations(
+        obsid=obsid,
+        start=start,
+        stop=stop,
+        scenario=scenario,
+        cmds=cmds,
+        starcat_date=starcat_date,
+    )
     starcats = []
     rev_pars_dict = REV_PARS_DICT if cmds is None else cmds.rev_pars_dict()
 
     with ExitStack() as context_stack:
         if conf.cache_starcats:
             starcats_db = context_stack.enter_context(
-                shelve.open(str(STARCATS_CACHE_PATH())))
+                shelve.open(str(STARCATS_CACHE_PATH()))
+            )
         else:
             # Defining as a dict provides the same interface as shelve but
             # precludes caching.
             starcats_db = {}
 
         for obs in obss:
-            if (idx := obs.get('starcat_idx')) is None:
+            if (idx := obs.get("starcat_idx")) is None:
                 continue
 
-            db_key = '{}-{}-{:05d}'.format(
-                obs['starcat_date'], obs['source'], obs['obsid'])
+            db_key = "{}-{}-{:05d}".format(
+                obs["starcat_date"], obs["source"], obs["obsid"]
+            )
             if db_key in starcats_db:
                 # From the cache
                 starcat_dict = starcats_db[db_key]
                 if as_dict:
                     starcat = starcat_dict
                 else:
-                    meta = starcat_dict.pop('meta')
+                    meta = starcat_dict.pop("meta")
                     starcat = ACATable(starcat_dict)
                     starcat.meta = meta
                     starcat.acqs = AcqTable()
@@ -355,16 +396,18 @@ def get_starcats(start=None, stop=None, *, obsid=None, scenario=None,
                 if isinstance(params, bytes):
                     params = decode_starcat_params(params)
                 starcat = convert_aostrcat_to_acatable(obs, params)
-                set_detector_and_sim_offset(starcat, obs['simpos'])
-                starcat.add_column(-999, index=2, name='id')
-                starcat.add_column(-999.0, index=5, name='mag')
+                set_detector_and_sim_offset(starcat, obs["simpos"])
+                starcat.add_column(-999, index=2, name="id")
+                starcat.add_column(-999.0, index=5, name="mag")
                 set_fid_ids(starcat)
                 set_star_ids(starcat)
 
-                starcat_dict = {name: starcat[name].tolist() for name in starcat.colnames}
-                starcat_dict['meta'] = starcat.meta
-                del starcat_dict['meta']['acqs']
-                del starcat_dict['meta']['guides']
+                starcat_dict = {
+                    name: starcat[name].tolist() for name in starcat.colnames
+                }
+                starcat_dict["meta"] = starcat.meta
+                del starcat_dict["meta"]["acqs"]
+                del starcat_dict["meta"]["guides"]
 
                 if as_dict:
                     starcat = starcat_dict
@@ -443,58 +486,61 @@ def get_observations(
         Observation parameters for matching observations.
     """
     from kadi.commands.commands_v2 import get_cmds
+
     if starcat_date is not None:
         start = starcat_date if start is None else start
         stop = CxoTime(starcat_date) + 7 * u.day if stop is None else stop
-    start = CxoTime('1999:001' if start is None else start)
+    start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)
 
     if cmds is None:
         if scenario not in OBSERVATIONS:
             cmds = get_cmds(scenario=scenario)
-            cmds_obs = cmds[cmds['tlmsid'] == 'OBS']
+            cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
             obsids = []
             for cmd in cmds_obs:
-                if cmd['params'] is None:
-                    _obsid = cmd['obsid']
+                if cmd["params"] is None:
+                    _obsid = cmd["obsid"]
                 else:
-                    _obsid = cmd['params']['obsid']
+                    _obsid = cmd["params"]["obsid"]
                 obsids.append(_obsid)
 
-            cmds_obs['obsid'] = obsids
+            cmds_obs["obsid"] = obsids
             OBSERVATIONS[scenario] = cmds_obs
         else:
             cmds_obs = OBSERVATIONS[scenario]
     else:
-        cmds_obs = cmds[cmds['tlmsid'] == 'OBS']
+        cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
 
     # Get observations in date range with padding
     # _some_ padding is necessary because start/stop are used to filter observations based on
     # obs_start, which can be more than 30 minutes after starcat_date. I was generous with padding.
-    i0, i1 = cmds_obs.find_date([(start - 7 * u.day).date,
-                                 (stop + 7 * u.day).date])
+    i0, i1 = cmds_obs.find_date([(start - 7 * u.day).date, (stop + 7 * u.day).date])
     cmds_obs = cmds_obs[i0:i1]
 
     if starcat_date is not None:
-        cmds_obs = cmds_obs[cmds_obs['starcat_date'] == starcat_date]
+        cmds_obs = cmds_obs[cmds_obs["starcat_date"] == starcat_date]
         if len(cmds_obs) == 0:
-            raise ValueError(f'No matching observations for {starcat_date=}')
+            raise ValueError(f"No matching observations for {starcat_date=}")
 
     if obsid is not None:
-        cmds_obs = cmds_obs[cmds_obs['obsid'] == obsid]
+        cmds_obs = cmds_obs[cmds_obs["obsid"] == obsid]
         if len(cmds_obs) == 0:
-            raise ValueError(f'No matching observations for {obsid=}')
+            raise ValueError(f"No matching observations for {obsid=}")
 
-    obss = [cmd['params'].copy() for cmd in cmds_obs]
+    obss = [cmd["params"].copy() for cmd in cmds_obs]
     for obs, cmd_obs in zip(obss, cmds_obs):
-        obs['source'] = cmd_obs['source']
+        obs["source"] = cmd_obs["source"]
 
     # Filter observations by date to include any observation that intersects
     # the date range.
     datestart = start.date
     datestop = stop.date
-    obss = [obs for obs in obss
-            if obs['obs_start'] <= datestop and obs['obs_stop'] >= datestart]
+    obss = [
+        obs
+        for obs in obss
+        if obs["obs_start"] <= datestop and obs["obs_stop"] >= datestart
+    ]
 
     return obss
 
@@ -521,15 +567,17 @@ def get_agasc_cone_fast(ra, dec, radius=1.5, date=None):
     ra_decs = get_ra_decs(agasc_file)
 
     if STARS_AGASC is None:
-        with tables.open_file(agasc_file, 'r') as h5:
+        with tables.open_file(agasc_file, "r") as h5:
             dat = h5.root.data[:]
-            cols = {'AGASC_ID': dat['AGASC_ID'],
-                    'RA': dat['RA'],
-                    'DEC': dat['DEC'],
-                    'PM_RA': dat['PM_RA'],
-                    'PM_DEC': dat['PM_DEC'],
-                    'EPOCH': dat['EPOCH'],
-                    'MAG_ACA': dat['MAG_ACA']}
+            cols = {
+                "AGASC_ID": dat["AGASC_ID"],
+                "RA": dat["RA"],
+                "DEC": dat["DEC"],
+                "PM_RA": dat["PM_RA"],
+                "PM_DEC": dat["PM_DEC"],
+                "EPOCH": dat["EPOCH"],
+                "MAG_ACA": dat["MAG_ACA"],
+            }
             STARS_AGASC = Table(cols)
             del dat  # Explicitly delete to free memory (?)
 

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -2,22 +2,21 @@
 This module provides the functions for dynamically determining Chandra commanded states
 based entirely on known history of commands.
 """
-import contextlib
-import re
 import collections
-import itertools
+import contextlib
 import inspect
+import itertools
+import re
 
-import numpy as np
-
-from astropy.table import Table, Column
 import astropy.units as u
-
+import Chandra.Maneuver
+import numpy as np
+import Ska.Sun
+from astropy.table import Column, Table
 from Chandra.Time import DateTime, date2secs, secs2date
 from cxotime import CxoTime
-import Chandra.Maneuver
 from Quaternion import Quat
-import Ska.Sun
+
 from . import commands
 
 # Registry of Transition classes with state transition name as key.  A state transition
@@ -1831,6 +1830,7 @@ def get_chandra_states(main_args=None):
     to stdout or a file.
     """
     import argparse
+
     from astropy.io import ascii
 
     descr = (

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -31,21 +31,46 @@ TRANSITION_CLASSES = set()
 STATE_KEYS = []
 
 # Quaternion componenent names
-QUAT_COMPS = ['q1', 'q2', 'q3', 'q4']
+QUAT_COMPS = ["q1", "q2", "q3", "q4"]
 
 # State keys for PCAD-related transitions.  If *any* of these are requested then
 # *all* of them need to be processed to get the correct answer.
-PCAD_STATE_KEYS = (QUAT_COMPS
-                   + ['targ_' + qc for qc in QUAT_COMPS]
-                   + ['ra', 'dec', 'roll']
-                   + ['auto_npnt', 'pcad_mode', 'pitch', 'off_nom_roll'])
+PCAD_STATE_KEYS = (
+    QUAT_COMPS
+    + ["targ_" + qc for qc in QUAT_COMPS]
+    + ["ra", "dec", "roll"]
+    + ["auto_npnt", "pcad_mode", "pitch", "off_nom_roll"]
+)
 
 # Default state keys (mostly matches classic command states list)
-DEFAULT_STATE_KEYS = ('ccd_count', 'clocking', 'dec', 'dither', 'fep_count',
-                      'hetg', 'letg', 'obsid', 'off_nom_roll', 'pcad_mode', 'pitch', 'power_cmd',
-                      'q1', 'q2', 'q3', 'q4', 'ra', 'roll', 'si_mode', 'simfa_pos', 'simpos',
-                      'targ_q1', 'targ_q2', 'targ_q3', 'targ_q4',
-                      'vid_board')
+DEFAULT_STATE_KEYS = (
+    "ccd_count",
+    "clocking",
+    "dec",
+    "dither",
+    "fep_count",
+    "hetg",
+    "letg",
+    "obsid",
+    "off_nom_roll",
+    "pcad_mode",
+    "pitch",
+    "power_cmd",
+    "q1",
+    "q2",
+    "q3",
+    "q4",
+    "ra",
+    "roll",
+    "si_mode",
+    "simfa_pos",
+    "simpos",
+    "targ_q1",
+    "targ_q2",
+    "targ_q3",
+    "targ_q4",
+    "vid_board",
+)
 
 
 @contextlib.contextmanager
@@ -61,6 +86,7 @@ def disable_grating_move_duration():
 
 class NoTransitionsError(ValueError):
     """No transitions found within commands"""
+
     pass
 
 
@@ -68,7 +94,7 @@ class TransKeysSet(set):
     """Like set() but with more compact str output for table printing"""
 
     def __str__(self):
-        return ','.join(sorted(self))
+        return ",".join(sorted(self))
 
     def __and__(self, other):
         return TransKeysSet(super(TransKeysSet, self).__and__(other))
@@ -97,17 +123,19 @@ class StateDict(dict):
 # Transition base classes
 ###################################################################
 
+
 class TransitionMeta(type):
     """
     Metaclass that adds the class to the TRANSITIONS dict (keyed by state_key),
     the TRANSITIONS_CLASSES set, and makes the complete list of STATE_KEYS.
     """
+
     def __new__(mcls, name, bases, members):
         cls = super(TransitionMeta, mcls).__new__(mcls, name, bases, members)
 
         # Register transition classes that have a `state_keys` (base classes do
         # not have this attribute set).
-        if hasattr(cls, 'state_keys'):
+        if hasattr(cls, "state_keys"):
             for state_key in cls.state_keys:
                 if state_key not in STATE_KEYS:
                     STATE_KEYS.append(state_key)
@@ -124,6 +152,7 @@ class BaseTransition(object, metaclass=TransitionMeta):
     """
     Base transition class from which all actual transition classes are derived.
     """
+
     @classmethod
     def get_state_changing_commands(cls, cmds):
         """
@@ -154,16 +183,18 @@ class BaseTransition(object, metaclass=TransitionMeta):
         # Second do command_params.  Note could use `cmds[attr] == val`for "vectorized"
         # compare, but unrolling the loop here is more efficient since the CmdList class
         # would internally assemble a pure-Python version of the column first.
-        if hasattr(cls, 'command_params'):
+        if hasattr(cls, "command_params"):
             attrs_list = list(cls.command_params.keys())
-            vals_list = [val if isinstance(val, list) else [val]
-                         for val in cls.command_params.values()]
+            vals_list = [
+                val if isinstance(val, list) else [val]
+                for val in cls.command_params.values()
+            ]
             ok = np.ones(len(out_cmds), dtype=bool)
             for idx, cmd in enumerate(out_cmds):
                 for attr, vals in zip(attrs_list, vals_list):
                     ok_idx = False
                     for val in vals:
-                        ok_idx |= (cmd[attr] == val)
+                        ok_idx |= cmd[attr] == val
                     ok[idx] = ok[idx] & ok_idx
 
             out_cmds = out_cmds[ok]
@@ -176,43 +207,48 @@ class BaseTransition(object, metaclass=TransitionMeta):
         Put some useful information at the top of docstring.
         """
         docs = []
-        docs.append('*State keys*: ' + ', '.join(cls.state_keys))
+        docs.append("*State keys*: " + ", ".join(cls.state_keys))
 
-        if hasattr(cls, 'command_attributes'):
+        if hasattr(cls, "command_attributes"):
             cmd_attrs = []
             for key, val in cls.command_attributes.items():
-                cmd_attrs.append('{}={}'.format(key, val))
+                cmd_attrs.append("{}={}".format(key, val))
 
-            if hasattr(cls, 'command_params'):
+            if hasattr(cls, "command_params"):
                 keys_list = list(cls.command_params.keys())
-                vals_list = [val if isinstance(val, list) else [val]
-                             for val in cls.command_params.values()]
+                vals_list = [
+                    val if isinstance(val, list) else [val]
+                    for val in cls.command_params.values()
+                ]
                 for key, vals in zip(keys_list, vals_list):
-                    valstr = ' or '.join(str(val) for val in vals)
-                    cmd_attrs.append('{}={}'.format(key, valstr))
+                    valstr = " or ".join(str(val) for val in vals)
+                    cmd_attrs.append("{}={}".format(key, valstr))
 
-            docs.append('')
-            docs.append('*Commands*: ' + ', '.join(cmd_attrs))
+            docs.append("")
+            docs.append("*Commands*: " + ", ".join(cmd_attrs))
 
         others = []
         for attr, val in cls.__dict__.items():
-            if (attr.startswith('_') or inspect.ismethod(val)
-                    or attr in ('state_keys', 'command_attributes', 'command_params')):
+            if (
+                attr.startswith("_")
+                or inspect.ismethod(val)
+                or attr in ("state_keys", "command_attributes", "command_params")
+            ):
                 continue
-            others.append('{}={}'.format(attr, val))
+            others.append("{}={}".format(attr, val))
         if others:
-            docs.append('')
-            docs.append('*Others*: ' + ', '.join(others))
+            docs.append("")
+            docs.append("*Others*: " + ", ".join(others))
 
         # Common 4-space indent
-        docs = ['    ' + doc for doc in docs]
+        docs = ["    " + doc for doc in docs]
 
         if cls.__doc__:
             # Get rid of initial new line and any trailing whitespace/newlines
-            docs.insert(0, cls.__doc__.lstrip('\n').rstrip())
-            docs.insert(1, '    ')
+            docs.insert(0, cls.__doc__.lstrip("\n").rstrip())
+            docs.insert(1, "    ")
 
-        cls.__doc__ = '\n'.join(docs)
+        cls.__doc__ = "\n".join(docs)
 
 
 class FixedTransition(BaseTransition):
@@ -225,6 +261,7 @@ class FixedTransition(BaseTransition):
     :param transition_key: single transition key or list of transition keys
     :param transition_val: single transition value or list of values
     """
+
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
         """
@@ -247,7 +284,7 @@ class FixedTransition(BaseTransition):
             attrs = [attrs]
 
         for cmd in state_cmds:
-            date = cmd['date']
+            date = cmd["date"]
             for val, attr in zip(vals, attrs):
                 transitions_dict[date][attr] = val
 
@@ -263,6 +300,7 @@ class ParamTransition(BaseTransition):
     :param transition_key: single transition key or list of transition keys
     :param cmd_param_key: command parameter name (str or list of str)
     """
+
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
         """
@@ -287,12 +325,12 @@ class ParamTransition(BaseTransition):
             names = [names]
 
         for cmd in state_cmds:
-            date = cmd['date']
-            cmd_idx = cmd['idx']
+            date = cmd["date"]
+            cmd_idx = cmd["idx"]
             if rev_pars_dict is None or cmd_idx == -1:
-                params = cmd['params']
+                params = cmd["params"]
             else:
-                params = dict(rev_pars_dict[cmd['idx']])
+                params = dict(rev_pars_dict[cmd["idx"]])
 
             for name, param_key in zip(names, param_keys):
                 transitions_dict[date][name] = params[param_key]
@@ -302,89 +340,101 @@ class ParamTransition(BaseTransition):
 # CCDM format and subformat transitions
 ###################################################################
 
+
 class Format1_Transition(FixedTransition):
     """Transition to telemetry format 1"""
-    command_attributes = {'tlmsid': 'CSELFMT1'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT1'
+
+    command_attributes = {"tlmsid": "CSELFMT1"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT1"
 
 
 class Format2_Transition(FixedTransition):
     """Transition to telemetry format 2"""
-    command_attributes = {'tlmsid': 'CSELFMT2'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT2'
+
+    command_attributes = {"tlmsid": "CSELFMT2"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT2"
 
 
 class Format3_Transition(FixedTransition):
     """Transition to telemetry format 3"""
-    command_attributes = {'tlmsid': 'CSELFMT3'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT3'
+
+    command_attributes = {"tlmsid": "CSELFMT3"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT3"
 
 
 class Format4_Transition(FixedTransition):
     """Transition to telemetry format 4"""
-    command_attributes = {'tlmsid': 'CSELFMT4'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT4'
+
+    command_attributes = {"tlmsid": "CSELFMT4"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT4"
 
 
 class Format5_Transition(FixedTransition):
     """Transition to telemetry format 5"""
-    command_attributes = {'tlmsid': 'CSELFMT5'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT5'
+
+    command_attributes = {"tlmsid": "CSELFMT5"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT5"
 
 
 class Format6_Transition(FixedTransition):
     """Transition to telemetry format 6"""
-    command_attributes = {'tlmsid': 'CSELFMT6'}
-    state_keys = ['format']
-    transition_key = 'format'
-    transition_val = 'FMT6'
+
+    command_attributes = {"tlmsid": "CSELFMT6"}
+    state_keys = ["format"]
+    transition_key = "format"
+    transition_val = "FMT6"
 
 
 class SubFormatEPS_Transition(FixedTransition):
     """Transition to telemetry EPS subformat"""
-    command_attributes = {'tlmsid': 'OFMTSEPS'}
-    state_keys = ['subformat']
-    transition_key = 'subformat'
-    transition_val = 'EPS'
+
+    command_attributes = {"tlmsid": "OFMTSEPS"}
+    state_keys = ["subformat"]
+    transition_key = "subformat"
+    transition_val = "EPS"
 
 
 class SubFormatNRM_Transition(FixedTransition):
     """Transition to telemetry NRM subformat"""
-    command_attributes = {'tlmsid': 'OFMTSNRM'}
-    state_keys = ['subformat']
-    transition_key = 'subformat'
-    transition_val = 'NORM'
+
+    command_attributes = {"tlmsid": "OFMTSNRM"}
+    state_keys = ["subformat"]
+    transition_key = "subformat"
+    transition_val = "NORM"
 
 
 class SubFormatPDG_Transition(FixedTransition):
     """Transition to telemetry PDG subformat"""
-    command_attributes = {'tlmsid': 'OFMTSPDG'}
-    state_keys = ['subformat']
-    transition_key = 'subformat'
-    transition_val = 'PDG'
+
+    command_attributes = {"tlmsid": "OFMTSPDG"}
+    state_keys = ["subformat"]
+    transition_key = "subformat"
+    transition_val = "PDG"
 
 
 class SubFormatSSR_Transition(FixedTransition):
     """Transition to telemetry SSR subformat"""
-    command_attributes = {'tlmsid': 'OFMTSSSR'}
-    state_keys = ['subformat']
-    transition_key = 'subformat'
-    transition_val = 'SSR'
+
+    command_attributes = {"tlmsid": "OFMTSSSR"}
+    state_keys = ["subformat"]
+    transition_key = "subformat"
+    transition_val = "SSR"
 
 
 ###################################################################
 # Mech transitions
 ###################################################################
+
 
 class MechMove(FixedTransition):
     """
@@ -405,6 +455,7 @@ class MechMove(FixedTransition):
     :param move_duration: duration of the move (astropy time Quantity)
     :param apply_move_duration: if True, apply the move duration to states
     """
+
     apply_move_duration = True
 
     @classmethod
@@ -430,16 +481,16 @@ class MechMove(FixedTransition):
             attrs = [attrs]
 
         for cmd in state_cmds:
-            date_start = CxoTime(cmd['date'])
+            date_start = CxoTime(cmd["date"])
             date_stop = date_start + move_duration
             for val, attr in zip(vals, attrs):
-                if attr == 'grating':
+                if attr == "grating":
                     transitions_dict[date_start.date][attr] = val
                 else:
                     # 'letg' or 'hetg' insert/retract status, include the move
                     # interval here
                     if cls.apply_move_duration:
-                        transitions_dict[date_start.date][attr] = val + '_MOVE'
+                        transitions_dict[date_start.date][attr] = val + "_MOVE"
                         transitions_dict[date_stop.date][attr] = val
                     else:
                         transitions_dict[date_start.date][attr] = val
@@ -447,128 +498,143 @@ class MechMove(FixedTransition):
 
 class HETG_INSR_Transition(MechMove):
     """HETG insertion"""
-    command_attributes = {'tlmsid': '4OHETGIN'}
-    state_keys = ['letg', 'hetg', 'grating']
-    transition_key = ['hetg', 'grating']
-    transition_val = ['INSR', 'HETG']
+
+    command_attributes = {"tlmsid": "4OHETGIN"}
+    state_keys = ["letg", "hetg", "grating"]
+    transition_key = ["hetg", "grating"]
+    transition_val = ["INSR", "HETG"]
     move_duration = 157 * u.s
 
 
 class HETG_RETR_Transition(MechMove):
     """HETG retraction"""
-    command_attributes = {'tlmsid': '4OHETGRE'}
-    state_keys = ['letg', 'hetg', 'grating']
-    transition_key = ['hetg', 'grating']
-    transition_val = ['RETR', 'NONE']
+
+    command_attributes = {"tlmsid": "4OHETGRE"}
+    state_keys = ["letg", "hetg", "grating"]
+    transition_key = ["hetg", "grating"]
+    transition_val = ["RETR", "NONE"]
     move_duration = 153 * u.s
 
 
 class LETG_INSR_Transition(MechMove):
     """LETG insertion"""
-    command_attributes = {'tlmsid': '4OLETGIN'}
-    state_keys = ['letg', 'hetg', 'grating']
-    transition_key = ['letg', 'grating']
-    transition_val = ['INSR', 'LETG']
+
+    command_attributes = {"tlmsid": "4OLETGIN"}
+    state_keys = ["letg", "hetg", "grating"]
+    transition_key = ["letg", "grating"]
+    transition_val = ["INSR", "LETG"]
     move_duration = 203 * u.s
 
 
 class LETG_RETR_Transition(MechMove):
     """LETG retraction"""
-    command_attributes = {'tlmsid': '4OLETGRE'}
-    state_keys = ['letg', 'hetg', 'grating']
-    transition_key = ['letg', 'grating']
-    transition_val = ['RETR', 'NONE']
+
+    command_attributes = {"tlmsid": "4OLETGRE"}
+    state_keys = ["letg", "hetg", "grating"]
+    transition_key = ["letg", "grating"]
+    transition_val = ["RETR", "NONE"]
     move_duration = 203 * u.s
 
 
 class SimTscTransition(ParamTransition):
     """SIM translating science compartment translation"""
-    command_attributes = {'type': 'SIMTRANS'}
-    state_keys = ['simpos']
-    transition_key = 'simpos'
-    cmd_param_key = 'pos'
+
+    command_attributes = {"type": "SIMTRANS"}
+    state_keys = ["simpos"]
+    transition_key = "simpos"
+    cmd_param_key = "pos"
 
 
 class SimFocusTransition(ParamTransition):
     """SIM focus assembly translation"""
-    command_attributes = {'type': 'SIMFOCUS'}
-    state_keys = ['simfa_pos']
-    transition_key = 'simfa_pos'
-    cmd_param_key = 'pos'
+
+    command_attributes = {"type": "SIMFOCUS"}
+    state_keys = ["simfa_pos"]
+    transition_key = "simfa_pos"
+    cmd_param_key = "pos"
 
 
 ###################################################################
 # OBC etc transitions
 ###################################################################
 
+
 class ObsidTransition(ParamTransition):
     """Obsid update"""
-    command_attributes = {'type': 'MP_OBSID'}
-    state_keys = ['obsid']
-    transition_key = 'obsid'
-    cmd_param_key = 'id'
+
+    command_attributes = {"type": "MP_OBSID"}
+    state_keys = ["obsid"]
+    transition_key = "obsid"
+    cmd_param_key = "id"
 
 
 class EclipseEntryTimerTransition(ParamTransition):
     """Eclipse entry timer update"""
-    command_attributes = {'tlmsid': 'EOECLETO'}
-    state_keys = ['eclipse_timer']
-    transition_key = 'eclipse_timer'
-    cmd_param_key = 'timecnt'
+
+    command_attributes = {"tlmsid": "EOECLETO"}
+    state_keys = ["eclipse_timer"]
+    transition_key = "eclipse_timer"
+    cmd_param_key = "timecnt"
 
 
 class EclipsePenumbraEntryTransition(FixedTransition):
     """Eclipse penumbra entry"""
-    command_attributes = {'type': 'ORBPOINT'}
-    command_params = {'event_type': ['PENTRY', 'LSPENTRY']}
-    state_keys = ['eclipse']
-    transition_key = 'eclipse'
-    transition_val = 'PENUMBRA'
+
+    command_attributes = {"type": "ORBPOINT"}
+    command_params = {"event_type": ["PENTRY", "LSPENTRY"]}
+    state_keys = ["eclipse"]
+    transition_key = "eclipse"
+    transition_val = "PENUMBRA"
 
 
 class EclipsePenumbraExitTransition(FixedTransition):
     """Eclipse penumbra exit"""
-    command_attributes = {'type': 'ORBPOINT'}
-    command_params = {'event_type': ['PEXIT', 'LSPEXIT']}
-    state_keys = ['eclipse']
-    transition_key = 'eclipse'
-    transition_val = 'DAY'
+
+    command_attributes = {"type": "ORBPOINT"}
+    command_params = {"event_type": ["PEXIT", "LSPEXIT"]}
+    state_keys = ["eclipse"]
+    transition_key = "eclipse"
+    transition_val = "DAY"
 
 
 class EclipseUmbraEntryTransition(FixedTransition):
     """Eclipse umbra entry"""
-    command_attributes = {'type': 'ORBPOINT'}
-    command_params = {'event_type': 'EONIGHT'}
-    state_keys = ['eclipse']
-    transition_key = 'eclipse'
-    transition_val = 'UMBRA'
+
+    command_attributes = {"type": "ORBPOINT"}
+    command_params = {"event_type": "EONIGHT"}
+    state_keys = ["eclipse"]
+    transition_key = "eclipse"
+    transition_val = "UMBRA"
 
 
 class EclipseUmbraExitTransition(FixedTransition):
     """Eclipse umbra exit"""
-    command_attributes = {'type': 'ORBPOINT'}
-    command_params = {'event_type': 'EODAY'}
-    state_keys = ['eclipse']
-    transition_key = 'eclipse'
-    transition_val = 'PENUMBRA'
+
+    command_attributes = {"type": "ORBPOINT"}
+    command_params = {"event_type": "EODAY"}
+    state_keys = ["eclipse"]
+    transition_key = "eclipse"
+    transition_val = "PENUMBRA"
 
 
 class SPMEnableTransition(FixedTransition):
     """Sun position monitor enable"""
-    command_attributes = {'tlmsid': 'AOFUNCEN'}
-    command_params = {'aopcadse': 30}
-    state_keys = ['sun_pos_mon']
-    transition_key = 'sun_pos_mon'
-    transition_val = 'ENAB'
+
+    command_attributes = {"tlmsid": "AOFUNCEN"}
+    command_params = {"aopcadse": 30}
+    state_keys = ["sun_pos_mon"]
+    transition_key = "sun_pos_mon"
+    transition_val = "ENAB"
 
 
 class SPMDisableTransition(FixedTransition):
     """Sun position monitor disable"""
-    command_attributes = {'tlmsid': 'AOFUNCDS'}
-    command_params = {'aopcadsd': 30}
-    state_keys = ['sun_pos_mon']
-    transition_key = 'sun_pos_mon'
-    transition_val = 'DISA'
+
+    command_attributes = {"tlmsid": "AOFUNCDS"}
+    command_params = {"aopcadsd": 30}
+    state_keys = ["sun_pos_mon"]
+    transition_key = "sun_pos_mon"
+    transition_val = "DISA"
 
 
 class SPMEclipseEnableTransition(BaseTransition):
@@ -580,11 +646,12 @@ class SPMEclipseEnableTransition(BaseTransition):
     Eclipse entry is event type ORBPOINT with TYPE=PENTRY or TYPE=LSPENTRY
     Eclipse exit is event type ORBPOINT with TYPE=PEXIT or TYPE=LSPEXIT
     """
+
     # Command attributes and params are just for docstring, but actual transition
     # command filtering in set_transitions is more complicated.
-    command_attributes = {'type': 'ORBPOINT'}
-    command_params = {'event_type': ['PEXIT', 'LSPEXIT']}
-    state_keys = ['sun_pos_mon']
+    command_attributes = {"type": "ORBPOINT"}
+    command_params = {"event_type": ["PEXIT", "LSPEXIT"]}
+    state_keys = ["sun_pos_mon"]
 
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
@@ -599,94 +666,118 @@ class SPMEclipseEnableTransition(BaseTransition):
         :returns: None
         """
         # Preselect only commands that might have an impact here.
-        ok = (cmds['tlmsid'] == 'EOESTECN') | (cmds['type'] == 'ORBPOINT')
+        ok = (cmds["tlmsid"] == "EOESTECN") | (cmds["type"] == "ORBPOINT")
         cmds = cmds[ok]
 
         connect_time = 0
         connect_flag = False
 
         for cmd in cmds:
-            if cmd['tlmsid'] == 'EOESTECN':
-                connect_time = DateTime(cmd['date']).secs
+            if cmd["tlmsid"] == "EOESTECN":
+                connect_time = DateTime(cmd["date"]).secs
 
-            elif cmd['type'] == 'ORBPOINT':
-                if cmd['event_type'] in ('PENTRY', 'LSPENTRY'):
-                    entry_time = DateTime(cmd['date']).secs
-                    connect_flag = (entry_time - connect_time < 125)
+            elif cmd["type"] == "ORBPOINT":
+                if cmd["event_type"] in ("PENTRY", "LSPENTRY"):
+                    entry_time = DateTime(cmd["date"]).secs
+                    connect_flag = entry_time - connect_time < 125
 
-                elif cmd['event_type'] in ('PEXIT', 'LSPEXIT') and connect_flag:
-                    scs33 = DateTime(cmd['date']) + 11 * 60 / 86400  # 11 minutes in days
-                    transitions_dict[scs33.date]['sun_pos_mon'] = 'ENAB'
+                elif cmd["event_type"] in ("PEXIT", "LSPEXIT") and connect_flag:
+                    scs33 = (
+                        DateTime(cmd["date"]) + 11 * 60 / 86400
+                    )  # 11 minutes in days
+                    transitions_dict[scs33.date]["sun_pos_mon"] = "ENAB"
                     connect_flag = False
 
 
 class SCS84EnableTransition(FixedTransition):
     """SCS-84 enable"""
-    command_attributes = {'tlmsid': 'COENASX'}
-    command_params = {'coenas1': 84}
-    state_keys = ['scs84']
-    transition_key = 'scs84'
-    transition_val = 'ENAB'
-    default_value = 'DISA'
+
+    command_attributes = {"tlmsid": "COENASX"}
+    command_params = {"coenas1": 84}
+    state_keys = ["scs84"]
+    transition_key = "scs84"
+    transition_val = "ENAB"
+    default_value = "DISA"
 
 
 class SCS84DisableTransition(FixedTransition):
     """SCS-84 disable"""
-    command_attributes = {'tlmsid': 'CODISASX'}
-    command_params = {'codisas1': 84}
-    state_keys = ['scs84']
-    transition_key = 'scs84'
-    transition_val = 'DISA'
+
+    command_attributes = {"tlmsid": "CODISASX"}
+    command_params = {"codisas1": 84}
+    state_keys = ["scs84"]
+    transition_key = "scs84"
+    transition_val = "DISA"
 
 
 class SCS98EnableTransition(FixedTransition):
     """SCS-98 enable"""
-    command_attributes = {'tlmsid': 'COENASX'}
-    command_params = {'coenas1': 98}
-    state_keys = ['scs98']
-    transition_key = 'scs98'
-    transition_val = 'ENAB'
+
+    command_attributes = {"tlmsid": "COENASX"}
+    command_params = {"coenas1": 98}
+    state_keys = ["scs98"]
+    transition_key = "scs98"
+    transition_val = "ENAB"
 
 
 class SCS98DisableTransition(FixedTransition):
     """SCS-98 disable"""
-    command_attributes = {'tlmsid': 'CODISASX'}
-    command_params = {'codisas1': 98}
-    state_keys = ['scs98']
-    transition_key = 'scs98'
-    transition_val = 'DISA'
+
+    command_attributes = {"tlmsid": "CODISASX"}
+    command_params = {"codisas1": 98}
+    state_keys = ["scs98"]
+    transition_key = "scs98"
+    transition_val = "DISA"
 
 
 class RadmonEnableTransition(FixedTransition):
     """RADMON enable"""
-    command_attributes = {'tlmsid': 'OORMPEN'}
-    state_keys = ['radmon']
-    transition_key = 'radmon'
-    transition_val = 'ENAB'
+
+    command_attributes = {"tlmsid": "OORMPEN"}
+    state_keys = ["radmon"]
+    transition_key = "radmon"
+    transition_val = "ENAB"
 
 
 class RadmonDisableTransition(FixedTransition):
     """RADMON disable"""
-    command_attributes = {'tlmsid': 'OORMPDS'}
-    state_keys = ['radmon']
-    transition_key = 'radmon'
-    transition_val = 'DISA'
+
+    command_attributes = {"tlmsid": "OORMPDS"}
+    state_keys = ["radmon"]
+    transition_key = "radmon"
+    transition_val = "DISA"
 
 
 class OrbitPointTransition(ParamTransition):
     """Orbit point state based on backstop ephemeris entries"""
-    command_attributes = {'type': 'ORBPOINT'}
-    state_keys = ['orbit_point']
-    transition_key = 'orbit_point'
-    cmd_param_key = 'event_type'
+
+    command_attributes = {"type": "ORBPOINT"}
+    state_keys = ["orbit_point"]
+    transition_key = "orbit_point"
+    cmd_param_key = "event_type"
 
 
 class EphemerisTransition(ParamTransition):
     """On-board ephemeris update values"""
-    command_attributes = {'tlmsid': 'AOEPHUPS'}
-    state_keys = ['aoephem1', 'aoephem2', 'aoratio', 'aoargper', 'aoeccent',
-                  'ao1minus', 'ao1plus', 'aomotion', 'aoiterat', 'aoorbang',
-                  'aoperige', 'aoascend', 'aosini', 'aoslr', 'aosqrtmu']
+
+    command_attributes = {"tlmsid": "AOEPHUPS"}
+    state_keys = [
+        "aoephem1",
+        "aoephem2",
+        "aoratio",
+        "aoargper",
+        "aoeccent",
+        "ao1minus",
+        "ao1plus",
+        "aomotion",
+        "aoiterat",
+        "aoorbang",
+        "aoperige",
+        "aoascend",
+        "aosini",
+        "aoslr",
+        "aosqrtmu",
+    ]
     transition_key = state_keys
     cmd_param_key = state_keys
 
@@ -696,8 +787,9 @@ class EphemerisUpdateTransition(BaseTransition):
     On-board ephemeris update date.  Mostly useful for the FOT to assist in backstop
     processing.
     """
-    command_attributes = {'tlmsid': 'AOEPHUPS'}
-    state_keys = ['ephem_update']
+
+    command_attributes = {"tlmsid": "AOEPHUPS"}
+    state_keys = ["ephem_update"]
 
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
@@ -714,11 +806,12 @@ class EphemerisUpdateTransition(BaseTransition):
         state_cmds = cls.get_state_changing_commands(cmds)
 
         for cmd in state_cmds:
-            date = cmd['date']
-            transitions_dict[date]['ephem_update'] = date[:8]
+            date = cmd["date"]
+            transitions_dict[date]["ephem_update"] = date[:8]
 
 
 ###################################################################
+
 
 class SunVectorTransition(BaseTransition):
     """
@@ -726,6 +819,7 @@ class SunVectorTransition(BaseTransition):
     roll during NPNT.  These are function transitions which check to see that
     ``pcad_mode == 'NPNT'`` before changing the pitch / off_nominal_roll.
     """
+
     state_keys = PCAD_STATE_KEYS
 
     @classmethod
@@ -752,7 +846,7 @@ class SunVectorTransition(BaseTransition):
         # Now with the dates, finally make all the transition dicts which will
         # call `update_pitch_state` during state processing.
         for date in dates:
-            transitions_dict[date]['update_sun_vector'] = cls.update_sun_vector_state
+            transitions_dict[date]["update_sun_vector"] = cls.update_sun_vector_state
 
     @classmethod
     def update_sun_vector_state(cls, date, transitions, state, idx):
@@ -765,34 +859,42 @@ class SunVectorTransition(BaseTransition):
         :param state: current state (dict)
         :param idx: current index into transitions
         """
-        if state['pcad_mode'] == 'NPNT':
+        if state["pcad_mode"] == "NPNT":
             q_att = Quat([state[qc] for qc in QUAT_COMPS])
-            state['pitch'] = Ska.Sun.pitch(q_att.ra, q_att.dec, date)
-            state['off_nom_roll'] = Ska.Sun.off_nominal_roll(q_att, date)
+            state["pitch"] = Ska.Sun.pitch(q_att.ra, q_att.dec, date)
+            state["off_nom_roll"] = Ska.Sun.off_nominal_roll(q_att, date)
 
 
 class DitherEnableTransition(FixedTransition):
     """Dither enable"""
-    command_attributes = {'tlmsid': 'AOENDITH'}
-    state_keys = ['dither']
-    transition_key = 'dither'
-    transition_val = 'ENAB'
+
+    command_attributes = {"tlmsid": "AOENDITH"}
+    state_keys = ["dither"]
+    transition_key = "dither"
+    transition_val = "ENAB"
 
 
 class DitherDisableTransition(FixedTransition):
     """Dither disable"""
-    command_attributes = {'tlmsid': 'AODSDITH'}
-    state_keys = ['dither']
-    transition_key = 'dither'
-    transition_val = 'DISA'
+
+    command_attributes = {"tlmsid": "AODSDITH"}
+    state_keys = ["dither"]
+    transition_key = "dither"
+    transition_val = "DISA"
 
 
 class DitherParamsTransition(BaseTransition):
     """Dither parameters"""
-    command_attributes = {'tlmsid': 'AODITPAR'}
-    state_keys = ['dither_phase_pitch', 'dither_phase_yaw',
-                  'dither_ampl_pitch', 'dither_ampl_yaw',
-                  'dither_period_pitch', 'dither_period_yaw']
+
+    command_attributes = {"tlmsid": "AODITPAR"}
+    state_keys = [
+        "dither_phase_pitch",
+        "dither_phase_yaw",
+        "dither_ampl_pitch",
+        "dither_ampl_yaw",
+        "dither_period_pitch",
+        "dither_period_yaw",
+    ]
 
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
@@ -809,50 +911,57 @@ class DitherParamsTransition(BaseTransition):
         state_cmds = cls.get_state_changing_commands(cmds)
 
         for cmd in state_cmds:
-            dither = {'dither_phase_pitch': np.degrees(cmd['angp']),
-                      'dither_phase_yaw': np.degrees(cmd['angy']),
-                      'dither_ampl_pitch': np.degrees(cmd['coefp']) * 3600,
-                      'dither_ampl_yaw': np.degrees(cmd['coefy']) * 3600,
-                      'dither_period_pitch': 2 * np.pi / cmd['ratep'],
-                      'dither_period_yaw': 2 * np.pi / cmd['ratey']}
-            transitions_dict[cmd['date']].update(dither)
+            dither = {
+                "dither_phase_pitch": np.degrees(cmd["angp"]),
+                "dither_phase_yaw": np.degrees(cmd["angy"]),
+                "dither_ampl_pitch": np.degrees(cmd["coefp"]) * 3600,
+                "dither_ampl_yaw": np.degrees(cmd["coefy"]) * 3600,
+                "dither_period_pitch": 2 * np.pi / cmd["ratep"],
+                "dither_period_yaw": 2 * np.pi / cmd["ratey"],
+            }
+            transitions_dict[cmd["date"]].update(dither)
 
 
 class NMM_Transition(FixedTransition):
     """Transition to Normal Maneuver Mode"""
-    command_attributes = {'tlmsid': 'AONMMODE'}
+
+    command_attributes = {"tlmsid": "AONMMODE"}
     state_keys = PCAD_STATE_KEYS
-    transition_key = 'pcad_mode'
-    transition_val = 'NMAN'
+    transition_key = "pcad_mode"
+    transition_val = "NMAN"
 
 
 class NPM_Transition(FixedTransition):
     """Transition to Normal Point Mode"""
-    command_attributes = {'tlmsid': 'AONPMODE'}
+
+    command_attributes = {"tlmsid": "AONPMODE"}
     state_keys = PCAD_STATE_KEYS
-    transition_key = 'pcad_mode'
-    transition_val = 'NPNT'
+    transition_key = "pcad_mode"
+    transition_val = "NPNT"
 
 
 class AutoNPMEnableTransition(FixedTransition):
     """Enable automatic transition to Normal Point Mode"""
-    command_attributes = {'tlmsid': 'AONM2NPE'}
+
+    command_attributes = {"tlmsid": "AONM2NPE"}
     state_keys = PCAD_STATE_KEYS
-    transition_key = 'auto_npnt'
-    transition_val = 'ENAB'
+    transition_key = "auto_npnt"
+    transition_val = "ENAB"
 
 
 class AutoNPMDisableTransition(FixedTransition):
     """Disable automatic transition to Normal Point Mode"""
-    command_attributes = {'tlmsid': 'AONM2NPD'}
+
+    command_attributes = {"tlmsid": "AONM2NPD"}
     state_keys = PCAD_STATE_KEYS
-    transition_key = 'auto_npnt'
-    transition_val = 'DISA'
+    transition_key = "auto_npnt"
+    transition_val = "DISA"
 
 
 class TargQuatTransition(BaseTransition):
     """Commanded target quaternion"""
-    command_attributes = {'type': 'MP_TARGQUAT'}
+
+    command_attributes = {"type": "MP_TARGQUAT"}
     state_keys = PCAD_STATE_KEYS
 
     @classmethod
@@ -870,9 +979,9 @@ class TargQuatTransition(BaseTransition):
         state_cmds = cls.get_state_changing_commands(cmds)
 
         for cmd in state_cmds:
-            transition = transitions[cmd['date']]
-            for qc in ('q1', 'q2', 'q3', 'q4'):
-                transition['targ_' + qc] = cmd[qc]
+            transition = transitions[cmd["date"]]
+            for qc in ("q1", "q2", "q3", "q4"):
+                transition["targ_" + qc] = cmd[qc]
 
 
 class ManeuverTransition(BaseTransition):
@@ -882,7 +991,8 @@ class ManeuverTransition(BaseTransition):
     perform attitude quaternion updated accordingly.  At the end of the maneuver it
     schedules a NPM transition if ``auto_npnt`` is enabled.
     """
-    command_attributes = {'tlmsid': 'AOMANUVR'}
+
+    command_attributes = {"tlmsid": "AOMANUVR"}
     state_keys = PCAD_STATE_KEYS
 
     @classmethod
@@ -890,7 +1000,7 @@ class ManeuverTransition(BaseTransition):
         state_cmds = cls.get_state_changing_commands(cmds)
 
         for cmd in state_cmds:
-            transitions[cmd['date']]['maneuver_transition'] = cls.callback
+            transitions[cmd["date"]]["maneuver_transition"] = cls.callback
 
     @classmethod
     def callback(cls, date, transitions, state, idx):
@@ -907,8 +1017,8 @@ class ManeuverTransition(BaseTransition):
 
         # If auto-transition to NPM after manvr is enabled (this is
         # normally the case) then back to NPNT at end of maneuver
-        if state['auto_npnt'] == 'ENAB':
-            transition = {'date': end_manvr_date, 'pcad_mode': 'NPNT'}
+        if state["auto_npnt"] == "ENAB":
+            transition = {"date": end_manvr_date, "pcad_mode": "NPNT"}
             add_transition(transitions, idx, transition)
 
     @classmethod
@@ -918,7 +1028,7 @@ class ManeuverTransition(BaseTransition):
         called by the ManeuverTransition and NormalSunTransition classes.
         """
         # Get the current target attitude state
-        targ_att = [state['targ_' + qc] for qc in QUAT_COMPS]
+        targ_att = [state["targ_" + qc] for qc in QUAT_COMPS]
 
         # Check that target attitude is defined. If start time is between
         # AOUPTARQ and AOMANUVR command then this will happen. In this case just
@@ -929,23 +1039,27 @@ class ManeuverTransition(BaseTransition):
 
         # Deal with startup transient where spacecraft attitude is not known.
         # In this case first maneuver is a bogus null maneuver.
-        if state['q1'] is None:
+        if state["q1"] is None:
             for qc in QUAT_COMPS:
-                state[qc] = state['targ_' + qc]
+                state[qc] = state["targ_" + qc]
 
         # Get current spacecraft attitude
         curr_att = [state[qc] for qc in QUAT_COMPS]
 
         # Get attitudes for the maneuver at about 5-minute intervals.
-        atts = Chandra.Maneuver.attitudes(curr_att, targ_att,
-                                          tstart=DateTime(date).secs)
+        atts = Chandra.Maneuver.attitudes(
+            curr_att, targ_att, tstart=DateTime(date).secs
+        )
 
         # Compute pitch and off-nominal roll at the midpoint of each interval, except
         # also include the exact last attitude.
-        pitches = np.hstack([(atts[:-1].pitch + atts[1:].pitch) / 2,
-                             atts[-1].pitch])
-        off_nom_rolls = np.hstack([(atts[:-1].off_nom_roll + atts[1:].off_nom_roll) / 2,
-                                   atts[-1].off_nom_roll])
+        pitches = np.hstack([(atts[:-1].pitch + atts[1:].pitch) / 2, atts[-1].pitch])
+        off_nom_rolls = np.hstack(
+            [
+                (atts[:-1].off_nom_roll + atts[1:].off_nom_roll) / 2,
+                atts[-1].off_nom_roll,
+            ]
+        )
 
         # Add transitions for each bit of the maneuver.  Note that this sets the attitude
         # (q1..q4) at the *beginning* of each state, while setting pitch and
@@ -954,16 +1068,16 @@ class ManeuverTransition(BaseTransition):
         # would probably be better to have the midpoint attitude.
         for att, pitch, off_nom_roll in zip(atts, pitches, off_nom_rolls):
             date = DateTime(att.time).date
-            transition = {'date': date}
+            transition = {"date": date}
             for qc in QUAT_COMPS:
                 transition[qc] = att[qc]
-            transition['pitch'] = pitch
-            transition['off_nom_roll'] = off_nom_roll
+            transition["pitch"] = pitch
+            transition["off_nom_roll"] = off_nom_roll
 
             q_att = Quat([att[x] for x in QUAT_COMPS])
-            transition['ra'] = q_att.ra
-            transition['dec'] = q_att.dec
-            transition['roll'] = q_att.roll
+            transition["ra"] = q_att.ra
+            transition["dec"] = q_att.dec
+            transition["roll"] = q_att.roll
 
             add_transition(transitions, idx, transition)
 
@@ -976,7 +1090,8 @@ class NormalSunTransition(ManeuverTransition):
     to a normal sun pointed attitude (based on a pure-pitch maneuver from
     current attitude).  It also changes ``pcad_mode`` to NSUN.
     """
-    command_attributes = {'tlmsid': 'AONSMSAF'}
+
+    command_attributes = {"tlmsid": "AONSMSAF"}
     state_keys = PCAD_STATE_KEYS
 
     @classmethod
@@ -987,13 +1102,13 @@ class NormalSunTransition(ManeuverTransition):
         attitude.  It then calls the parent method to add the actual maneuver.
         """
         # Transition to NSUN
-        state['pcad_mode'] = 'NSUN'
+        state["pcad_mode"] = "NSUN"
 
         # Setup for maneuver to sun-pointed attitude from current att
         curr_att = [state[qc] for qc in QUAT_COMPS]
         targ_att = Chandra.Maneuver.NSM_attitude(curr_att, date)
         for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
-            state['targ_' + qc] = targ_q
+            state["targ_" + qc] = targ_q
 
         # Do the maneuver
         cls.add_manvr_transitions(date, transitions, state, idx)
@@ -1020,42 +1135,44 @@ def decode_power(mnem):
     :param mnem: power command string
 
     """
-    fep_info = {'fep_count': 0,
-                'ccd_count': 0,
-                'feps': '',
-                'ccds': '',
-                'vid_board': 1,
-                'clocking': 0}
+    fep_info = {
+        "fep_count": 0,
+        "ccd_count": 0,
+        "feps": "",
+        "ccds": "",
+        "vid_board": 1,
+        "clocking": 0,
+    }
 
     # Special case WSPOW000XX to turn off vid_board
-    if mnem.startswith('WSPOW000'):
-        fep_info['vid_board'] = 0
+    if mnem.startswith("WSPOW000"):
+        fep_info["vid_board"] = 0
 
     # the hex for the commanding is after the WSPOW
     powstr = mnem[5:]
-    if (len(powstr) != 5):
+    if len(powstr) != 5:
         raise ValueError("%s in unexpected format" % mnem)
 
     # convert the hex to decimal and "&" it with 63 (binary 111111)
     fepkey = int(powstr, 16) & 63
     # count the true binary bits
     for bit in range(0, 6):
-        if (fepkey & (1 << bit)):
-            fep_info['fep_count'] = fep_info['fep_count'] + 1
-            fep_info['feps'] = fep_info['feps'] + str(bit) + ' '
+        if fepkey & (1 << bit):
+            fep_info["fep_count"] = fep_info["fep_count"] + 1
+            fep_info["feps"] = fep_info["feps"] + str(bit) + " "
 
     # convert the hex to decimal and right shift by 8 places
     vidkey = int(powstr, 16) >> 8
 
     # count the true bits
     for bit in range(0, 10):
-        if (vidkey & (1 << bit)):
-            fep_info['ccd_count'] = fep_info['ccd_count'] + 1
+        if vidkey & (1 << bit):
+            fep_info["ccd_count"] = fep_info["ccd_count"] + 1
             # position indicates I or S chip
-            if (bit < 4):
-                fep_info['ccds'] = fep_info['ccds'] + 'I' + str(bit) + ' '
+            if bit < 4:
+                fep_info["ccds"] = fep_info["ccds"] + "I" + str(bit) + " "
             else:
-                fep_info['ccds'] = fep_info['ccds'] + 'S' + str(bit - 4) + ' '
+                fep_info["ccds"] = fep_info["ccds"] + "S" + str(bit - 4) + " "
 
     return fep_info
 
@@ -1064,8 +1181,16 @@ class ACISTransition(BaseTransition):
     """
     Implement transitions for ACIS states.
     """
-    command_attributes = {'type': 'ACISPKT'}
-    state_keys = ['clocking', 'power_cmd', 'vid_board', 'fep_count', 'si_mode', 'ccd_count']
+
+    command_attributes = {"type": "ACISPKT"}
+    state_keys = [
+        "clocking",
+        "power_cmd",
+        "vid_board",
+        "fep_count",
+        "si_mode",
+        "ccd_count",
+    ]
 
     @classmethod
     def set_transitions(cls, transitions, cmds, start, stop):
@@ -1081,42 +1206,43 @@ class ACISTransition(BaseTransition):
         """
         state_cmds = cls.get_state_changing_commands(cmds)
         for cmd in state_cmds:
-            tlmsid = cmd['tlmsid']
-            date = cmd['date']
+            tlmsid = cmd["tlmsid"]
+            date = cmd["date"]
 
-            if tlmsid.startswith('WSPOW'):
+            if tlmsid.startswith("WSPOW"):
                 pwr = decode_power(tlmsid)
-                transitions[date].update(fep_count=pwr['fep_count'],
-                                         ccd_count=pwr['ccd_count'],
-                                         vid_board=pwr['vid_board'],
-                                         clocking=pwr['clocking'],
-                                         power_cmd=tlmsid)
+                transitions[date].update(
+                    fep_count=pwr["fep_count"],
+                    ccd_count=pwr["ccd_count"],
+                    vid_board=pwr["vid_board"],
+                    clocking=pwr["clocking"],
+                    power_cmd=tlmsid,
+                )
 
-            elif tlmsid in ('XCZ0000005', 'XTZ0000005'):
+            elif tlmsid in ("XCZ0000005", "XTZ0000005"):
                 transitions[date].update(clocking=1, power_cmd=tlmsid)
 
-            elif tlmsid == 'WSVIDALLDN':
-                transitions[date].update(vid_board=0, ccd_count=0,
-                                         power_cmd=tlmsid)
+            elif tlmsid == "WSVIDALLDN":
+                transitions[date].update(vid_board=0, ccd_count=0, power_cmd=tlmsid)
 
-            elif tlmsid == 'AA00000000':
+            elif tlmsid == "AA00000000":
                 transitions[date].update(clocking=0, power_cmd=tlmsid)
 
-            elif tlmsid == 'WSFEPALLUP':
+            elif tlmsid == "WSFEPALLUP":
                 transitions[date].update(fep_count=6, power_cmd=tlmsid)
 
-            elif tlmsid.startswith('WC'):
-                transitions[date].update(si_mode='CC_' + tlmsid[2:7])
+            elif tlmsid.startswith("WC"):
+                transitions[date].update(si_mode="CC_" + tlmsid[2:7])
 
             # Two special-case raw-mode SI modes (https://github.com/sot/cmd_states/issues/23)
-            elif tlmsid == 'WT000B5024':
-                transitions[date].update(si_mode='TN_000B4')
+            elif tlmsid == "WT000B5024":
+                transitions[date].update(si_mode="TN_000B4")
 
-            elif tlmsid == 'WT000B7024':
-                transitions[date].update(si_mode='TN_000B6')
+            elif tlmsid == "WT000B7024":
+                transitions[date].update(si_mode="TN_000B6")
 
-            elif tlmsid.startswith('WT'):
-                transitions[date].update(si_mode='TE_' + tlmsid[2:7])
+            elif tlmsid.startswith("WT"):
+                transitions[date].update(si_mode="TE_" + tlmsid[2:7])
 
 
 class ACISFP_SetPointTransition(BaseTransition):
@@ -1126,8 +1252,9 @@ class ACISFP_SetPointTransition(BaseTransition):
     Looks for ACISPKT commands with TLMSID like ``WSFTNEG<number>``, where the
     ACIS FP setpoint temperature is ``-<number>``.
     """
-    command_attributes = {'type': 'ACISPKT'}
-    state_keys = ['acisfp_setpoint']
+
+    command_attributes = {"type": "ACISPKT"}
+    state_keys = ["acisfp_setpoint"]
     default_value = -121.0
 
     @classmethod
@@ -1144,19 +1271,20 @@ class ACISFP_SetPointTransition(BaseTransition):
         """
         state_cmds = cls.get_state_changing_commands(cmds)
         for cmd in state_cmds:
-            tlmsid = cmd['tlmsid']
-            date = cmd['date']
+            tlmsid = cmd["tlmsid"]
+            date = cmd["date"]
 
-            if tlmsid.startswith('WSFTNEG'):
-                match = re.search(r'(\d+)$', tlmsid)
+            if tlmsid.startswith("WSFTNEG"):
+                match = re.search(r"(\d+)$", tlmsid)
                 if not match:
-                    raise ValueError(f'unable to parse command {tlmsid}')
+                    raise ValueError(f"unable to parse command {tlmsid}")
                 transitions[date].update(acisfp_setpoint=-float(match.group(1)))
 
 
 ###################################################################
 # State transitions processing code
 ###################################################################
+
 
 def get_transition_classes(state_keys=None):
     """
@@ -1168,9 +1296,13 @@ def get_transition_classes(state_keys=None):
     elif state_keys is None:
         state_keys = DEFAULT_STATE_KEYS
 
-    trans_classes = set(itertools.chain.from_iterable(
-        classes for state_key, classes in TRANSITIONS.items()
-        if state_key in state_keys))
+    trans_classes = set(
+        itertools.chain.from_iterable(
+            classes
+            for state_key, classes in TRANSITIONS.items()
+            if state_key in state_keys
+        )
+    )
 
     return trans_classes
 
@@ -1200,9 +1332,9 @@ def get_transitions_list(cmds, state_keys, start, stop, continuity=None):
     # then apply those.  These would be transitions that occur after the the
     # continuity time, e.g. in the case continuity in the middle of a maneuver
     # where we need the remaining attitude and pcad_mode transitions.
-    if continuity is not None and '__transitions__' in continuity:
-        for transition in continuity['__transitions__']:
-            transitions_dict[transition['date']].update(transition)
+    if continuity is not None and "__transitions__" in continuity:
+        for transition in continuity["__transitions__"]:
+            transitions_dict[transition["date"]].update(transition)
 
     # Iterate through Transition classes which depend on or affect ``state_keys``
     # and ask each one to update ``transitions_dict`` in-place to include
@@ -1216,7 +1348,7 @@ def get_transitions_list(cmds, state_keys, start, stop, continuity=None):
     transitions_list = []
     for date in sorted(transitions_dict):
         transition = transitions_dict[date]
-        transition['date'] = date
+        transition["date"] = date
         transitions_list.append(transition)
 
     # In the rest of this module ``transitions`` is always this *list* of transitions.
@@ -1240,24 +1372,32 @@ def add_transition(transitions, idx, transition):
     """
     # Prevent adding command before current command since the command
     # interpreter is a one-pass process.
-    date = transition['date']
-    if date < transitions[idx]['date']:
-        raise ValueError('cannot insert transition prior to current command')
+    date = transition["date"]
+    if date < transitions[idx]["date"]:
+        raise ValueError("cannot insert transition prior to current command")
 
     # Insert transition at first place where new transition date is strictly
     # less than existing transition date.  This implementation is linear, and
     # could be improved, though in practice transitions are often inserted
     # close to the original.
     for ii in range(idx + 1, len(transitions)):
-        if date < transitions[ii]['date']:
+        if date < transitions[ii]["date"]:
             transitions.insert(ii, transition)
             break
     else:
         transitions.append(transition)
 
 
-def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=None,
-               reduce=True, merge_identical=False, scenario=None):
+def get_states(
+    start=None,
+    stop=None,
+    state_keys=None,
+    cmds=None,
+    continuity=None,
+    reduce=True,
+    merge_identical=False,
+    scenario=None,
+):
     """
     Get table of states corresponding to intervals when ``state_keys`` parameters
     are unchanged given the input commands ``cmds`` or ``start`` date.
@@ -1321,21 +1461,23 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
             raise ValueError("must supply either 'cmds' argument or 'start' argument")
         cmds = commands.get_cmds(start, stop, scenario=scenario)
         start = DateTime(start).date
-        stop = DateTime(stop or cmds[-1]['date']).date  # User-supplied stop or last command
+        stop = DateTime(
+            stop or cmds[-1]["date"]
+        ).date  # User-supplied stop or last command
     else:
-        start = cmds[0]['date'] if start is None else DateTime(start).date
-        stop = cmds[-1]['date'] if stop is None else DateTime(stop).date
+        start = cmds[0]["date"] if start is None else DateTime(start).date
+        stop = cmds[-1]["date"] if stop is None else DateTime(stop).date
 
     # Get initial state at start of commands
     if continuity is None:
         try:
             continuity = get_continuity(start, state_keys, scenario=scenario)
         except ValueError as exc:
-            if 'did not find transitions' in str(exc):
+            if "did not find transitions" in str(exc):
                 raise ValueError(
-                    f'no continuity found for {start=}. Need to have state '
+                    f"no continuity found for {start=}. Need to have state "
                     f'transitions following first command at {cmds[0]["date"]} '
-                    'so use a later start date.'
+                    "so use a later start date."
                 )
             else:
                 raise
@@ -1370,7 +1512,7 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
     continuity_transitions = []
 
     for idx, transition in enumerate(transitions):
-        date = transition['date']
+        date = transition["date"]
 
         # Some transition classes (e.g. Maneuver) might put in transitions that
         # extend past the stop time.  Add to a list for potential use in continuity.
@@ -1394,33 +1536,33 @@ def get_states(start=None, stop=None, state_keys=None, cmds=None, continuity=Non
                 # instead of directly updating the state.  The function might itself
                 # update the state or it might generate downstream transitions.
                 value(date, transitions, state, idx)
-            elif key != 'date':
+            elif key != "date":
                 # Normal case of just updating current state
                 state[key] = value
 
     # Make into an astropy Table and set up datestart/stop columns
     out = Table(rows=states, names=state_keys)
-    out.add_column(Column(datestarts, name='datestart'), 0)
+    out.add_column(Column(datestarts, name="datestart"), 0)
     # Add datestop which is just the previous datestart.
-    datestop = out['datestart'].copy()
-    datestop[:-1] = out['datestart'][1:]
+    datestop = out["datestart"].copy()
+    datestop[:-1] = out["datestart"][1:]
     # Final datestop far in the future
     datestop[-1] = stop
-    out.add_column(Column(datestop, name='datestop'), 1)
+    out.add_column(Column(datestop, name="datestop"), 1)
 
     # Add corresponding tstart, tstop
-    out.add_column(Column(date2secs(out['datestart']), name='tstart'), 2)
-    out.add_column(Column(date2secs(out['datestop']), name='tstop'), 3)
-    out['tstart'].info.format = '.3f'
-    out['tstop'].info.format = '.3f'
+    out.add_column(Column(date2secs(out["datestart"]), name="tstart"), 2)
+    out.add_column(Column(date2secs(out["datestop"]), name="tstop"), 3)
+    out["tstart"].info.format = ".3f"
+    out["tstop"].info.format = ".3f"
 
-    out['trans_keys'] = [st.trans_keys for st in states]
+    out["trans_keys"] = [st.trans_keys for st in states]
 
     if reduce:
         out = reduce_states(out, orig_state_keys, merge_identical)
 
     # See long comment where continuity_transitions is defined
-    out.meta['continuity_transitions'] = continuity_transitions
+    out.meta["continuity_transitions"] = continuity_transitions
 
     return out
 
@@ -1454,18 +1596,19 @@ def reduce_states(states, state_keys, merge_identical=False, all_keys=False):
     if not isinstance(states, Table):
         states = Table(states)
 
-    has_transitions = {state_key: np.zeros(len(states), dtype=bool)
-                       for state_key in state_keys}
+    has_transitions = {
+        state_key: np.zeros(len(states), dtype=bool) for state_key in state_keys
+    }
     has_transition = np.zeros(len(states), dtype=bool)
 
     for key in state_keys:
         # Get array where this key has transitions
         if merge_identical:
             col = states[key]
-            has_transitions[key][1:] |= (col[:-1] != col[1:])
+            has_transitions[key][1:] |= col[:-1] != col[1:]
         else:
             has_trans = has_transitions[key]
-            for ii, trans_keys in enumerate(states['trans_keys']):
+            for ii, trans_keys in enumerate(states["trans_keys"]):
                 has_trans[ii] = key in trans_keys
         has_transitions[key][0] = True
 
@@ -1476,12 +1619,12 @@ def reduce_states(states, state_keys, merge_identical=False, all_keys=False):
     if all_keys:
         out = states
     else:
-        out = states[['datestart', 'datestop', 'tstart', 'tstop'] + list(state_keys)]
+        out = states[["datestart", "datestop", "tstart", "tstop"] + list(state_keys)]
     out = out[has_transition]
 
-    for dt in ('date', 't'):
-        out[f'{dt}stop'][:-1] = out[f'{dt}start'][1:]
-        out[f'{dt}stop'][-1] = states[f'{dt}stop'][-1]
+    for dt in ("date", "t"):
+        out[f"{dt}stop"][:-1] = out[f"{dt}start"][1:]
+        out[f"{dt}stop"][-1] = states[f"{dt}stop"][-1]
 
     trans_keys_list = [TransKeysSet() for _ in range(len(out))]
     for key in state_keys:
@@ -1494,16 +1637,17 @@ def reduce_states(states, state_keys, merge_identical=False, all_keys=False):
 
     # First state trans_keys is the transition keys from continuity.  Reduce
     # this by set intersection to the output state_keys.
-    if 'trans_keys' in states.colnames:
-        trans_keys_list[0] = states['trans_keys'][0] & set(state_keys)
+    if "trans_keys" in states.colnames:
+        trans_keys_list[0] = states["trans_keys"][0] & set(state_keys)
 
-    out['trans_keys'] = trans_keys_list
+    out["trans_keys"] = trans_keys_list
 
     return out
 
 
-def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000),
-                   scenario=None):
+def get_continuity(
+    date=None, state_keys=None, lookbacks=(7, 30, 180, 1000), scenario=None
+):
     """
     Get the state and transition dates at ``date`` for ``state_keys``.
 
@@ -1569,24 +1713,32 @@ def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000),
                 # Note that we need to specify start and stop to ensure that the states span
                 # the required time range. Without this the time range of cmds is used which
                 # can give unexpected outputs if ``date``` is within a maneuver.
-                states = get_states(state_keys=state_key, cmds=cmds, start=start, stop=stop,
-                                    continuity={}, reduce=False, scenario=scenario)
+                states = get_states(
+                    state_keys=state_key,
+                    cmds=cmds,
+                    start=start,
+                    stop=stop,
+                    continuity={},
+                    reduce=False,
+                    scenario=scenario,
+                )
             except NoTransitionsError:
                 # No transitions within `cmds` for state_key, continue with other keys
                 continue
             else:
                 # get_states() sets this meta value with a list of transitions that were beyond
                 # the stop time and did not get processed.
-                continuity_transitions.extend(states.meta['continuity_transitions'])
+                continuity_transitions.extend(states.meta["continuity_transitions"])
 
-            colnames = set(states.colnames) - set(['datestart', 'datestop',
-                                                   'tstart', 'tstop', 'trans_keys'])
+            colnames = set(states.colnames) - set(
+                ["datestart", "datestop", "tstart", "tstop", "trans_keys"]
+            )
             for colname in colnames:
                 if states[colname][-1] is not None:
                     # Reduce states to only the desired state_key
                     red_states = reduce_states(states, [colname])
                     continuity[colname] = red_states[colname][-1]
-                    dates[colname] = red_states['datestart'][-1]
+                    dates[colname] = red_states["datestart"][-1]
 
         # If we have filled in continuity for every key then we're done.
         # Otherwise bump the lookback and try again.
@@ -1599,25 +1751,28 @@ def get_continuity(date=None, state_keys=None, lookbacks=(7, 30, 180, 1000),
         # Try to get defaults from transition classes
         for missing_key in missing_keys:
             for cls in get_transition_classes(missing_key):
-                if hasattr(cls, 'default_value'):
+                if hasattr(cls, "default_value"):
                     continuity[missing_key] = cls.default_value
-                    dates[missing_key] = 'DEFAULT'
+                    dates[missing_key] = "DEFAULT"
 
         # Try again...
         missing_keys = set(state_keys) - set(continuity)
         if missing_keys:
-            raise ValueError('did not find transitions for state key(s)'
-                             ' {} within {} days of {}.  Maybe adjust the `lookbacks` argument?'
-                             .format(missing_keys, lookbacks[-1], stop.date))
+            raise ValueError(
+                "did not find transitions for state key(s)"
+                " {} within {} days of {}.  Maybe adjust the `lookbacks` argument?".format(
+                    missing_keys, lookbacks[-1], stop.date
+                )
+            )
 
     # Finally reduce down to the state_keys the user requested
     continuity = {key: continuity[key] for key in state_keys}
     dates = {key: dates[key] for key in state_keys}
-    continuity['__dates__'] = dates
+    continuity["__dates__"] = dates
 
     # List of transitions needed to fully express continuity.  See long comment above.
     if continuity_transitions:
-        continuity['__transitions__'] = continuity_transitions
+        continuity["__transitions__"] = continuity_transitions
 
     return continuity
 
@@ -1631,17 +1786,18 @@ def interpolate_states(states, times):
     :returns: ``states`` view at ``times``
     """
     from astropy.table import Column
-    if not isinstance(times, np.ndarray) or times.dtype.kind != 'f':
+
+    if not isinstance(times, np.ndarray) or times.dtype.kind != "f":
         times = DateTime(times).secs
 
     try:
-        tstops = states['tstop']
+        tstops = states["tstop"]
     except (ValueError, KeyError):
-        tstops = date2secs(states['datestop'])
+        tstops = date2secs(states["datestop"])
 
     indexes = np.searchsorted(tstops, times)
     out = states[indexes]
-    out.add_column(Column(secs2date(times), name='date'), index=0)
+    out.add_column(Column(secs2date(times), name="date"), index=0)
 
     return out
 
@@ -1663,9 +1819,9 @@ def print_state_keys_transition_classes_docs():
         state_keys_classes[keys].append(cls)
 
     for keys in sorted(state_keys_classes):
-        print(', '.join('``{}``'.format(key) for key in keys))
+        print(", ".join("``{}``".format(key) for key in keys))
         for cls in sorted(state_keys_classes[keys], key=lambda cls: cls.__name__):
-            print('  - :class:`~{}.{}`'.format(cls.__module__, cls.__name__))
+            print("  - :class:`~{}.{}`".format(cls.__module__, cls.__name__))
         print()
 
 
@@ -1677,31 +1833,30 @@ def get_chandra_states(main_args=None):
     import argparse
     from astropy.io import ascii
 
-    descr = ('Ouput the Chandra commanded states over a date range '
-             'as a space-delimited ASCII table.')
+    descr = (
+        "Ouput the Chandra commanded states over a date range "
+        "as a space-delimited ASCII table."
+    )
     parser = argparse.ArgumentParser(description=descr)
-    parser.add_argument("--start",
-                        help="Start date (default=Now-10 days)")
-    parser.add_argument("--stop",
-                        help="Stop date (default=None)")
-    parser.add_argument("--state-keys",
-                        help="Comma-separated list of state keys")
-    parser.add_argument("--merge-identical",
-                        default=False,
-                        action='store_true',
-                        help="Merge adjacent states that have identical values "
-                        "(default=False)")
-    parser.add_argument("--outfile",
-                        help="Output file (default=stdout)")
+    parser.add_argument("--start", help="Start date (default=Now-10 days)")
+    parser.add_argument("--stop", help="Stop date (default=None)")
+    parser.add_argument("--state-keys", help="Comma-separated list of state keys")
+    parser.add_argument(
+        "--merge-identical",
+        default=False,
+        action="store_true",
+        help="Merge adjacent states that have identical values " "(default=False)",
+    )
+    parser.add_argument("--outfile", help="Output file (default=stdout)")
 
     opt = parser.parse_args(main_args)
 
     start = DateTime() - 10 if opt.start is None else DateTime(opt.start)
     stop = DateTime(opt.stop)
-    state_keys = opt.state_keys.split(',') if opt.state_keys else None
+    state_keys = opt.state_keys.split(",") if opt.state_keys else None
     states = get_states(start, stop, state_keys, merge_identical=opt.merge_identical)
-    del states['trans_keys']
-    del states['tstart']
-    del states['tstop']
+    del states["trans_keys"]
+    del states["tstart"]
+    del states["tstop"]
 
-    ascii.write(states, output=opt.outfile, format='fixed_width', delimiter='')
+    ascii.write(states, output=opt.outfile, format="fixed_width", delimiter="")

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1,30 +1,23 @@
-from pathlib import Path
 import os
+from pathlib import Path
 
-import numpy as np
-from astropy.table import Table, vstack
 import astropy.units as u
-import pytest
-
+import numpy as np
 # Use data file from parse_cm.test for get_cmds_from_backstop test.
 # This package is a dependency
 import parse_cm.tests
-from testr.test_helper import has_internet
+import pytest
+from astropy.table import Table, vstack
 from Chandra.Time import secs2date
 from cxotime import CxoTime
+from testr.test_helper import has_internet
 
 from kadi import commands
-from kadi.commands import (
-    core,
-    commands_v1,
-    commands_v2,
-    conf,
-    get_starcats,
-    get_observations,
-    get_starcats_as_table,
-)
-from kadi.scripts import update_cmds_v1, update_cmds_v2
+from kadi.commands import (commands_v1, commands_v2, conf, core,
+                           get_observations, get_starcats,
+                           get_starcats_as_table)
 from kadi.commands.command_sets import get_cmds_from_event
+from kadi.scripts import update_cmds_v1, update_cmds_v2
 
 HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -14,14 +14,21 @@ from Chandra.Time import secs2date
 from cxotime import CxoTime
 
 from kadi import commands
-from kadi.commands import (core, commands_v1, commands_v2, conf, get_starcats,
-                           get_observations, get_starcats_as_table)
+from kadi.commands import (
+    core,
+    commands_v1,
+    commands_v2,
+    conf,
+    get_starcats,
+    get_observations,
+    get_starcats_as_table,
+)
 from kadi.scripts import update_cmds_v1, update_cmds_v2
 from kadi.commands.command_sets import get_cmds_from_event
 
-HAS_MPDIR = Path(os.environ['SKA'], 'data', 'mpcrit1', 'mplogs', '2020').exists()
+HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()
-VERSIONS = ['1', '2'] if HAS_INTERNET else ['1']
+VERSIONS = ["1", "2"] if HAS_INTERNET else ["1"]
 
 
 @pytest.fixture(scope="module", params=VERSIONS)
@@ -32,100 +39,136 @@ def version(request):
 @pytest.fixture
 def version_env(monkeypatch, version):
     if version is None:
-        monkeypatch.delenv('KADI_COMMANDS_VERSION', raising=False)
+        monkeypatch.delenv("KADI_COMMANDS_VERSION", raising=False)
     else:
-        monkeypatch.setenv('KADI_COMMANDS_VERSION', version)
+        monkeypatch.setenv("KADI_COMMANDS_VERSION", version)
     return version
 
 
 @pytest.fixture(scope="module", autouse=True)
 def cmds_dir(tmp_path_factory):
-    with commands_v2.conf.set_temp('cache_loads_in_astropy_cache', True):
-        with commands_v2.conf.set_temp('clean_loads_dir', False):
-            cmds_dir = tmp_path_factory.mktemp('cmds_dir')
-            with commands_v2.conf.set_temp('commands_dir', str(cmds_dir)):
+    with commands_v2.conf.set_temp("cache_loads_in_astropy_cache", True):
+        with commands_v2.conf.set_temp("clean_loads_dir", False):
+            cmds_dir = tmp_path_factory.mktemp("cmds_dir")
+            with commands_v2.conf.set_temp("commands_dir", str(cmds_dir)):
                 yield
 
 
 def test_find(version):
-    if version == '1':
+    if version == "1":
         idx_cmds = commands_v1.IDX_CMDS
         pars_dict = commands_v1.PARS_DICT
     else:
         idx_cmds = commands_v2.IDX_CMDS
         pars_dict = commands_v2.PARS_DICT
 
-    cs = core._find('2012:029:12:00:00', '2012:030:12:00:00',
-                    idx_cmds=idx_cmds, pars_dict=pars_dict)
+    cs = core._find(
+        "2012:029:12:00:00", "2012:030:12:00:00", idx_cmds=idx_cmds, pars_dict=pars_dict
+    )
     assert isinstance(cs, Table)
-    assert len(cs) == 147 if version == '1' else 151  # OBS commands in v2 only
-    if version == '1':
-        assert np.all(cs['timeline_id'][:10] == 426098447)
-        assert np.all(cs['timeline_id'][-10:] == 426098448)
+    assert len(cs) == 147 if version == "1" else 151  # OBS commands in v2 only
+    if version == "1":
+        assert np.all(cs["timeline_id"][:10] == 426098447)
+        assert np.all(cs["timeline_id"][-10:] == 426098448)
     else:
-        assert np.all(cs['source'][:10] == 'JAN2612A')
-        assert np.all(cs['source'][-10:] == 'JAN3012C')
-    assert cs['date'][0] == '2012:029:13:00:00.000'
-    assert cs['date'][-1] == '2012:030:11:00:01.285'
-    assert cs['tlmsid'][-1] == 'CTXBON'
+        assert np.all(cs["source"][:10] == "JAN2612A")
+        assert np.all(cs["source"][-10:] == "JAN3012C")
+    assert cs["date"][0] == "2012:029:13:00:00.000"
+    assert cs["date"][-1] == "2012:030:11:00:01.285"
+    assert cs["tlmsid"][-1] == "CTXBON"
 
-    cs = core._find('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans',
-                    idx_cmds=idx_cmds, pars_dict=pars_dict)
+    cs = core._find(
+        "2012:029:12:00:00",
+        "2012:030:12:00:00",
+        type="simtrans",
+        idx_cmds=idx_cmds,
+        pars_dict=pars_dict,
+    )
     assert len(cs) == 2
-    assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
+    assert np.all(cs["date"] == ["2012:030:02:00:00.000", "2012:030:08:27:02.000"])
 
-    cs = core._find('2012:015:12:00:00', '2012:030:12:00:00',
-                    idx_cmds=idx_cmds, pars_dict=pars_dict,
-                    type='acispkt', tlmsid='wsvidalldn',)
+    cs = core._find(
+        "2012:015:12:00:00",
+        "2012:030:12:00:00",
+        idx_cmds=idx_cmds,
+        pars_dict=pars_dict,
+        type="acispkt",
+        tlmsid="wsvidalldn",
+    )
     assert len(cs) == 3
-    assert np.all(cs['date'] == ['2012:018:01:16:15.798', '2012:020:16:51:17.713',
-                                 '2012:026:05:28:09.000'])
+    assert np.all(
+        cs["date"]
+        == ["2012:018:01:16:15.798", "2012:020:16:51:17.713", "2012:026:05:28:09.000"]
+    )
 
-    cs = core._find('2011:001:12:00:00', '2014:001:12:00:00', msid='aflcrset',
-                    idx_cmds=idx_cmds, pars_dict=pars_dict)
+    cs = core._find(
+        "2011:001:12:00:00",
+        "2014:001:12:00:00",
+        msid="aflcrset",
+        idx_cmds=idx_cmds,
+        pars_dict=pars_dict,
+    )
     assert len(cs) == 2494
 
 
 def test_get_cmds(version_env):
-    cs = commands.get_cmds('2012:029:12:00:00', '2012:030:12:00:00')
+    cs = commands.get_cmds("2012:029:12:00:00", "2012:030:12:00:00")
     assert isinstance(cs, commands.CommandTable)
-    assert len(cs) == 147 if version_env == '1' else 151  # OBS commands in v2 only
-    if version_env == '2':
-        assert np.all(cs['source'][:10] == 'JAN2612A')
-        assert np.all(cs['source'][-10:] == 'JAN3012C')
+    assert len(cs) == 147 if version_env == "1" else 151  # OBS commands in v2 only
+    if version_env == "2":
+        assert np.all(cs["source"][:10] == "JAN2612A")
+        assert np.all(cs["source"][-10:] == "JAN3012C")
     else:
-        assert np.all(cs['timeline_id'][:10] == 426098447)
-        assert np.all(cs['timeline_id'][-10:] == 426098448)
-    assert cs['date'][0] == '2012:029:13:00:00.000'
-    assert cs['date'][-1] == '2012:030:11:00:01.285'
-    assert cs['tlmsid'][-1] == 'CTXBON'
+        assert np.all(cs["timeline_id"][:10] == 426098447)
+        assert np.all(cs["timeline_id"][-10:] == 426098448)
+    assert cs["date"][0] == "2012:029:13:00:00.000"
+    assert cs["date"][-1] == "2012:030:11:00:01.285"
+    assert cs["tlmsid"][-1] == "CTXBON"
 
-    cs = commands.get_cmds('2012:029:12:00:00', '2012:030:12:00:00', type='simtrans')
+    cs = commands.get_cmds("2012:029:12:00:00", "2012:030:12:00:00", type="simtrans")
     assert len(cs) == 2
-    assert np.all(cs['date'] == ['2012:030:02:00:00.000', '2012:030:08:27:02.000'])
-    assert np.all(cs['pos'] == [75624, 73176])  # from params
+    assert np.all(cs["date"] == ["2012:030:02:00:00.000", "2012:030:08:27:02.000"])
+    assert np.all(cs["pos"] == [75624, 73176])  # from params
 
     cmd = cs[1]
 
-    assert repr(cmd).startswith('<Cmd 2012:030:08:27:02.000 SIMTRANS')
-    assert str(cmd).startswith('2012:030:08:27:02.000 SIMTRANS')
-    if version_env == '2':
-        assert repr(cmd).endswith('scs=133 step=161 source=JAN3012C vcdu=15639968 pos=73176>')
-        assert str(cmd).endswith('scs=133 step=161 source=JAN3012C vcdu=15639968 pos=73176')
+    assert repr(cmd).startswith("<Cmd 2012:030:08:27:02.000 SIMTRANS")
+    assert str(cmd).startswith("2012:030:08:27:02.000 SIMTRANS")
+    if version_env == "2":
+        assert repr(cmd).endswith(
+            "scs=133 step=161 source=JAN3012C vcdu=15639968 pos=73176>"
+        )
+        assert str(cmd).endswith(
+            "scs=133 step=161 source=JAN3012C vcdu=15639968 pos=73176"
+        )
     else:
-        assert repr(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176>')
-        assert str(cmd).endswith('scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176')
+        assert repr(cmd).endswith(
+            "scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176>"
+        )
+        assert str(cmd).endswith(
+            "scs=133 step=161 timeline_id=426098449 vcdu=15639968 pos=73176"
+        )
 
-    assert cmd['pos'] == 73176
-    assert cmd['step'] == 161
+    assert cmd["pos"] == 73176
+    assert cmd["step"] == 161
 
 
 def test_get_cmds_zero_length_result(version_env):
-    cmds = commands.get_cmds(date='2017:001:12:00:00')
+    cmds = commands.get_cmds(date="2017:001:12:00:00")
     assert len(cmds) == 0
-    source_name = 'source' if version_env == '2' else 'timeline_id'
-    assert cmds.colnames == ['idx', 'date', 'type', 'tlmsid', 'scs',
-                             'step', 'time', source_name, 'vcdu', 'params']
+    source_name = "source" if version_env == "2" else "timeline_id"
+    assert cmds.colnames == [
+        "idx",
+        "date",
+        "type",
+        "tlmsid",
+        "scs",
+        "step",
+        "time",
+        source_name,
+        "vcdu",
+        "params",
+    ]
 
 
 def test_get_cmds_inclusive_stop(version_env):
@@ -133,16 +176,16 @@ def test_get_cmds_inclusive_stop(version_env):
     or start <= date <= stop for inclusive_stop=True.
     """
     # Query over a range that includes two commands at exactly start and stop.
-    start, stop = '2020:001:15:50:00.000', '2020:001:15:50:00.257'
+    start, stop = "2020:001:15:50:00.000", "2020:001:15:50:00.257"
     cmds = commands.get_cmds(start, stop)
-    assert np.all(cmds['date'] == [start])
+    assert np.all(cmds["date"] == [start])
 
     cmds = commands.get_cmds(start, stop, inclusive_stop=True)
-    assert np.all(cmds['date'] == [start, stop])
+    assert np.all(cmds["date"] == [start, stop])
 
 
 def test_cmds_as_list_of_dict(version_env):
-    cmds = commands.get_cmds('2020:140', '2020:141')
+    cmds = commands.get_cmds("2020:140", "2020:141")
     cmds_list = cmds.as_list_of_dict()
     assert isinstance(cmds_list, list)
     assert isinstance(cmds_list[0], dict)
@@ -154,32 +197,33 @@ def test_cmds_as_list_of_dict(version_env):
 
 def test_cmds_as_list_of_dict_ska_parsecm():
     """Test the ska_parsecm=True compatibility mode for list_of_dict"""
-    cmds = commands.get_cmds('2020:140', '2020:141')
+    cmds = commands.get_cmds("2020:140", "2020:141")
     cmds_list = cmds.as_list_of_dict(ska_parsecm=True)
     assert isinstance(cmds_list, list)
     assert isinstance(cmds_list[0], dict)
     assert cmds_list[0] == {
-        'cmd': 'COMMAND_HW',  # Cmd parameter exists and matches type
-        'date': '2020:140:00:00:00.000',
-        'idx': 21387,
-        'params': {'HEX': '7C063C0', 'MSID': 'CIU1024T'},  # Keys are upper case
-        'scs': 129,
-        'step': 496,
-        'time': 706233669.184,
-        'timeline_id': 426104285,
-        'tlmsid': 'CIMODESL',
-        'type': 'COMMAND_HW',
-        'vcdu': 12516929}
+        "cmd": "COMMAND_HW",  # Cmd parameter exists and matches type
+        "date": "2020:140:00:00:00.000",
+        "idx": 21387,
+        "params": {"HEX": "7C063C0", "MSID": "CIU1024T"},  # Keys are upper case
+        "scs": 129,
+        "step": 496,
+        "time": 706233669.184,
+        "timeline_id": 426104285,
+        "tlmsid": "CIMODESL",
+        "type": "COMMAND_HW",
+        "vcdu": 12516929,
+    }
     for cmd in cmds_list:
-        assert cmd.get('cmd') == cmd.get('type')
-        assert all(param.upper() == param for param in cmd['params'])
+        assert cmd.get("cmd") == cmd.get("type")
+        assert all(param.upper() == param for param in cmd["params"])
 
 
 def test_get_cmds_from_backstop_and_add_cmds():
-    bs_file = Path(parse_cm.tests.__file__).parent / 'data' / 'CR182_0803.backstop'
+    bs_file = Path(parse_cm.tests.__file__).parent / "data" / "CR182_0803.backstop"
     bs_cmds = commands.get_cmds_from_backstop(bs_file, remove_starcat=True)
 
-    cmds = commands.get_cmds(start='2018:182:00:00:00', stop='2018:182:08:00:00')
+    cmds = commands.get_cmds(start="2018:182:00:00:00", stop="2018:182:08:00:00")
 
     assert len(bs_cmds) == 674
     assert len(cmds) == 56
@@ -188,25 +232,25 @@ def test_get_cmds_from_backstop_and_add_cmds():
     for bs_col, col in zip(bs_cmds.itercols(), cmds.itercols()):
         assert bs_col.dtype == col.dtype
 
-    assert np.all(secs2date(cmds['time']) == cmds['date'])
-    assert np.all(secs2date(bs_cmds['time']) == bs_cmds['date'])
+    assert np.all(secs2date(cmds["time"]) == cmds["date"])
+    assert np.all(secs2date(bs_cmds["time"]) == bs_cmds["date"])
 
     new_cmds = cmds.add_cmds(bs_cmds)
     assert len(new_cmds) == len(cmds) + len(bs_cmds)
 
     # No MP_STARCAT command parameters by default
-    ok = bs_cmds['type'] == 'MP_STARCAT'
+    ok = bs_cmds["type"] == "MP_STARCAT"
     assert np.count_nonzero(ok) == 15
-    assert np.all(bs_cmds['params'][ok] == {})
+    assert np.all(bs_cmds["params"][ok] == {})
 
     # Accept MP_STARCAT commands (also check read_backstop command)
     bs_cmds = commands.read_backstop(bs_file)
-    ok = bs_cmds['type'] == 'MP_STARCAT'
+    ok = bs_cmds["type"] == "MP_STARCAT"
     assert np.count_nonzero(ok) == 15
-    assert np.all(bs_cmds['params'][ok] != {})
+    assert np.all(bs_cmds["params"][ok] != {})
 
 
-@pytest.mark.skipif('not HAS_MPDIR')
+@pytest.mark.skipif("not HAS_MPDIR")
 def test_commands_create_archive_regress(tmpdir, version_env):
     """Create cmds archive from scratch and test that it matches flight
 
@@ -216,19 +260,22 @@ def test_commands_create_archive_regress(tmpdir, version_env):
     update_cmds = update_cmds_v2 if version_env == "2" else update_cmds_v1
     commands = commands_v2 if version_env == "2" else commands_v1
 
-    kadi_orig = os.environ.get('KADI')
-    start = CxoTime('2021:290')
+    kadi_orig = os.environ.get("KADI")
+    start = CxoTime("2021:290")
     stop = start + 30
     cmds_flight = commands.get_cmds(start + 3, stop - 3)
     cmds_flight.fetch_params()
 
-    with conf.set_temp('commands_dir', str(tmpdir)):
+    with conf.set_temp("commands_dir", str(tmpdir)):
         try:
-            os.environ['KADI'] = str(tmpdir)
+            os.environ["KADI"] = str(tmpdir)
             update_cmds.main(
-                ('--lookback=30' if version_env == "2" else f'--start={start.date}',
-                 f'--stop={stop.date}',
-                 f'--data-root={tmpdir}'))
+                (
+                    "--lookback=30" if version_env == "2" else f"--start={start.date}",
+                    f"--stop={stop.date}",
+                    f"--data-root={tmpdir}",
+                )
+            )
             # Force reload of LazyVal
             del commands.IDX_CMDS._val
             del commands.PARS_DICT._val
@@ -246,17 +293,17 @@ def test_commands_create_archive_regress(tmpdir, version_env):
             # are different, so remove it.
             for cmds in (cmds_local, cmds_flight):
                 for cmd in cmds:
-                    if cmd['tlmsid'] == 'OBS' and 'starcat_idx' in cmd['params']:
-                        del cmd['params']['starcat_idx']
+                    if cmd["tlmsid"] == "OBS" and "starcat_idx" in cmd["params"]:
+                        del cmd["params"]["starcat_idx"]
 
-            for attr in ('tlmsid', 'date', 'params'):
+            for attr in ("tlmsid", "date", "params"):
                 assert np.all(cmds_flight[attr] == cmds_local[attr])
 
         finally:
             if kadi_orig is None:
-                del os.environ['KADI']
+                del os.environ["KADI"]
             else:
-                os.environ['KADI'] = kadi_orig
+                os.environ["KADI"] = kadi_orig
 
             # Force reload
             del commands.IDX_CMDS._val
@@ -269,49 +316,50 @@ def stop_date_fixture_factory(stop_date):
     @pytest.fixture()
     def stop_date_fixture(monkeypatch):
         commands_v2.clear_caches()
-        monkeypatch.setenv('KADI_COMMANDS_DEFAULT_STOP', stop_date)
+        monkeypatch.setenv("KADI_COMMANDS_DEFAULT_STOP", stop_date)
         cmds_dir = Path(conf.commands_dir) / stop_date
-        with commands_v2.conf.set_temp('commands_dir', str(cmds_dir)):
+        with commands_v2.conf.set_temp("commands_dir", str(cmds_dir)):
             yield
+
     return stop_date_fixture
 
 
-stop_date_2021_10_24 = stop_date_fixture_factory('2021-10-24')
-stop_date_2020_12_03 = stop_date_fixture_factory('2020-12-03')
+stop_date_2021_10_24 = stop_date_fixture_factory("2021-10-24")
+stop_date_2020_12_03 = stop_date_fixture_factory("2020-12-03")
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_get_cmds_v2_arch_only(stop_date_2020_12_03):
-    cmds = commands_v2.get_cmds(start='2020-01-01', stop='2020-01-02')
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
+    cmds = commands_v2.get_cmds(start="2020-01-01", stop="2020-01-02")
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
     assert len(cmds) == 153
-    assert np.all(cmds['idx'] != -1)
+    assert np.all(cmds["idx"] != -1)
     # Also do a zero-length query
-    cmds = commands_v2.get_cmds(start='2020-01-01', stop='2020-01-01')
+    cmds = commands_v2.get_cmds(start="2020-01-01", stop="2020-01-01")
     assert len(cmds) == 0
     commands_v2.clear_caches()
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_get_cmds_v2_arch_recent(stop_date_2020_12_03):
-    cmds = commands_v2.get_cmds(start='2020-09-01', stop='2020-12-01')
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
+    cmds = commands_v2.get_cmds(start="2020-09-01", stop="2020-12-01")
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
 
     # Since recent matches arch in the past, even though the results are a mix
     # of arch and recent, they commands actually come from the arch because of
     # how the matching block is used (commands come from arch up through the end
     # of the matching block).
-    assert np.all(cmds['idx'] != -1)
+    assert np.all(cmds["idx"] != -1)
     assert len(cmds) == 17640
 
     loads = commands_v2.get_loads()
     assert loads.pformat_all() == [
-        '  name         cmd_start              cmd_stop       observing_stop vehicle_stop          rltt          scheduled_stop_time ',  # noqa
-        '-------- --------------------- --------------------- -------------- ------------ --------------------- ---------------------',  # noqa
-        'NOV0920A 2020:314:12:13:00.000 2020:321:00:48:01.673             --           -- 2020:314:12:16:00.000 2020:321:00:48:01.673',  # noqa
-        'NOV1620A 2020:321:00:45:01.673 2020:327:19:26:00.000             --           -- 2020:321:00:48:01.673 2020:327:19:26:00.000',  # noqa
-        'NOV2320A 2020:327:19:23:00.000 2020:334:20:44:27.758             --           -- 2020:327:19:26:00.000 2020:334:20:44:27.758',  # noqa
-        'NOV3020A 2020:334:20:41:27.758 2020:342:06:04:34.287             --           -- 2020:334:20:44:27.758 2020:342:06:04:34.287'  # noqa
+        "  name         cmd_start              cmd_stop       observing_stop vehicle_stop          rltt          scheduled_stop_time ",  # noqa
+        "-------- --------------------- --------------------- -------------- ------------ --------------------- ---------------------",  # noqa
+        "NOV0920A 2020:314:12:13:00.000 2020:321:00:48:01.673             --           -- 2020:314:12:16:00.000 2020:321:00:48:01.673",  # noqa
+        "NOV1620A 2020:321:00:45:01.673 2020:327:19:26:00.000             --           -- 2020:321:00:48:01.673 2020:327:19:26:00.000",  # noqa
+        "NOV2320A 2020:327:19:23:00.000 2020:334:20:44:27.758             --           -- 2020:327:19:26:00.000 2020:334:20:44:27.758",  # noqa
+        "NOV3020A 2020:334:20:41:27.758 2020:342:06:04:34.287             --           -- 2020:334:20:44:27.758 2020:342:06:04:34.287",  # noqa
     ]
     commands_v2.clear_caches()
 
@@ -320,100 +368,101 @@ def test_get_cmds_v2_arch_recent(stop_date_2020_12_03):
 def test_get_cmds_v2_recent_only(stop_date_2020_12_03):
     # This query stop is well beyond the default stop date, so it should get
     # only commands out to the end of the NOV3020A loads (~ Dec 7).
-    cmds = commands_v2.get_cmds(start='2020-12-01', stop='2021-01-01')
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
+    cmds = commands_v2.get_cmds(start="2020-12-01", stop="2021-01-01")
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
     assert len(cmds) == 1523
-    assert np.all(cmds['idx'] == -1)
+    assert np.all(cmds["idx"] == -1)
     assert cmds[:5].pformat_like_backstop() == [
-        '2020:336:00:08:38.610 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128',  # noqa
-        '2020:336:00:08:39.635 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128',  # noqa
-        '2020:336:00:12:55.214 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=131',  # noqa
-        '2020:336:00:12:55.214 | ORBPOINT         | None       | NOV3020A | event_type=XEF1000, scs=0',  # noqa
-        '2020:336:00:12:59.214 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=131'  # noqa
+        "2020:336:00:08:38.610 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128",  # noqa
+        "2020:336:00:08:39.635 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128",  # noqa
+        "2020:336:00:12:55.214 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=131",  # noqa
+        "2020:336:00:12:55.214 | ORBPOINT         | None       | NOV3020A | event_type=XEF1000, scs=0",  # noqa
+        "2020:336:00:12:59.214 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=131",  # noqa
     ]
     assert cmds[-5:].pformat_like_backstop() == [
-        '2020:342:03:15:02.313 | COMMAND_SW       | OFMTSNRM   | NOV3020A | hex=8010A00, msid=OFMTSNRM, scs=130',  # noqa
-        '2020:342:03:15:02.313 | COMMAND_SW       | COSCSEND   | NOV3020A | hex=C800000, msid=OBC_END_SCS, scs=130',  # noqa
-        '2020:342:06:04:34.287 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=133',  # noqa
-        '2020:342:06:04:34.287 | COMMAND_SW       | COSCSEND   | NOV3020A | hex=C800000, msid=OBC_END_SCS, scs=133',  # noqa
-        '2020:342:06:04:34.287 | LOAD_EVENT       | None       | NOV3020A | event_type=SCHEDULED_STOP_TIME, scs=0'  # noqa
+        "2020:342:03:15:02.313 | COMMAND_SW       | OFMTSNRM   | NOV3020A | hex=8010A00, msid=OFMTSNRM, scs=130",  # noqa
+        "2020:342:03:15:02.313 | COMMAND_SW       | COSCSEND   | NOV3020A | hex=C800000, msid=OBC_END_SCS, scs=130",  # noqa
+        "2020:342:06:04:34.287 | ACISPKT          | AA00000000 | NOV3020A | cmds=3, words=3, scs=133",  # noqa
+        "2020:342:06:04:34.287 | COMMAND_SW       | COSCSEND   | NOV3020A | hex=C800000, msid=OBC_END_SCS, scs=133",  # noqa
+        "2020:342:06:04:34.287 | LOAD_EVENT       | None       | NOV3020A | event_type=SCHEDULED_STOP_TIME, scs=0",  # noqa
     ]
 
     # Same for no stop date
-    cmds = commands_v2.get_cmds(start='2020-12-01', stop=None)
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
+    cmds = commands_v2.get_cmds(start="2020-12-01", stop=None)
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
     assert len(cmds) == 1523
-    assert np.all(cmds['idx'] == -1)
+    assert np.all(cmds["idx"] == -1)
 
     # Sanity check on the loads
     loads = commands_v2.get_loads()
-    assert np.all(loads['name'] == ['NOV0920A', 'NOV1620A', 'NOV2320A', 'NOV3020A'])
+    assert np.all(loads["name"] == ["NOV0920A", "NOV1620A", "NOV2320A", "NOV3020A"])
 
     # zero-length query
-    cmds = commands_v2.get_cmds(start='2020-12-01', stop='2020-12-01')
+    cmds = commands_v2.get_cmds(start="2020-12-01", stop="2020-12-01")
     assert len(cmds) == 0
     commands_v2.clear_caches()
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_get_cmds_nsm_2021(stop_date_2021_10_24):
-    """NSM at ~2021:296:10:41. This tests non-load commands from cmd_events.
-    """
-    cmds = commands_v2.get_cmds('2021:296:10:35:00')  # , '2021:298:01:58:00')
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
-    exp = ['2021:296:10:35:00.000 | COMMAND_HW       | CIMODESL   | OCT1821A | '
-           'hex=7C067C0, msid=CIU1024X, scs=128',
-           '2021:296:10:35:00.257 | COMMAND_HW       | CTXAOF     | OCT1821A | '
-           'hex=780000C, msid=CTXAOF, scs=128',
-           '2021:296:10:35:00.514 | COMMAND_HW       | CPAAOF     | OCT1821A | '
-           'hex=780001E, msid=CPAAOF, scs=128',
-           '2021:296:10:35:00.771 | COMMAND_HW       | CTXBOF     | OCT1821A | '
-           'hex=780004C, msid=CTXBOF, scs=128',
-           '2021:296:10:35:01.028 | COMMAND_HW       | CPABON     | OCT1821A | '
-           'hex=7800056, msid=CPABON, scs=128',
-           '2021:296:10:35:01.285 | COMMAND_HW       | CTXBON     | OCT1821A | '
-           'hex=7800044, msid=CTXBON, scs=128',
-           '2021:296:10:41:57.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:296:10:41:57.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:296:10:41:58.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, msid=AFLCRSET, scs=0',
-           '2021:296:10:41:58.025 | SIMTRANS         | None       | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, pos=-99616, scs=0',
-           '2021:296:10:42:20.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | '
-           'event=Obsid, event_date=2021:296:10:42:20, id=0, scs=0',
-           '2021:296:10:43:03.685 | ACISPKT          | AA00000000 | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:296:10:43:04.710 | ACISPKT          | AA00000000 | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:296:10:43:14.960 | ACISPKT          | WSPOW0002A | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:296:10:43:14.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | '
-           'event=NSM, event_date=2021:296:10:41:57, scs=0',
-           '2021:297:01:41:01.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | '
-           'event=Maneuver, event_date=2021:297:01:41:01, msid=AONMMODE, scs=0',
-           '2021:297:01:41:01.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | '
-           'event=Maneuver, event_date=2021:297:01:41:01, msid=AONM2NPE, scs=0',
-           '2021:297:01:41:05.356 | MP_TARGQUAT      | AOUPTARQ   | CMD_EVT  | '
-           'event=Maneuver, event_date=2021:297:01:41:01, q1=7.05469070e-01, '
-           'q2=3.29883070e-01, q3=5.34409010e-01, q4=3.28477660e-01, scs=0',
-           '2021:297:01:41:11.250 | COMMAND_SW       | AOMANUVR   | CMD_EVT  | '
-           'event=Maneuver, event_date=2021:297:01:41:01, msid=AOMANUVR, scs=0',
-           '2021:297:02:12:42.886 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EQF003M, scs=0',
-           '2021:297:03:40:42.886 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EQF005M, scs=0',
-           '2021:297:03:40:42.886 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EQF015M, scs=0',
-           '2021:297:04:43:26.016 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EALT1, scs=0',
-           '2021:297:04:43:27.301 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=XALT1, scs=0',
-           '2021:297:12:42:42.886 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EQF013M, scs=0',
-           '2021:297:13:59:39.602 | ORBPOINT         | None       | OCT1821A | '
-           'event_type=EEF1000, scs=0']
+    """NSM at ~2021:296:10:41. This tests non-load commands from cmd_events."""
+    cmds = commands_v2.get_cmds("2021:296:10:35:00")  # , '2021:298:01:58:00')
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
+    exp = [
+        "2021:296:10:35:00.000 | COMMAND_HW       | CIMODESL   | OCT1821A | "
+        "hex=7C067C0, msid=CIU1024X, scs=128",
+        "2021:296:10:35:00.257 | COMMAND_HW       | CTXAOF     | OCT1821A | "
+        "hex=780000C, msid=CTXAOF, scs=128",
+        "2021:296:10:35:00.514 | COMMAND_HW       | CPAAOF     | OCT1821A | "
+        "hex=780001E, msid=CPAAOF, scs=128",
+        "2021:296:10:35:00.771 | COMMAND_HW       | CTXBOF     | OCT1821A | "
+        "hex=780004C, msid=CTXBOF, scs=128",
+        "2021:296:10:35:01.028 | COMMAND_HW       | CPABON     | OCT1821A | "
+        "hex=7800056, msid=CPABON, scs=128",
+        "2021:296:10:35:01.285 | COMMAND_HW       | CTXBON     | OCT1821A | "
+        "hex=7800044, msid=CTXBON, scs=128",
+        "2021:296:10:41:57.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:296:10:41:57.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:296:10:41:58.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, msid=AFLCRSET, scs=0",
+        "2021:296:10:41:58.025 | SIMTRANS         | None       | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, pos=-99616, scs=0",
+        "2021:296:10:42:20.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | "
+        "event=Obsid, event_date=2021:296:10:42:20, id=0, scs=0",
+        "2021:296:10:43:03.685 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:296:10:43:04.710 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:296:10:43:14.960 | ACISPKT          | WSPOW0002A | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:296:10:43:14.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
+        "event=NSM, event_date=2021:296:10:41:57, scs=0",
+        "2021:297:01:41:01.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | "
+        "event=Maneuver, event_date=2021:297:01:41:01, msid=AONMMODE, scs=0",
+        "2021:297:01:41:01.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | "
+        "event=Maneuver, event_date=2021:297:01:41:01, msid=AONM2NPE, scs=0",
+        "2021:297:01:41:05.356 | MP_TARGQUAT      | AOUPTARQ   | CMD_EVT  | "
+        "event=Maneuver, event_date=2021:297:01:41:01, q1=7.05469070e-01, "
+        "q2=3.29883070e-01, q3=5.34409010e-01, q4=3.28477660e-01, scs=0",
+        "2021:297:01:41:11.250 | COMMAND_SW       | AOMANUVR   | CMD_EVT  | "
+        "event=Maneuver, event_date=2021:297:01:41:01, msid=AOMANUVR, scs=0",
+        "2021:297:02:12:42.886 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EQF003M, scs=0",
+        "2021:297:03:40:42.886 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EQF005M, scs=0",
+        "2021:297:03:40:42.886 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EQF015M, scs=0",
+        "2021:297:04:43:26.016 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EALT1, scs=0",
+        "2021:297:04:43:27.301 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=XALT1, scs=0",
+        "2021:297:12:42:42.886 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EQF013M, scs=0",
+        "2021:297:13:59:39.602 | ORBPOINT         | None       | OCT1821A | "
+        "event_type=EEF1000, scs=0",
+    ]
     assert cmds.pformat_like_backstop(max_params_width=200) == exp
     commands_v2.clear_caches()
 
@@ -422,7 +471,7 @@ def test_get_cmds_nsm_2021(stop_date_2021_10_24):
 def test_cmds_scenario(stop_date_2020_12_03):
     """Test custom scenario with a couple of ACIS commands"""
     # First make the cmd_events.csv file for the scenario
-    scenario = 'test_acis'
+    scenario = "test_acis"
     cmds_dir = Path(commands_v2.conf.commands_dir) / scenario
     cmds_dir.mkdir(exist_ok=True)
     # Note variation in format of date, since this comes from humans.
@@ -431,67 +480,70 @@ Date,Event,Params,Author,Comment
 2020-12-01T00:08:30,Command,ACISPKT | TLMSID=WSPOW00000",Tom Aldcroft,
 2020-12-01 00:08:39,Command,"ACISPKT | TLMSID=WSVIDALLDN",Tom Aldcroft,
 """
-    (cmds_dir / 'cmd_events.csv').write_text(cmd_evts_text)
+    (cmds_dir / "cmd_events.csv").write_text(cmd_evts_text)
 
     # Now get commands in a time range that includes the new command events
-    cmds = commands_v2.get_cmds('2020-12-01 00:08:00', '2020-12-01 00:09:00',
-                                scenario=scenario)
-    cmds = cmds[cmds['tlmsid'] != 'OBS']
+    cmds = commands_v2.get_cmds(
+        "2020-12-01 00:08:00", "2020-12-01 00:09:00", scenario=scenario
+    )
+    cmds = cmds[cmds["tlmsid"] != "OBS"]
     exp = [
-        '2020:336:00:08:30.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Command, event_date=2020:336:00:08:30, scs=0',  # noqa
-        '2020:336:00:08:38.610 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128',  # noqa
-        '2020:336:00:08:39.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=Command, event_date=2020:336:00:08:39, scs=0',  # noqa
-        '2020:336:00:08:39.635 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128'  # noqa
+        "2020:336:00:08:30.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Command, event_date=2020:336:00:08:30, scs=0",  # noqa
+        "2020:336:00:08:38.610 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128",  # noqa
+        "2020:336:00:08:39.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=Command, event_date=2020:336:00:08:39, scs=0",  # noqa
+        "2020:336:00:08:39.635 | COMMAND_HW       | CNOOP      | NOV3020A | hex=7E00000, msid=CNOOPLR, scs=128",  # noqa
     ]
     assert cmds.pformat_like_backstop() == exp
     commands_v2.clear_caches()
 
 
 def test_command_set_bsh():
-    cmds = get_cmds_from_event('2000:001', 'Bright star hold', '')
+    cmds = get_cmds_from_event("2000:001", "Bright star hold", "")
     exp = [
-        '2000:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, msid=AFLCRSET, scs=0',
-        '2000:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, pos=-99616, scs=0',
-        '2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0']
+        "2000:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, msid=AFLCRSET, scs=0",
+        "2000:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, pos=-99616, scs=0",
+        "2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
+    ]
 
     assert cmds.pformat_like_backstop() == exp
     commands_v2.clear_caches()
 
 
 def test_command_set_safe_mode():
-    cmds = get_cmds_from_event('2000:001', 'Safe mode', '')
+    cmds = get_cmds_from_event("2000:001", "Safe mode", "")
     exp = [
-        '2000:001:00:00:00.000 | COMMAND_SW       | ACPCSFSU   | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:00:00.000 | COMMAND_SW       | CSELFMT5   | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, msid=AFLCRSET, scs=0',
-        '2000:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, pos=-99616, scs=0',
-        '2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0',
-        '2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | '
-        'event=Safe_mode, event_date=2000:001:00:00:00, scs=0']
+        "2000:001:00:00:00.000 | COMMAND_SW       | ACPCSFSU   | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:00:00.000 | COMMAND_SW       | CSELFMT5   | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, msid=AFLCRSET, scs=0",
+        "2000:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, pos=-99616, scs=0",
+        "2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+        "2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
+        "event=Safe_mode, event_date=2000:001:00:00:00, scs=0",
+    ]
 
     assert cmds.pformat_like_backstop() == exp
     commands_v2.clear_caches()
@@ -503,48 +555,53 @@ def test_bright_star_hold_event(cmds_dir, stop_date_2020_12_03):
 
     Confirm that this inserts expected commands and interrupts all load commands.
     """
-    bsh_dir = Path(conf.commands_dir) / 'bsh'
+    bsh_dir = Path(conf.commands_dir) / "bsh"
     bsh_dir.mkdir(parents=True, exist_ok=True)
-    cmd_events_file = bsh_dir / 'cmd_events.csv'
-    cmd_events_file.write_text("""\
+    cmd_events_file = bsh_dir / "cmd_events.csv"
+    cmd_events_file.write_text(
+        """\
 State,Date,Event,Params,Author,Comment
 Definitive,2020:337:00:00:00,Bright star hold,,Tom Aldcroft,
-""")
-    cmds = commands_v2.get_cmds(start='2020:336:21:48:00', stop='2020:338', scenario='bsh')
+"""
+    )
+    cmds = commands_v2.get_cmds(
+        start="2020:336:21:48:00", stop="2020:338", scenario="bsh"
+    )
     exp = [
-        '2020:336:21:48:03.312 | LOAD_EVENT       | OBS        | NOV3020A | '
-        'manvr_start=2020:336:21:09:24.361, prev_att=(-0.242373434, -0.348723922, '
-        '0.42827',
-        '2020:336:21:48:06.387 | COMMAND_SW       | CODISASX   | NOV3020A | '
-        'hex=8456200, msid=CODISASX, codisas1=98 , scs=128',
-        '2020:336:21:48:07.412 | COMMAND_SW       | AOFUNCEN   | NOV3020A | '
-        'hex=803031E, msid=AOFUNCEN, aopcadse=30 , scs=128',
-        '2020:336:21:54:23.061 | COMMAND_SW       | AOFUNCEN   | NOV3020A | '
-        'hex=8030320, msid=AOFUNCEN, aopcadse=32 , scs=128',
-        '2020:336:21:55:23.061 | COMMAND_SW       | AOFUNCEN   | NOV3020A | '
-        'hex=8030315, msid=AOFUNCEN, aopcadse=21 , scs=128',
+        "2020:336:21:48:03.312 | LOAD_EVENT       | OBS        | NOV3020A | "
+        "manvr_start=2020:336:21:09:24.361, prev_att=(-0.242373434, -0.348723922, "
+        "0.42827",
+        "2020:336:21:48:06.387 | COMMAND_SW       | CODISASX   | NOV3020A | "
+        "hex=8456200, msid=CODISASX, codisas1=98 , scs=128",
+        "2020:336:21:48:07.412 | COMMAND_SW       | AOFUNCEN   | NOV3020A | "
+        "hex=803031E, msid=AOFUNCEN, aopcadse=30 , scs=128",
+        "2020:336:21:54:23.061 | COMMAND_SW       | AOFUNCEN   | NOV3020A | "
+        "hex=8030320, msid=AOFUNCEN, aopcadse=32 , scs=128",
+        "2020:336:21:55:23.061 | COMMAND_SW       | AOFUNCEN   | NOV3020A | "
+        "hex=8030315, msid=AOFUNCEN, aopcadse=21 , scs=128",
         # BSH interrupt at 2020:337
-        '2020:337:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0',
-        '2020:337:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, msid=AFLCRSET, scs=0',
-        '2020:337:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, pos=-99616, scs=0',
-        '2020:337:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0',
-        '2020:337:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0',
-        '2020:337:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0',
-        '2020:337:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | '
-        'event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0',
+        "2020:337:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
+        "2020:337:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, msid=AFLCRSET, scs=0",
+        "2020:337:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, pos=-99616, scs=0",
+        "2020:337:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
+        "2020:337:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
+        "2020:337:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
+        "2020:337:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
+        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
         # Only ORBPOINT from here on
-        '2020:337:02:07:03.790 | ORBPOINT         | None       | NOV3020A | '
-        'event_type=EAPOGEE, scs=0',
-        '2020:337:21:15:45.455 | ORBPOINT         | None       | NOV3020A | '
-        'event_type=EALT1, scs=0',
-        '2020:337:21:15:46.227 | ORBPOINT         | None       | NOV3020A | '
-        'event_type=XALT1, scs=0']
+        "2020:337:02:07:03.790 | ORBPOINT         | None       | NOV3020A | "
+        "event_type=EAPOGEE, scs=0",
+        "2020:337:21:15:45.455 | ORBPOINT         | None       | NOV3020A | "
+        "event_type=EALT1, scs=0",
+        "2020:337:21:15:46.227 | ORBPOINT         | None       | NOV3020A | "
+        "event_type=XALT1, scs=0",
+    ]
     assert cmds.pformat_like_backstop() == exp
     commands_v2.clear_caches()
 
@@ -553,120 +610,134 @@ Definitive,2020:337:00:00:00,Bright star hold,,Tom Aldcroft,
 def test_get_observations_by_obsid_single():
     obss = get_observations(obsid=8008)
     assert len(obss) == 1
-    del obss[0]['starcat_idx']
+    del obss[0]["starcat_idx"]
     assert obss == [
-        {'obsid': 8008,
-         'simpos': 92904,
-         'obs_stop': '2007:002:18:04:28.965',
-         'manvr_start': '2007:002:04:31:48.216',
-         'targ_att': (0.149614271, 0.490896707, 0.831470649, 0.21282047),
-         'npnt_enab': True,
-         'obs_start': '2007:002:04:46:58.056',
-         'prev_att': (0.319214732, 0.535685207, 0.766039803, 0.155969017),
-         'starcat_date': '2007:002:04:31:43.965',
-         'source': 'DEC2506C'}
+        {
+            "obsid": 8008,
+            "simpos": 92904,
+            "obs_stop": "2007:002:18:04:28.965",
+            "manvr_start": "2007:002:04:31:48.216",
+            "targ_att": (0.149614271, 0.490896707, 0.831470649, 0.21282047),
+            "npnt_enab": True,
+            "obs_start": "2007:002:04:46:58.056",
+            "prev_att": (0.319214732, 0.535685207, 0.766039803, 0.155969017),
+            "starcat_date": "2007:002:04:31:43.965",
+            "source": "DEC2506C",
+        }
     ]
 
 
 def test_get_observations_by_obsid_multi():
     # Following ACA high background NSM 2019:248
-    obss = get_observations(obsid=47912, scenario='flight')
+    obss = get_observations(obsid=47912, scenario="flight")
     # Don't compare starcat_idx because it might change with a repro
     for obs in obss:
-        obs.pop('starcat_idx', None)
+        obs.pop("starcat_idx", None)
 
     assert obss == [
-        {'obsid': 47912,
-         'simpos': -99616,
-         'obs_stop': '2019:248:16:51:18.000',
-         'manvr_start': '2019:248:14:52:35.407',
-         'targ_att': (-0.564950617, 0.252299958, -0.165669121, 0.767938327),
-         'npnt_enab': True,
-         'obs_start': '2019:248:15:27:35.289',
-         'prev_att': (-0.218410783, 0.748632452, -0.580771797, 0.233560059),
-         'starcat_date': '2019:248:14:52:31.156',
-         'source': 'SEP0219B'},
-        {'obsid': 47912,
-         'simpos': -99616,
-         'obs_stop': '2019:249:01:59:00.000',
-         'manvr_start': '2019:248:16:51:18.000',
-         'targ_att': (-0.3594375808951632,
-                      0.6553454859043244,
-                      -0.4661410647781301,
-                      0.47332803366853643),
-         'npnt_enab': False,
-         'obs_start': '2019:248:17:18:17.732',
-         'prev_att': (-0.564950617, 0.252299958, -0.165669121, 0.767938327),
-         'source': 'CMD_EVT'},
-        {'obsid': 47912,
-         'simpos': -99616,
-         'obs_stop': '2019:249:23:30:00.000',
-         'manvr_start': '2019:249:01:59:10.250',
-         'targ_att': (-0.54577727, 0.27602874, -0.17407247, 0.77177334),
-         'npnt_enab': True,
-         'obs_start': '2019:249:02:25:31.907',
-         'prev_att': (-0.3594375808951632,
-                      0.6553454859043244,
-                      -0.4661410647781301,
-                      0.47332803366853643),
-         'starcat_date': '2019:248:14:52:31.156',
-         'source': 'CMD_EVT'}
+        {
+            "obsid": 47912,
+            "simpos": -99616,
+            "obs_stop": "2019:248:16:51:18.000",
+            "manvr_start": "2019:248:14:52:35.407",
+            "targ_att": (-0.564950617, 0.252299958, -0.165669121, 0.767938327),
+            "npnt_enab": True,
+            "obs_start": "2019:248:15:27:35.289",
+            "prev_att": (-0.218410783, 0.748632452, -0.580771797, 0.233560059),
+            "starcat_date": "2019:248:14:52:31.156",
+            "source": "SEP0219B",
+        },
+        {
+            "obsid": 47912,
+            "simpos": -99616,
+            "obs_stop": "2019:249:01:59:00.000",
+            "manvr_start": "2019:248:16:51:18.000",
+            "targ_att": (
+                -0.3594375808951632,
+                0.6553454859043244,
+                -0.4661410647781301,
+                0.47332803366853643,
+            ),
+            "npnt_enab": False,
+            "obs_start": "2019:248:17:18:17.732",
+            "prev_att": (-0.564950617, 0.252299958, -0.165669121, 0.767938327),
+            "source": "CMD_EVT",
+        },
+        {
+            "obsid": 47912,
+            "simpos": -99616,
+            "obs_stop": "2019:249:23:30:00.000",
+            "manvr_start": "2019:249:01:59:10.250",
+            "targ_att": (-0.54577727, 0.27602874, -0.17407247, 0.77177334),
+            "npnt_enab": True,
+            "obs_start": "2019:249:02:25:31.907",
+            "prev_att": (
+                -0.3594375808951632,
+                0.6553454859043244,
+                -0.4661410647781301,
+                0.47332803366853643,
+            ),
+            "starcat_date": "2019:248:14:52:31.156",
+            "source": "CMD_EVT",
+        },
     ]
 
 
 def test_get_observations_by_start_date():
     # Test observations from a 6 months ago onward
-    obss = get_observations(start=CxoTime.now() - 180 * u.day, scenario='flight')
+    obss = get_observations(start=CxoTime.now() - 180 * u.day, scenario="flight")
     assert len(obss) > 500
     # Latest obs should also be no less than 14 days old
-    assert obss[-1]['obs_start'] > (CxoTime.now() - 14 * u.day).date
+    assert obss[-1]["obs_start"] > (CxoTime.now() - 14 * u.day).date
 
 
 def test_get_observations_by_start_stop_date_with_scenario():
     # Test observations in a range and use the scenario keyword
-    obss = get_observations(start='2022:001', stop='2022:002', scenario='flight')
+    obss = get_observations(start="2022:001", stop="2022:002", scenario="flight")
     assert len(obss) == 7
-    assert obss[1]['obsid'] == 45814
-    assert obss[1]['obs_start'] == '2022:001:05:48:44.808'
-    assert obss[-1]['obsid'] == 23800
-    assert obss[-1]['obs_start'] == '2022:001:17:33:53.255'
+    assert obss[1]["obsid"] == 45814
+    assert obss[1]["obs_start"] == "2022:001:05:48:44.808"
+    assert obss[-1]["obsid"] == 23800
+    assert obss[-1]["obs_start"] == "2022:001:17:33:53.255"
 
 
 def test_get_observations_no_match():
-    with pytest.raises(ValueError, match='No matching observations for obsid=8008'):
-        get_observations(obsid=8008, start='2022:001', stop='2022:002', scenario='flight')
+    with pytest.raises(ValueError, match="No matching observations for obsid=8008"):
+        get_observations(
+            obsid=8008, start="2022:001", stop="2022:002", scenario="flight"
+        )
 
 
 def test_get_observations_start_stop_inclusion():
     # Covers time from the middle of obsid 8008 to the middle of obsid 8009
-    obss = get_observations('2007:002:05:00:00', '2007:002:20:00:01', scenario='flight')
+    obss = get_observations("2007:002:05:00:00", "2007:002:20:00:01", scenario="flight")
     assert len(obss) == 2
 
     # One second in the middle of obsid 8008
-    obss = get_observations('2007:002:05:00:00', '2007:002:05:00:01', scenario='flight')
+    obss = get_observations("2007:002:05:00:00", "2007:002:05:00:01", scenario="flight")
     assert len(obss) == 1
 
     # During a maneuver
-    obss = get_observations('2007:002:18:05:00', '2007:002:18:08:00', scenario='flight')
+    obss = get_observations("2007:002:18:05:00", "2007:002:18:08:00", scenario="flight")
     assert len(obss) == 0
 
 
 years = np.arange(2003, CxoTime.now().ymdhms.year + 1)
 
 
-@pytest.mark.parametrize('year', years)
+@pytest.mark.parametrize("year", years)
 def test_get_starcats_each_year(year):
-    starcats = get_starcats(start=f'{year}:001', stop=f'{year}:004', scenario='flight')
+    starcats = get_starcats(start=f"{year}:001", stop=f"{year}:004", scenario="flight")
     assert len(starcats) > 2
     for starcat in starcats:
         # Make sure fids and stars are all ID'd
-        ok = starcat['type'] != 'MON'
-        assert np.all(starcat['id'][ok] != -999)
+        ok = starcat["type"] != "MON"
+        assert np.all(starcat["id"][ok] != -999)
 
 
 def test_get_starcats_with_cmds():
-    start, stop = '2021:365:19:00:00', '2022:002:01:25:00'
-    cmds = commands_v2.get_cmds(start, stop, scenario='flight')
+    start, stop = "2021:365:19:00:00", "2022:002:01:25:00"
+    cmds = commands_v2.get_cmds(start, stop, scenario="flight")
     starcats0 = get_starcats(start, stop)
     starcats1 = get_starcats(cmds=cmds)
     assert len(starcats0) == len(starcats1)
@@ -678,17 +749,30 @@ def test_get_starcats_with_cmds():
 
 def test_get_starcats_obsid():
     from mica.starcheck import get_starcat
-    sc_kadi = get_starcats(obsid=26330, scenario='flight')[0]
+
+    sc_kadi = get_starcats(obsid=26330, scenario="flight")[0]
     sc_mica = get_starcat(26330)
     assert len(sc_kadi) == len(sc_mica)
-    assert sc_kadi.colnames == ['slot', 'idx', 'id', 'type', 'sz', 'mag',
-                                'maxmag', 'yang', 'zang', 'dim', 'res', 'halfw']
+    assert sc_kadi.colnames == [
+        "slot",
+        "idx",
+        "id",
+        "type",
+        "sz",
+        "mag",
+        "maxmag",
+        "yang",
+        "zang",
+        "dim",
+        "res",
+        "halfw",
+    ]
     for name in sc_kadi.colnames:
-        if name == 'mag':
+        if name == "mag":
             continue  # kadi mag is latest from agasc, could change
-        elif name == 'maxmag':
+        elif name == "maxmag":
             assert np.allclose(sc_kadi[name], sc_mica[name], atol=0.001, rtol=0)
-        elif name in ('yang', 'zang'):
+        elif name in ("yang", "zang"):
             assert np.all(np.abs(sc_kadi[name] - sc_mica[name]) < 1)
         else:
             assert np.all(sc_kadi[name] == sc_mica[name])
@@ -701,29 +785,31 @@ def test_get_starcats_date():
     Note: from https://icxc.harvard.edu//mp/mplogs/2006/DEC2506/oflsc/starcheck.html#obsid8008
     MP_STARCAT at 2007:002:04:31:43.965 (VCDU count = 7477935)
     """
-    sc = get_starcats(obsid=8008, scenario='flight')[0]
-    obs = get_observations(obsid=8008, scenario='flight')[0]
-    assert sc.date == obs['starcat_date'] == '2007:002:04:31:43.965'
-    cmds = commands_v2.get_cmds('2007:002', '2007:003')
-    sc_cmd = cmds[cmds['date'] == obs['starcat_date']][0]
-    assert sc_cmd['type'] == 'MP_STARCAT'
+    sc = get_starcats(obsid=8008, scenario="flight")[0]
+    obs = get_observations(obsid=8008, scenario="flight")[0]
+    assert sc.date == obs["starcat_date"] == "2007:002:04:31:43.965"
+    cmds = commands_v2.get_cmds("2007:002", "2007:003")
+    sc_cmd = cmds[cmds["date"] == obs["starcat_date"]][0]
+    assert sc_cmd["type"] == "MP_STARCAT"
 
 
 def test_get_starcats_by_date():
     """Test that the getting a starcat using the starcat_date as argument returns the same catalog
     as using the OBSID.
     """
-    sc = get_starcats(obsid=8008, scenario='flight')[0]
-    sc_by_date = get_starcats(starcat_date='2007:002:04:31:43.965', scenario='flight')[0]
+    sc = get_starcats(obsid=8008, scenario="flight")[0]
+    sc_by_date = get_starcats(starcat_date="2007:002:04:31:43.965", scenario="flight")[
+        0
+    ]
     assert np.all(sc == sc_by_date)
-    with pytest.raises(ValueError, match='No matching observations for starcat_date'):
-        get_starcats(starcat_date='2007:002:04:31:43.966', scenario='flight')
+    with pytest.raises(ValueError, match="No matching observations for starcat_date"):
+        get_starcats(starcat_date="2007:002:04:31:43.966", scenario="flight")
 
 
 def test_get_starcats_as_table():
     """Test that get_starcats_as_table returns the same as vstacked get_starcats"""
-    start, stop = '2020:001', '2020:002'
-    starcats = get_starcats(start, stop, scenario='flight')
+    start, stop = "2020:001", "2020:002"
+    starcats = get_starcats(start, stop, scenario="flight")
     obsids = []
     dates = []
     for starcat in starcats:
@@ -731,27 +817,33 @@ def test_get_starcats_as_table():
         dates.extend([starcat.date] * len(starcat))
         # Meta causes warnings in vstack, just ignore here
         starcat.meta = {}
-    aces = get_starcats_as_table(start, stop, scenario='flight')
+    aces = get_starcats_as_table(start, stop, scenario="flight")
     aces_from_starcats = vstack(starcats)
-    assert np.all(aces['obsid'] == obsids)
-    assert np.all(aces['starcat_date'] == dates)
+    assert np.all(aces["obsid"] == obsids)
+    assert np.all(aces["starcat_date"] == dates)
     for name in aces_from_starcats.colnames:
         assert np.all(aces[name] == aces_from_starcats[name])
 
 
 @pytest.mark.parametrize(
-    'par_str', ['ACISPKT|  TLmSID= aa0000000 par1 = 1    par2=-1.0',
-                'AcisPKT|TLmSID=AA0000000 par1=1 par2=-1.0',
-                'ACISPKT|  TLmSID = aa0000000  par1  =1    par2 =  -1.0'])
+    "par_str",
+    [
+        "ACISPKT|  TLmSID= aa0000000 par1 = 1    par2=-1.0",
+        "AcisPKT|TLmSID=AA0000000 par1=1 par2=-1.0",
+        "ACISPKT|  TLmSID = aa0000000  par1  =1    par2 =  -1.0",
+    ],
+)
 def test_get_cmds_from_event_case(par_str):
-    cmds = get_cmds_from_event('2022:001', 'Command', par_str)
+    cmds = get_cmds_from_event("2022:001", "Command", par_str)
     assert len(cmds) == 1
     cmd = cmds[0]
-    assert cmd['type'] == 'ACISPKT'
-    assert cmd['params'] == {'event': 'Command',
-                             'event_date': '2022:001:00:00:00',
-                             'par1': 1,
-                             'par2': -1.0}
+    assert cmd["type"] == "ACISPKT"
+    assert cmd["params"] == {
+        "event": "Command",
+        "event_date": "2022:001:00:00:00",
+        "par1": 1,
+        "par2": -1.0,
+    }
 
 
 cmd_events_all_text = """\
@@ -769,112 +861,141 @@ cmd_events_all_text = """\
     Bright star hold,
     Dither,ON
     """
-cmd_events_all = Table.read(cmd_events_all_text, format='ascii.csv')
+cmd_events_all = Table.read(cmd_events_all_text, format="ascii.csv")
 cmd_events_all_exps = [
     None,
     None,
-    ['2020:001:00:00:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=Command, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPEN, scs=135',  # noqa
-        '2020:001:00:00:01.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:001:00:00:02.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135',  # noqa
-        '2020:001:00:00:03.000 | COMMAND_HW       | 2S2HVON    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVON, scs=135',  # noqa
-        '2020:001:00:00:13.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=4 , msid=2S2STHV, scs=135',  # noqa
-        '2020:001:00:00:23.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=8 , msid=2S2STHV, scs=135',  # noqa
-        '2020:001:00:00:24.000 | ACISPKT          | WSPOW08E1E | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:001:00:01:27.000 | ACISPKT          | WT00C62014 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:001:00:01:31.000 | ACISPKT          | XTZ0000005 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:001:00:01:35.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:001:00:01:39.000 | ACISPKT          | RH_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:002:15:01:39.000 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVOF, scs=135',  # noqa
-        '2020:002:15:01:39.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPDS, scs=135',  # noqa
-        '2020:002:15:01:40.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135',  # noqa
-        '2020:002:17:40:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:002:17:40:10.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:002:17:40:14.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135',  # noqa
-        '2020:002:17:40:18.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135'],  # noqa
-    ['2020:001:00:00:00.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | event=Obsid, event_date=2020:001:00:00:00, id=65527, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONMMODE, scs=0',  # noqa
-        '2020:001:00:00:00.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONM2NPE, scs=0',  # noqa
-        '2020:001:00:00:04.356 | MP_TARGQUAT      | AOUPTARQ   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, q1=7.05469070e-01, q2=3.29883070e-01, q3=5.34409010e-01, q4=3.28477660e-01, scs=0',  # noqa
-        '2020:001:00:00:10.250 | COMMAND_SW       | AOMANUVR   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AOMANUVR, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | ACPCSFSU   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:00.000 | COMMAND_SW       | CSELFMT5   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
-        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
-        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
-        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
-        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
-        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
-        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0',  # noqa
-        '2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, pos=-99616, scs=0',  # noqa
-        '2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0',  # noqa
-        '2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0'],  # noqa
-    ['2020:001:00:00:00.000 | COMMAND_SW       | AOENDITH   | CMD_EVT  | event=Dither, event_date=2020:001:00:00:00, scs=0']]  # noqa
+    [
+        "2020:001:00:00:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=Command, event_date=2020:001:00:00:00, scs=0"
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, scs=0"
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPEN, scs=135",  # noqa
+        "2020:001:00:00:01.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:001:00:00:02.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",  # noqa
+        "2020:001:00:00:03.000 | COMMAND_HW       | 2S2HVON    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVON, scs=135",  # noqa
+        "2020:001:00:00:13.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=4 , msid=2S2STHV, scs=135",  # noqa
+        "2020:001:00:00:23.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=8 , msid=2S2STHV, scs=135",  # noqa
+        "2020:001:00:00:24.000 | ACISPKT          | WSPOW08E1E | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:001:00:01:27.000 | ACISPKT          | WT00C62014 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:001:00:01:31.000 | ACISPKT          | XTZ0000005 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:001:00:01:35.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:001:00:01:39.000 | ACISPKT          | RH_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:002:15:01:39.000 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=2S2HVOF, scs=135",  # noqa
+        "2020:002:15:01:39.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, msid=OORMPDS, scs=135",  # noqa
+        "2020:002:15:01:40.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",  # noqa
+        "2020:002:17:40:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:002:17:40:10.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:002:17:40:14.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",  # noqa
+        "2020:002:17:40:18.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS, event_date=2020:001:00:00:00, scs=135",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | event=Obsid, event_date=2020:001:00:00:00, id=65527, scs=0"
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONMMODE, scs=0",  # noqa
+        "2020:001:00:00:00.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AONM2NPE, scs=0",  # noqa
+        "2020:001:00:00:04.356 | MP_TARGQUAT      | AOUPTARQ   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, q1=7.05469070e-01, q2=3.29883070e-01, q3=5.34409010e-01, q4=3.28477660e-01, scs=0",  # noqa
+        "2020:001:00:00:10.250 | COMMAND_SW       | AOMANUVR   | CMD_EVT  | event=Maneuver, event_date=2020:001:00:00:00, msid=AOMANUVR, scs=0",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | ACPCSFSU   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:00.000 | COMMAND_SW       | CSELFMT5   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0",  # noqa
+        "2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, pos=-99616, scs=0",  # noqa
+        "2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2020:001:00:00:00, scs=0",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | AONSMSAF   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0",  # noqa
+        "2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, pos=-99616, scs=0",  # noqa
+        "2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2020:001:00:00:00, scs=0",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0",  # noqa
+        "2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, pos=-99616, scs=0",  # noqa
+        "2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=SCS-107, event_date=2020:001:00:00:00, scs=0",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:00:01.025 | COMMAND_HW       | AFIDP      | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, msid=AFLCRSET, scs=0",  # noqa
+        "2020:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, pos=-99616, scs=0",  # noqa
+        "2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
+        "2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",
+    ],  # noqa
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | AOENDITH   | CMD_EVT  | event=Dither, event_date=2020:001:00:00:00, scs=0"
+    ],
+]  # noqa
 
 
-@pytest.mark.parametrize('idx', range(len(cmd_events_all_exps)))
+@pytest.mark.parametrize("idx", range(len(cmd_events_all_exps)))
 def test_get_cmds_from_event_all(idx):
     """Test getting commands from every event type in the Command Events sheet"""
     cevt = cmd_events_all[idx]
     exp = cmd_events_all_exps[idx]
-    cmds = get_cmds_from_event('2020:001:00:00:00', cevt['Event'], cevt['Params'])
+    cmds = get_cmds_from_event("2020:001:00:00:00", cevt["Event"], cevt["Params"])
     if cmds is not None:
         cmds = cmds.pformat_like_backstop(max_params_width=None)
     assert cmds == exp
 
 
-@pytest.mark.skipif(not HAS_INTERNET, reason='No internet connection')
+@pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_scenario_with_rts(monkeypatch):
     """Test a custom scenario with RTS. This is basically the same as the
     example in the documentation."""
     from kadi import paths
 
-    monkeypatch.setenv('KADI_COMMANDS_VERSION', '2')
-    monkeypatch.setenv('KADI_COMMANDS_DEFAULT_STOP', '2021:299')
+    monkeypatch.setenv("KADI_COMMANDS_VERSION", "2")
+    monkeypatch.setenv("KADI_COMMANDS_DEFAULT_STOP", "2021:299")
 
     # Ensure local cmd_events.csv is up to date by requesting "recent" commands
     # relative to the default stop.
-    cmds = commands.get_cmds(start='2021:299')
+    cmds = commands.get_cmds(start="2021:299")
 
     path_flight = paths.CMD_EVENTS_PATH()
-    path_cti = paths.CMD_EVENTS_PATH(scenario='nsm-cti')
+    path_cti = paths.CMD_EVENTS_PATH(scenario="nsm-cti")
     path_cti.parent.mkdir(exist_ok=True, parents=True)
 
     # Make a new custom scenario from the flight version
     events_flight = Table.read(path_flight)
-    cti_event = {'State': 'definitive', 'Date': '2021:297:13:00:00',
-                 'Event': 'RTS', 'Params': 'RTSLOAD,1_CTI06,NUM_HOURS=12:00:00,SCS_NUM=135',
-                 'Author': 'Tom Aldcroft', 'Reviewer': 'John Scott', 'Comment': ''}
+    cti_event = {
+        "State": "definitive",
+        "Date": "2021:297:13:00:00",
+        "Event": "RTS",
+        "Params": "RTSLOAD,1_CTI06,NUM_HOURS=12:00:00,SCS_NUM=135",
+        "Author": "Tom Aldcroft",
+        "Reviewer": "John Scott",
+        "Comment": "",
+    }
     events_cti = events_flight.copy()
     events_cti.add_row(cti_event)
     events_cti.write(path_cti, overwrite=True)
 
     # Now read the commands from the custom scenario
-    cmds = commands.get_cmds('2021:296:10:35:00', '2021:298:01:58:00', scenario='nsm-cti')
+    cmds = commands.get_cmds(
+        "2021:296:10:35:00", "2021:298:01:58:00", scenario="nsm-cti"
+    )
     cmds.fetch_params()
     for cmd in cmds:
-        if 'hex' in cmd['params']:
-            del cmd['params']['hex']
+        if "hex" in cmd["params"]:
+            del cmd["params"]["hex"]
 
     exp = """\
 2021:296:10:35:00.000 | COMMAND_HW       | CIMODESL   | OCT1821A | msid=CIU1024X, scs=128
@@ -936,12 +1057,12 @@ def test_scenario_with_rts(monkeypatch):
 2021:298:01:57:33.000 | COMMAND_SW       | CODISASX   | OCT2521B | msid=CODISASX, codisas1=135 , scs=131
 2021:298:01:57:34.000 | COMMAND_SW       | COCLRSX    | OCT2521B | msid=COCLRSX, coclrs1=135 , scs=131"""  # noqa
 
-    out = '\n'.join(cmds.pformat_like_backstop(max_params_width=60))
+    out = "\n".join(cmds.pformat_like_backstop(max_params_width=60))
     assert out == exp
 
     # 11 RTS commands. Note that the ACIS stop science commands from the RTS
     # are NOT evident because they are cut by the RLTT at 2021:298:01:57:00.
     # TODO: (someday?) instead of the RLTT notice the disable SCS 135 command
     # CODISASX.
-    ok = cmds['event'] == 'RTS'
+    ok = cmds["event"] == "RTS"
     assert np.count_nonzero(ok) == 11

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -16,12 +16,12 @@ from astropy.io import ascii
 from astropy.table import Table
 
 try:
-    fetch.get_time_range('dp_pitch')
+    fetch.get_time_range("dp_pitch")
     HAS_PITCH = True
 except Exception:
     HAS_PITCH = False
 
-VERSIONS = ['1', '2'] if has_internet() else ['1']
+VERSIONS = ["1", "2"] if has_internet() else ["1"]
 
 
 @pytest.fixture(scope="module", params=VERSIONS)
@@ -32,41 +32,43 @@ def version(request):
 @pytest.fixture(autouse=True)
 def version_env(monkeypatch, version):
     if version is None:
-        monkeypatch.delenv('KADI_COMMANDS_VERSION', raising=False)
+        monkeypatch.delenv("KADI_COMMANDS_VERSION", raising=False)
     else:
-        monkeypatch.setenv('KADI_COMMANDS_VERSION', version)
+        monkeypatch.setenv("KADI_COMMANDS_VERSION", version)
     return version
 
 
 # Canonical state0 giving spacecraft state at beginning of timelines
 # 2002:007:13 fetch --start 2002:007:13:00:00 --stop 2002:007:13:02:00 aoattqt1
 # aoattqt2 aoattqt3 aoattqt4 cobsrqid aopcadmd tscpos
-STATE0 = {'ccd_count': 5,
-          'clocking': 0,
-          'datestart': '2002:007:13:00:00.000',
-          'datestop': '2099:001:00:00:00.000',
-          'dec': -11.500,
-          'fep_count': 0,
-          'hetg': 'RETR',
-          'letg': 'RETR',
-          'obsid': 61358,
-          'pcad_mode': 'NPNT',
-          'pitch': 61.37,
-          'power_cmd': 'AA00000000',
-          'q1': -0.568062,
-          'q2': 0.121674,
-          'q3': 0.00114141,
-          'q4': 0.813941,
-          'ra': 352.000,
-          'roll': 289.37,
-          'si_mode': 'undef',
-          'simfa_pos': -468,
-          'simpos': -99616,
-          'trans_keys': 'undef',
-          'tstart': 127020624.552,
-          'tstop': 3187296066.184,
-          'vid_board': 0,
-          'dither': 'None'}
+STATE0 = {
+    "ccd_count": 5,
+    "clocking": 0,
+    "datestart": "2002:007:13:00:00.000",
+    "datestop": "2099:001:00:00:00.000",
+    "dec": -11.500,
+    "fep_count": 0,
+    "hetg": "RETR",
+    "letg": "RETR",
+    "obsid": 61358,
+    "pcad_mode": "NPNT",
+    "pitch": 61.37,
+    "power_cmd": "AA00000000",
+    "q1": -0.568062,
+    "q2": 0.121674,
+    "q3": 0.00114141,
+    "q4": 0.813941,
+    "ra": 352.000,
+    "roll": 289.37,
+    "si_mode": "undef",
+    "simfa_pos": -468,
+    "simpos": -99616,
+    "trans_keys": "undef",
+    "tstart": 127020624.552,
+    "tstop": 3187296066.184,
+    "vid_board": 0,
+    "dither": "None",
+}
 
 
 def assert_all_close_states(rc, rk, keys):
@@ -76,7 +78,7 @@ def assert_all_close_states(rc, rk, keys):
     """
     for key in keys:
         rcdtype = rc[key].dtype
-        if rcdtype.kind == 'f':
+        if rcdtype.kind == "f":
             assert np.allclose(rk[key].astype(rcdtype), rc[key])
         else:
             assert np.all(rk[key] == rc[key])
@@ -90,23 +92,30 @@ def get_states_test(start, stop, state_keys, continuity=None):
     stop = DateTime(stop)
 
     cstates = cmd_states_fetch_states(start.date, stop.date)
-    trans_keys = [set(val.split(',')) for val in cstates['trans_keys']]
-    cstates.remove_column('trans_keys')  # Necessary for older astropy
-    cstates['trans_keys'] = trans_keys
+    trans_keys = [set(val.split(",")) for val in cstates["trans_keys"]]
+    cstates.remove_column("trans_keys")  # Necessary for older astropy
+    cstates["trans_keys"] = trans_keys
     rcstates = states.reduce_states(cstates, state_keys, merge_identical=True)
     lenr = len(rcstates)
 
     cmds = commands.get_cmds(start - 7, stop)
     with states.disable_grating_move_duration():
-        kstates = states.get_states(state_keys=state_keys, cmds=cmds,
-                                    continuity=continuity, reduce=False)
+        kstates = states.get_states(
+            state_keys=state_keys, cmds=cmds, continuity=continuity, reduce=False
+        )
     rkstates = states.reduce_states(kstates, state_keys, merge_identical=True)[-lenr:]
 
     return rcstates, rkstates
 
 
-def compare_states(start, stop, state_keys, compare_state_keys=None, continuity=None,
-                   compare_dates=True):
+def compare_states(
+    start,
+    stop,
+    state_keys,
+    compare_state_keys=None,
+    continuity=None,
+    compare_dates=True,
+):
     """
     Helper for comparing states from kadi and cmd_states
     """
@@ -118,8 +127,8 @@ def compare_states(start, stop, state_keys, compare_state_keys=None, continuity=
     assert_all_close_states(rcstates, rkstates, compare_state_keys)
 
     if compare_dates:
-        assert np.all(rcstates['datestart'][1:] == rkstates['datestart'][1:])
-        assert np.all(rcstates['datestop'][:-1] == rkstates['datestop'][:-1])
+        assert np.all(rcstates["datestart"][1:] == rkstates["datestart"][1:])
+        assert np.all(rcstates["datestop"][:-1] == rkstates["datestop"][:-1])
 
     return rcstates, rkstates
 
@@ -128,20 +137,30 @@ def test_acis():
     """
     Test all ACIS states include vid_board for late-2017
     """
-    state_keys = ['clocking', 'power_cmd', 'fep_count', 'si_mode', 'vid_board']
-    rc, rk = compare_states('2017:280:12:00:00', '2017:360:12:00:00', state_keys, state_keys)
+    state_keys = ["clocking", "power_cmd", "fep_count", "si_mode", "vid_board"]
+    rc, rk = compare_states(
+        "2017:280:12:00:00", "2017:360:12:00:00", state_keys, state_keys
+    )
 
 
 def test_cmd_line_interface(tmpdir):
     """
     Test command line interface
     """
-    filename = os.path.join(str(tmpdir), 'out.txt')
-    states.get_chandra_states(['--outfile', filename,
-                               '--start', '2017:001:21:00:00',
-                               '--stop', '2017:002:11:30:00',
-                               '--state-keys', 'obsid,si_mode,pcad_mode'])
-    with open(filename, 'r') as fh:
+    filename = os.path.join(str(tmpdir), "out.txt")
+    states.get_chandra_states(
+        [
+            "--outfile",
+            filename,
+            "--start",
+            "2017:001:21:00:00",
+            "--stop",
+            "2017:002:11:30:00",
+            "--state-keys",
+            "obsid,si_mode,pcad_mode",
+        ]
+    )
+    with open(filename, "r") as fh:
         out = fh.read()
 
     # Work around bug in astropy 3.0 where text table output has `\r\r\n` line endings
@@ -149,55 +168,68 @@ def test_cmd_line_interface(tmpdir):
     # at which point python turns the \n into \r\n.
     lines = [line for line in out.splitlines() if line.strip()]
     assert lines == [
-        '             datestart               datestop  obsid   si_mode  pcad_mode ',
-        ' 2017:001:21:00:00.000  2017:001:21:02:06.467  18140  TE_008FC       NPNT ',
-        ' 2017:001:21:02:06.467  2017:001:21:05:06.467  18140  TE_008FC       NMAN ',
-        ' 2017:001:21:05:06.467  2017:001:21:06:41.467  19973  TE_008FC       NMAN ',
-        ' 2017:001:21:06:41.467  2017:001:21:23:02.282  19973  TE_00A58       NMAN ',
-        ' 2017:001:21:23:02.282  2017:002:11:23:43.185  19973  TE_00A58       NPNT ',
-        ' 2017:002:11:23:43.185  2017:002:11:26:43.185  19973  TE_00A58       NMAN ',
-        ' 2017:002:11:26:43.185  2017:002:11:29:29.870  50432  TE_00A58       NMAN ',
-        ' 2017:002:11:29:29.870  2017:002:11:30:00.000  50432  TE_00A58       NPNT ']
+        "             datestart               datestop  obsid   si_mode  pcad_mode ",
+        " 2017:001:21:00:00.000  2017:001:21:02:06.467  18140  TE_008FC       NPNT ",
+        " 2017:001:21:02:06.467  2017:001:21:05:06.467  18140  TE_008FC       NMAN ",
+        " 2017:001:21:05:06.467  2017:001:21:06:41.467  19973  TE_008FC       NMAN ",
+        " 2017:001:21:06:41.467  2017:001:21:23:02.282  19973  TE_00A58       NMAN ",
+        " 2017:001:21:23:02.282  2017:002:11:23:43.185  19973  TE_00A58       NPNT ",
+        " 2017:002:11:23:43.185  2017:002:11:26:43.185  19973  TE_00A58       NMAN ",
+        " 2017:002:11:26:43.185  2017:002:11:29:29.870  50432  TE_00A58       NMAN ",
+        " 2017:002:11:29:29.870  2017:002:11:30:00.000  50432  TE_00A58       NPNT ",
+    ]
 
 
 def test_quick():
     """
     Test for a few days in 2017.  Sanity check for refactoring etc.
     """
-    state_keys = (['obsid', 'clocking', 'power_cmd', 'fep_count', 'vid_board',
-                   'si_mode', 'ccd_count']
-                  + ['q1', 'q2', 'q3', 'q4', 'pcad_mode', 'dither', 'ra', 'dec', 'roll']
-                  + ['letg', 'hetg']
-                  + ['simpos', 'simfa_pos'])
-    continuity = {'letg': 'RETR', 'hetg': 'RETR'}  # Not necessarily set within 7 days
-    rc, rk = compare_states('2018:235:12:00:00', '2018:245:12:00:00', state_keys,
-                            continuity=continuity)
+    state_keys = (
+        [
+            "obsid",
+            "clocking",
+            "power_cmd",
+            "fep_count",
+            "vid_board",
+            "si_mode",
+            "ccd_count",
+        ]
+        + ["q1", "q2", "q3", "q4", "pcad_mode", "dither", "ra", "dec", "roll"]
+        + ["letg", "hetg"]
+        + ["simpos", "simfa_pos"]
+    )
+    continuity = {"letg": "RETR", "hetg": "RETR"}  # Not necessarily set within 7 days
+    rc, rk = compare_states(
+        "2018:235:12:00:00", "2018:245:12:00:00", state_keys, continuity=continuity
+    )
 
     # Now test using start/stop pair with start/stop and no supplied cmds or continuity.
     # This also tests the API kwarg order: datestart, datestop, state_keys, ..)
     with states.disable_grating_move_duration():
-        sts = states.get_states('2018:235:12:00:00', '2018:245:12:00:00',
-                                state_keys, reduce=False)
-    assert np.all(DateTime(sts['tstart']).date == sts['datestart'])
-    assert np.all(DateTime(sts['tstop']).date == sts['datestop'])
+        sts = states.get_states(
+            "2018:235:12:00:00", "2018:245:12:00:00", state_keys, reduce=False
+        )
+    assert np.all(DateTime(sts["tstart"]).date == sts["datestart"])
+    assert np.all(DateTime(sts["tstop"]).date == sts["datestop"])
 
     rk = states.reduce_states(sts, state_keys, merge_identical=True)
     assert len(rc) == len(rk)
 
     assert_all_close_states(rc, rk, state_keys)
 
-    assert np.all(rc['datestart'][1:] == rk['datestart'][1:])
-    assert np.all(rc['datestop'][:-1] == rk['datestop'][:-1])
+    assert np.all(rc["datestart"][1:] == rk["datestart"][1:])
+    assert np.all(rc["datestop"][:-1] == rk["datestop"][:-1])
 
 
 def test_acis_raw_mode():
     """Test ACIS raw-mode SI modes"""
     # Minimal test that they are found in a period of time known to have
     # raw mode commanding.
-    kstates = states.get_states(start='2017:189:12:00:00', stop='2017:197:12:00:00',
-                                state_keys=['si_mode'])
-    assert 'TN_000B4' in kstates['si_mode']
-    assert 'TN_000B6' in kstates['si_mode']
+    kstates = states.get_states(
+        start="2017:189:12:00:00", stop="2017:197:12:00:00", state_keys=["si_mode"]
+    )
+    assert "TN_000B4" in kstates["si_mode"]
+    assert "TN_000B6" in kstates["si_mode"]
 
 
 def test_states_2017():
@@ -219,12 +251,15 @@ def test_states_2017():
     will insert pitch breaks only in NPNT.  (Tested later).
     """
 
-    state_keys = (['obsid', 'clocking', 'power_cmd', 'fep_count']
-                  + ['q1', 'q2', 'q3', 'q4', 'pcad_mode', 'dither', 'ra', 'dec', 'roll']
-                  + ['letg', 'hetg']
-                  + ['simpos', 'simfa_pos'])
-    rcstates, rkstates = compare_states('2017:060:12:00:00', '2017:260:12:00:00',
-                                        state_keys, compare_dates=False)
+    state_keys = (
+        ["obsid", "clocking", "power_cmd", "fep_count"]
+        + ["q1", "q2", "q3", "q4", "pcad_mode", "dither", "ra", "dec", "roll"]
+        + ["letg", "hetg"]
+        + ["simpos", "simfa_pos"]
+    )
+    rcstates, rkstates = compare_states(
+        "2017:060:12:00:00", "2017:260:12:00:00", state_keys, compare_dates=False
+    )
 
     # Check state datestart.  There are 4 known discrepancies of 0.001 sec
     # due to a slight difference in the start time for NSUN maneuvers.  Cmd_states
@@ -234,10 +269,10 @@ def test_states_2017():
     # of the difference in startup between Chandra.cmd_states and kadi.states.
     rkstates = rkstates[1:]
     rcstates = rcstates[1:]
-    bad = np.flatnonzero(rkstates['datestart'] != rcstates['datestart'])
+    bad = np.flatnonzero(rkstates["datestart"] != rcstates["datestart"])
     assert len(bad) == 4
-    tk = DateTime(rkstates['datestart'][bad]).secs
-    tc = DateTime(rcstates['datestart'][bad]).secs
+    tk = DateTime(rkstates["datestart"][bad]).secs
+    tc = DateTime(rcstates["datestart"][bad]).secs
     assert np.all(np.abs(tk - tc) < 0.0015)
 
 
@@ -250,24 +285,25 @@ def test_pitch_2017():
     Make sure that pitch matches to within 0.5 deg in all samples, and 0.05 deg during
     NPNT.
     """
-    rcstates, rkstates = get_states_test('2017:060:12:00:00', '2017:160:12:00:00',
-                                         ['pcad_mode', 'pitch'])
+    rcstates, rkstates = get_states_test(
+        "2017:060:12:00:00", "2017:160:12:00:00", ["pcad_mode", "pitch"]
+    )
 
-    rcstates['tstop'] = DateTime(rcstates['datestop']).secs
-    rkstates['tstop'] = DateTime(rkstates['datestop']).secs
+    rcstates["tstop"] = DateTime(rcstates["datestop"]).secs
+    rkstates["tstop"] = DateTime(rkstates["datestop"]).secs
 
-    times = np.arange(rcstates['tstop'][0], rcstates['tstop'][-2], 200.0)
+    times = np.arange(rcstates["tstop"][0], rcstates["tstop"][-2], 200.0)
     rci = states.interpolate_states(rcstates, times)
     rki = states.interpolate_states(rkstates, times)
 
-    dp = np.abs(rci['pitch'] - rki['pitch'])
+    dp = np.abs(rci["pitch"] - rki["pitch"])
     assert np.all(dp < 0.5)
-    assert np.all(rci['pcad_mode'] == rki['pcad_mode'])
-    ok = rci['pcad_mode'] == 'NPNT'
+    assert np.all(rci["pcad_mode"] == rki["pcad_mode"])
+    ok = rci["pcad_mode"] == "NPNT"
     assert np.all(dp[ok] < 0.05)
 
 
-@pytest.mark.skipif('not HAS_PITCH')
+@pytest.mark.skipif("not HAS_PITCH")
 def test_sun_vec_versus_telemetry():
     """
     Test sun vector values `pitch` and `off_nominal_roll` versus flight telem.  Include
@@ -277,71 +313,101 @@ def test_sun_vec_versus_telemetry():
     State values are within 1.5 degrees of telemetry.
     """
 
-    state_keys = ['pitch', 'off_nom_roll']
-    start, stop = '2017:349:10:00:00', '2017:350:10:00:00'
+    state_keys = ["pitch", "off_nom_roll"]
+    start, stop = "2017:349:10:00:00", "2017:350:10:00:00"
     cmds = commands.get_cmds(start, stop)
-    rk = states.get_states(state_keys=state_keys, cmds=cmds, merge_identical=True)[-20:-1]
+    rk = states.get_states(state_keys=state_keys, cmds=cmds, merge_identical=True)[
+        -20:-1
+    ]
 
-    tstart = DateTime(rk['datestart']).secs
-    tstop = DateTime(rk['datestop']).secs
+    tstart = DateTime(rk["datestart"]).secs
+    tstop = DateTime(rk["datestop"]).secs
     tmid = (tstart + tstop) / 2
 
     # Pitch from telemetry
-    dat = fetch.Msid('pitch', tstart[0] - 100, tstop[-1] + 100)
+    dat = fetch.Msid("pitch", tstart[0] - 100, tstop[-1] + 100)
     dat.interpolate(times=tmid)
-    delta = np.abs(dat.vals - rk['pitch'])
-    assert np.max(rk['pitch']) - np.min(rk['pitch']) > 75  # Big maneuver
+    delta = np.abs(dat.vals - rk["pitch"])
+    assert np.max(rk["pitch"]) - np.min(rk["pitch"]) > 75  # Big maneuver
     assert np.all(delta < 1.5)
 
     # Off nominal roll (not roll from ra,dec,roll) from telemetry
-    dat = fetch.Msid('roll', tstart[0] - 100, tstop[-1] + 100)
+    dat = fetch.Msid("roll", tstart[0] - 100, tstop[-1] + 100)
     dat.interpolate(times=tmid)
-    delta = np.abs(dat.vals - rk['off_nom_roll'])
-    assert np.max(rk['off_nom_roll']) - np.min(rk['off_nom_roll']) > 20  # Large range
+    delta = np.abs(dat.vals - rk["off_nom_roll"])
+    assert np.max(rk["off_nom_roll"]) - np.min(rk["off_nom_roll"]) > 20  # Large range
     assert np.all(delta < 1.5)
 
 
 def test_dither():
     """Values look reasonable given load commands"""
-    cmds = commands.get_cmds('2017:341:21:40:05', '2017:350:00:00:00')
-    rk = states.get_states(state_keys=['dither_phase_pitch', 'dither_phase_yaw',
-                                       'dither_ampl_pitch', 'dither_ampl_yaw',
-                                       'dither_period_pitch', 'dither_period_yaw'],
-                           cmds=cmds)
+    cmds = commands.get_cmds("2017:341:21:40:05", "2017:350:00:00:00")
+    rk = states.get_states(
+        state_keys=[
+            "dither_phase_pitch",
+            "dither_phase_yaw",
+            "dither_ampl_pitch",
+            "dither_ampl_yaw",
+            "dither_period_pitch",
+            "dither_period_yaw",
+        ],
+        cmds=cmds,
+    )
 
-    assert np.all(rk['datestart'] == ['2017:341:21:40:05.265',
-                                      '2017:342:08:26:34.023',
-                                      '2017:345:02:45:50.318',
-                                      '2017:345:09:02:21.704',
-                                      '2017:345:17:18:08.893',
-                                      '2017:346:04:35:44.546',
-                                      '2017:349:21:28:42.426'])
-    assert np.all(rk['dither_phase_pitch'] == 0.0)
-    assert np.all(rk['dither_phase_yaw'] == 0.0)
-    ampls = [20.00149628163879,
-             7.9989482580707696,
-             20.00149628163879,
-             7.9989482580707696,
-             20.00149628163879,
-             7.9989482580707696,
-             20.00149628163879]
-    assert np.allclose(rk['dither_ampl_pitch'], ampls, atol=1e-6, rtol=0)
-    assert np.allclose(rk['dither_ampl_yaw'], ampls, atol=1e-6, rtol=0)
-    assert np.allclose(rk['dither_period_pitch'], [768.5740994184024,
-                                                   707.13038356352104,
-                                                   768.5740994184024,
-                                                   707.13038356352104,
-                                                   768.5740994184024,
-                                                   707.13038356352104,
-                                                   768.5740994184024], atol=1e-6, rtol=0)
+    assert np.all(
+        rk["datestart"]
+        == [
+            "2017:341:21:40:05.265",
+            "2017:342:08:26:34.023",
+            "2017:345:02:45:50.318",
+            "2017:345:09:02:21.704",
+            "2017:345:17:18:08.893",
+            "2017:346:04:35:44.546",
+            "2017:349:21:28:42.426",
+        ]
+    )
+    assert np.all(rk["dither_phase_pitch"] == 0.0)
+    assert np.all(rk["dither_phase_yaw"] == 0.0)
+    ampls = [
+        20.00149628163879,
+        7.9989482580707696,
+        20.00149628163879,
+        7.9989482580707696,
+        20.00149628163879,
+        7.9989482580707696,
+        20.00149628163879,
+    ]
+    assert np.allclose(rk["dither_ampl_pitch"], ampls, atol=1e-6, rtol=0)
+    assert np.allclose(rk["dither_ampl_yaw"], ampls, atol=1e-6, rtol=0)
+    assert np.allclose(
+        rk["dither_period_pitch"],
+        [
+            768.5740994184024,
+            707.13038356352104,
+            768.5740994184024,
+            707.13038356352104,
+            768.5740994184024,
+            707.13038356352104,
+            768.5740994184024,
+        ],
+        atol=1e-6,
+        rtol=0,
+    )
 
-    assert np.allclose(rk['dither_period_yaw'], [1086.9567572759399,
-                                                 999.99938521341483,
-                                                 1086.9567572759399,
-                                                 999.99938521341483,
-                                                 1086.9567572759399,
-                                                 999.99938521341483,
-                                                 1086.9567572759399], atol=1e-6, rtol=0)
+    assert np.allclose(
+        rk["dither_period_yaw"],
+        [
+            1086.9567572759399,
+            999.99938521341483,
+            1086.9567572759399,
+            999.99938521341483,
+            1086.9567572759399,
+            999.99938521341483,
+            1086.9567572759399,
+        ],
+        atol=1e-6,
+        rtol=0,
+    )
 
 
 def test_get_continuity_regress():
@@ -351,74 +417,88 @@ def test_get_continuity_regress():
     tests a bug fix where maneuver transitions were leaking past the stop time.
     It also tests that all continuity times are before the stop time.
     """
-    expected = {'ccd_count': 3,
-                'clocking': 1,
-                'dec': 32.166641023063612,
-                'dither': 'ENAB',
-                'fep_count': 3,
-                'hetg': 'RETR',
-                'letg': 'RETR',
-                'obsid': 20392,
-                'off_nom_roll': -2.0300858116326026,
-                'pcad_mode': 'NMAN',
-                'pitch': 134.5392571808533,
-                'power_cmd': 'XTZ0000005',
-                'q1': -0.32430877626423488,
-                'q2': -0.59794754520454407,
-                'q3': -0.73138983148061287,
-                'q4': 0.048491903554710794,
-                'ra': 158.0145560201608,
-                'roll': 84.946493470873875,
-                'si_mode': 'TE_005C6',
-                'simfa_pos': -468,
-                'simpos': 75624,
-                'targ_q1': 0.304190361,
-                'targ_q2': 0.445053899,
-                'targ_q3': 0.787398757,
-                'targ_q4': 0.298995734,
-                'vid_board': 1}
+    expected = {
+        "ccd_count": 3,
+        "clocking": 1,
+        "dec": 32.166641023063612,
+        "dither": "ENAB",
+        "fep_count": 3,
+        "hetg": "RETR",
+        "letg": "RETR",
+        "obsid": 20392,
+        "off_nom_roll": -2.0300858116326026,
+        "pcad_mode": "NMAN",
+        "pitch": 134.5392571808533,
+        "power_cmd": "XTZ0000005",
+        "q1": -0.32430877626423488,
+        "q2": -0.59794754520454407,
+        "q3": -0.73138983148061287,
+        "q4": 0.048491903554710794,
+        "ra": 158.0145560201608,
+        "roll": 84.946493470873875,
+        "si_mode": "TE_005C6",
+        "simfa_pos": -468,
+        "simpos": 75624,
+        "targ_q1": 0.304190361,
+        "targ_q2": 0.445053899,
+        "targ_q3": 0.787398757,
+        "targ_q4": 0.298995734,
+        "vid_board": 1,
+    }
 
-    dates = {'ccd_count': '2018:001:11:58:21.735',
-             'clocking': '2018:001:11:59:28.735',
-             'dec': '2018:001:11:57:47.798',
-             'dither': '2017:364:11:51:48.955',
-             'fep_count': '2018:001:11:58:21.735',
-             'hetg': '2018:001:02:58:48.143',
-             'letg': '2017:364:10:50:43.995',
-             'obsid': '2018:001:11:55:05.818',
-             'off_nom_roll': '2018:001:11:57:47.798',
-             'pcad_mode': '2018:001:11:52:05.818',
-             'pitch': '2018:001:11:57:47.798',
-             'power_cmd': '2018:001:11:59:28.735',
-             'q1': '2018:001:11:57:47.798',
-             'q2': '2018:001:11:57:47.798',
-             'q3': '2018:001:11:57:47.798',
-             'q4': '2018:001:11:57:47.798',
-             'ra': '2018:001:11:57:47.798',
-             'roll': '2018:001:11:57:47.798',
-             'si_mode': '2018:001:11:59:24.735',
-             'simfa_pos': '2017:364:11:39:00.159',
-             'simpos': '2018:001:02:55:13.804',
-             'targ_q1': '2018:001:11:52:10.175',
-             'targ_q2': '2018:001:11:52:10.175',
-             'targ_q3': '2018:001:11:52:10.175',
-             'targ_q4': '2018:001:11:52:10.175',
-             'vid_board': '2018:001:11:58:21.735'}
+    dates = {
+        "ccd_count": "2018:001:11:58:21.735",
+        "clocking": "2018:001:11:59:28.735",
+        "dec": "2018:001:11:57:47.798",
+        "dither": "2017:364:11:51:48.955",
+        "fep_count": "2018:001:11:58:21.735",
+        "hetg": "2018:001:02:58:48.143",
+        "letg": "2017:364:10:50:43.995",
+        "obsid": "2018:001:11:55:05.818",
+        "off_nom_roll": "2018:001:11:57:47.798",
+        "pcad_mode": "2018:001:11:52:05.818",
+        "pitch": "2018:001:11:57:47.798",
+        "power_cmd": "2018:001:11:59:28.735",
+        "q1": "2018:001:11:57:47.798",
+        "q2": "2018:001:11:57:47.798",
+        "q3": "2018:001:11:57:47.798",
+        "q4": "2018:001:11:57:47.798",
+        "ra": "2018:001:11:57:47.798",
+        "roll": "2018:001:11:57:47.798",
+        "si_mode": "2018:001:11:59:24.735",
+        "simfa_pos": "2017:364:11:39:00.159",
+        "simpos": "2018:001:02:55:13.804",
+        "targ_q1": "2018:001:11:52:10.175",
+        "targ_q2": "2018:001:11:52:10.175",
+        "targ_q3": "2018:001:11:52:10.175",
+        "targ_q4": "2018:001:11:52:10.175",
+        "vid_board": "2018:001:11:58:21.735",
+    }
 
     with states.disable_grating_move_duration():
-        continuity = states.get_continuity('2018:001:12:00:00')
+        continuity = states.get_continuity("2018:001:12:00:00")
 
     for key, val in expected.items():
         if isinstance(val, (int, str)):
             assert continuity[key] == val
         else:
             assert np.isclose(continuity[key], val, rtol=0, atol=1e-7)
-        assert continuity['__dates__'][key] == dates[key]
-        assert continuity['__dates__'][key] < '2018:001:12:00:00.000'
+        assert continuity["__dates__"][key] == dates[key]
+        assert continuity["__dates__"][key] < "2018:001:12:00:00.000"
         # Transitions with no spacecraft command (instead from injected maneuver state breaks)
-        manvr_keys = ('pitch', 'off_nom_roll', 'ra', 'dec', 'roll', 'q1', 'q2', 'q3', 'q4')
+        manvr_keys = (
+            "pitch",
+            "off_nom_roll",
+            "ra",
+            "dec",
+            "roll",
+            "q1",
+            "q2",
+            "q3",
+            "q4",
+        )
         if key not in manvr_keys:
-            cmds = commands.get_cmds(date=continuity['__dates__'][key])
+            cmds = commands.get_cmds(date=continuity["__dates__"][key])
             assert len(cmds) > 0
 
 
@@ -427,14 +507,14 @@ def test_get_continuity_vs_states():
     Functional test: continuity for a certain date should be the same as the last states
     when fed in cmds up through that date.
     """
-    date0 = '2017:014:12:00:00'
+    date0 = "2017:014:12:00:00"
     # Get last state up through `date0`.  Hardwire the lookback here to 21 days.
-    cmds = commands.get_cmds('2016:360:12:00:00', date0)
+    cmds = commands.get_cmds("2016:360:12:00:00", date0)
     sts = states.get_states(cmds=cmds, stop=date0)
     sts0 = sts[-1]
 
     continuity = states.get_continuity(date0)
-    del continuity['__dates__']
+    del continuity["__dates__"]
 
     for key, val in continuity.items():
         if isinstance(val, (int, str)):
@@ -448,95 +528,100 @@ def test_get_states_with_cmds_and_start_stop():
     stop."""
     # Get 6 commands from 2020:001:02:55:00.000 to 2020:001:02:55:01.285
     # (just comm setup commanding)
-    cmds = commands.get_cmds('2020:001:02:00:00', '2020:001:03:00:00')
+    cmds = commands.get_cmds("2020:001:02:00:00", "2020:001:03:00:00")
 
-    sts = states.get_states(cmds=cmds, state_keys=['fep_count'])
+    sts = states.get_states(cmds=cmds, state_keys=["fep_count"])
     assert len(sts) == 1
-    assert sts['datestart'][0] == '2020:001:02:55:00.000'
-    assert sts['datestop'][-1] == '2020:001:02:55:01.285'
-    assert np.all(sts['fep_count'] == 4)
+    assert sts["datestart"][0] == "2020:001:02:55:00.000"
+    assert sts["datestop"][-1] == "2020:001:02:55:01.285"
+    assert np.all(sts["fep_count"] == 4)
 
-    sts = states.get_states(cmds=cmds, state_keys=['fep_count'],
-                            start='2020:001:00:00:00',
-                            stop='2020:002:00:00:00')
+    sts = states.get_states(
+        cmds=cmds,
+        state_keys=["fep_count"],
+        start="2020:001:00:00:00",
+        stop="2020:002:00:00:00",
+    )
     assert len(sts) == 1
-    assert sts['datestart'][0] == '2020:001:00:00:00.000'
-    assert sts['datestop'][-1] == '2020:002:00:00:00.000'
-    assert np.all(sts['fep_count'] == 4)
+    assert sts["datestart"][0] == "2020:001:00:00:00.000"
+    assert sts["datestop"][-1] == "2020:002:00:00:00.000"
+    assert np.all(sts["fep_count"] == 4)
 
 
 def test_get_continuity_keys():
     """Test that output has only the desired state keys. Also test that one can
     provide a string instead of list of state keys"""
-    continuity = states.get_continuity('2017:014:12:00:00', 'clocking')
-    assert set(continuity) == set(['clocking', '__dates__'])
+    continuity = states.get_continuity("2017:014:12:00:00", "clocking")
+    assert set(continuity) == set(["clocking", "__dates__"])
 
 
 def test_get_continuity_fail():
     with pytest.raises(ValueError) as err:
-        states.get_continuity('2017:014:12:00:00', 'letg', lookbacks=[3])
-    assert 'did not find transitions' in str(err)
+        states.get_continuity("2017:014:12:00:00", "letg", lookbacks=[3])
+    assert "did not find transitions" in str(err)
 
 
-@pytest.mark.parametrize('all_keys', [True, False])
+@pytest.mark.parametrize("all_keys", [True, False])
 def test_reduce_states_merge_identical(all_keys):
     tstart = np.arange(0, 5)
     tstop = np.arange(1, 6)
     datestart = DateTime(tstart).date
     datestop = DateTime(tstop).date
-    dat0 = Table([datestart, datestop, tstart, tstop],
-                 names=['datestart', 'datestop', 'tstart', 'tstop'])
+    dat0 = Table(
+        [datestart, datestop, tstart, tstop],
+        names=["datestart", "datestop", "tstart", "tstop"],
+    )
     reduce_states = functools.partial(states.reduce_states, all_keys=all_keys)
 
     # Table with something that changes every time
     dat = dat0.copy()
-    dat['vals'] = np.arange(5)
-    dat['val1'] = 1
-    dat['val_not_key'] = 2  # Not part of the key
-    dr = reduce_states(dat, ['vals', 'val1'], merge_identical=True)
-    reduce_names = ['datestart', 'datestop', 'tstart', 'tstop', 'vals', 'val1']
+    dat["vals"] = np.arange(5)
+    dat["val1"] = 1
+    dat["val_not_key"] = 2  # Not part of the key
+    dr = reduce_states(dat, ["vals", "val1"], merge_identical=True)
+    reduce_names = ["datestart", "datestop", "tstart", "tstop", "vals", "val1"]
     if all_keys:
         # All the original cols + trans_keys
-        assert dr.colnames == dat.colnames + ['trans_keys']
+        assert dr.colnames == dat.colnames + ["trans_keys"]
         assert np.all(dr[dat.colnames] == dat)
     else:
         # No `val_not_key` column
-        assert dr.colnames == reduce_names + ['trans_keys']
+        assert dr.colnames == reduce_names + ["trans_keys"]
         assert np.all(dr[reduce_names] == dat[reduce_names])
 
     # Table with nothing that changes
     dat = dat0.copy()
-    dat['vals'] = 1
-    dat['val1'] = 1
-    dr = reduce_states(dat, ['vals', 'val1'], merge_identical=True)
+    dat["vals"] = 1
+    dat["val1"] = 1
+    dr = reduce_states(dat, ["vals", "val1"], merge_identical=True)
     assert len(dr) == 1
-    assert dr['datestart'][0] == dat['datestart'][0]
-    assert dr['datestop'][0] == dat['datestop'][-1]
+    assert dr["datestart"][0] == dat["datestart"][0]
+    assert dr["datestop"][0] == dat["datestop"][-1]
 
     # Table with edge changes
     dat = dat0.copy()
-    dat['vals'] = [1, 0, 0, 0, 1]
-    dr = reduce_states(dat, ['vals'], merge_identical=True)
+    dat["vals"] = [1, 0, 0, 0, 1]
+    dr = reduce_states(dat, ["vals"], merge_identical=True)
     assert len(dr) == 3
-    assert np.all(dr['datestart'] == dat['datestart'][[0, 1, 4]])
-    assert np.all(dr['datestop'] == dat['datestop'][[0, 3, 4]])
-    assert np.all(dr['vals'] == [1, 0, 1])
+    assert np.all(dr["datestart"] == dat["datestart"][[0, 1, 4]])
+    assert np.all(dr["datestop"] == dat["datestop"][[0, 3, 4]])
+    assert np.all(dr["vals"] == [1, 0, 1])
 
     # Table with multiple changes
     dat = dat0.copy()
-    dat['val1'] = [1, 0, 1, 1, 1]
-    dat['val2'] = [1, 1, 1, 1, 0]
-    dr = reduce_states(dat, ['val1', 'val2'], merge_identical=True)
+    dat["val1"] = [1, 0, 1, 1, 1]
+    dat["val2"] = [1, 1, 1, 1, 0]
+    dr = reduce_states(dat, ["val1", "val2"], merge_identical=True)
     assert len(dr) == 4
-    assert np.all(dr['datestart'] == dat['datestart'][[0, 1, 2, 4]])
-    assert np.all(dr['datestop'] == dat['datestop'][[0, 1, 3, 4]])
-    assert np.all(dr['val1'] == [1, 0, 1, 1])
-    assert np.all(dr['val2'] == [1, 1, 1, 0])
-    assert str(dr['trans_keys'][0]) == 'val1,val2'
-    assert dr['trans_keys'][0] == set(['val1', 'val2'])
-    assert dr['trans_keys'][1] == set(['val1'])
-    assert dr['trans_keys'][2] == set(['val1'])
-    assert dr['trans_keys'][3] == set(['val2'])
+    assert np.all(dr["datestart"] == dat["datestart"][[0, 1, 2, 4]])
+    assert np.all(dr["datestop"] == dat["datestop"][[0, 1, 3, 4]])
+    assert np.all(dr["val1"] == [1, 0, 1, 1])
+    assert np.all(dr["val2"] == [1, 1, 1, 0])
+    assert str(dr["trans_keys"][0]) == "val1,val2"
+    assert dr["trans_keys"][0] == set(["val1", "val2"])
+    assert dr["trans_keys"][1] == set(["val1"])
+    assert dr["trans_keys"][2] == set(["val1"])
+    assert dr["trans_keys"][3] == set(["val2"])
 
 
 def cmd_states_fetch_states(*args, **kwargs):
@@ -547,27 +632,30 @@ def cmd_states_fetch_states(*args, **kwargs):
     the definitive reference for states.
     """
     md5 = hashlib.md5()
-    md5.update(repr(args).encode('utf8'))
-    md5.update(repr(kwargs).encode('utf8'))
+    md5.update(repr(args).encode("utf8"))
+    md5.update(repr(kwargs).encode("utf8"))
     digest = md5.hexdigest()
-    datafile = Path(__file__).parent / 'data' / f'states_{digest}.ecsv'
-    datafile_gz = datafile.parent / (datafile.name + '.gz')
+    datafile = Path(__file__).parent / "data" / f"states_{digest}.ecsv"
+    datafile_gz = datafile.parent / (datafile.name + ".gz")
 
     if datafile_gz.exists():
-        cs = Table.read(datafile_gz, format='ascii.ecsv')
+        cs = Table.read(datafile_gz, format="ascii.ecsv")
     else:
         # Prevent accidentally writing data to flight in case of some packaging problem.
-        if 'KADI_WRITE_TEST_DATA' not in os.environ:
-            raise RuntimeError('cannot find test data. Define KADI_WRITE_TEST_DATA '
-                               'env var to create it.')
+        if "KADI_WRITE_TEST_DATA" not in os.environ:
+            raise RuntimeError(
+                "cannot find test data. Define KADI_WRITE_TEST_DATA "
+                "env var to create it."
+            )
         import Chandra.cmd_states as cmd_states
+
         cs = cmd_states.fetch_states(*args, **kwargs)
         cs = Table(cs)
-        print(f'Writing {datafile_gz} for args={args} kwargs={kwargs}')
-        cs.write(datafile, format='ascii.ecsv')
+        print(f"Writing {datafile_gz} for args={args} kwargs={kwargs}")
+        cs.write(datafile, format="ascii.ecsv")
 
         # Gzip the file
-        with open(datafile, 'rb') as f_in, gzip.open(datafile_gz, 'wb') as f_out:
+        with open(datafile, "rb") as f_in, gzip.open(datafile_gz, "wb") as f_out:
             f_out.writelines(f_in)
         datafile.unlink()
 
@@ -579,43 +667,51 @@ def test_reduce_states_cmd_states():
     Test that simple get_states() call with defaults gives the same results
     as calling cmd_states.fetch_states().
     """
-    cs = cmd_states_fetch_states('2018:235:12:00:00', '2018:245:12:00:00', allow_identical=True)
+    cs = cmd_states_fetch_states(
+        "2018:235:12:00:00", "2018:245:12:00:00", allow_identical=True
+    )
 
-    state_keys = (set(STATE0)
-                  - set(['datestart', 'datestop', 'trans_keys', 'tstart', 'tstop']))
+    state_keys = set(STATE0) - set(
+        ["datestart", "datestop", "trans_keys", "tstart", "tstop"]
+    )
 
     # Default setting is reduce states with merge_identical=False, which is the same
     # as cmd_states.
     with states.disable_grating_move_duration():
-        ksr = states.get_states('2018:235:12:00:00', '2018:245:12:00:00', state_keys)
+        ksr = states.get_states("2018:235:12:00:00", "2018:245:12:00:00", state_keys)
 
     assert len(ksr) == len(cs)
 
-    assert_all_close_states(cs, ksr, set(state_keys) - set(['trans_keys']))
+    assert_all_close_states(cs, ksr, set(state_keys) - set(["trans_keys"]))
 
-    assert np.all(ksr['datestart'][1:] == cs['datestart'][1:])
-    assert np.all(ksr['datestop'][:-1] == cs['datestop'][:-1])
+    assert np.all(ksr["datestart"][1:] == cs["datestart"][1:])
+    assert np.all(ksr["datestop"][:-1] == cs["datestop"][:-1])
 
     # Transition keys after first should match.  cmd_states is a comma-delimited string.
-    for k_trans_keys, c_trans_keys in zip(ksr['trans_keys'][1:], cs['trans_keys'][1:]):
-        assert k_trans_keys == set(c_trans_keys.split(','))
+    for k_trans_keys, c_trans_keys in zip(ksr["trans_keys"][1:], cs["trans_keys"][1:]):
+        assert k_trans_keys == set(c_trans_keys.split(","))
 
 
 ###########################################################################
 # Comparing to backstop history files or regression outputs
 ###########################################################################
 
+
 def compare_backstop_history(history, state_key, compare_val=True):
-    hist = ascii.read(history, guess=False, format='no_header',
-                      converters={'col1': [ascii.convert_numpy(str)]})
-    start = DateTime(hist['col1'][0], format='greta') - 1 / 86400.
-    stop = DateTime(hist['col1'][-1], format='greta') + 1 / 86400.
+    hist = ascii.read(
+        history,
+        guess=False,
+        format="no_header",
+        converters={"col1": [ascii.convert_numpy(str)]},
+    )
+    start = DateTime(hist["col1"][0], format="greta") - 1 / 86400.0
+    stop = DateTime(hist["col1"][-1], format="greta") + 1 / 86400.0
     sts = states.get_states(start=start, stop=stop, state_keys=state_key)
     sts = sts[1:]  # Drop the first state (which is continuity at start time)
     assert len(sts) == len(hist)
-    assert np.all(DateTime(sts['datestart']).greta == hist['col1'])
+    assert np.all(DateTime(sts["datestart"]).greta == hist["col1"])
     if compare_val:
-        assert np.all(sts[state_key] == hist['col3'])
+        assert np.all(sts[state_key] == hist["col3"])
 
 
 def test_backstop_format():
@@ -694,7 +790,7 @@ def test_backstop_format():
 2018209.132330954 | FMT1
 2018209.191502370 | FMT4
 2018209.191920170 | FMT2"""
-    compare_backstop_history(history, 'format')
+    compare_backstop_history(history, "format")
 
 
 def test_backstop_subformat():
@@ -816,7 +912,7 @@ def test_backstop_subformat():
 2018210.210002313 | NORM
 2018211.031002313 | NORM
 """
-    compare_backstop_history(history, 'subformat')
+    compare_backstop_history(history, "subformat")
 
 
 def test_backstop_sun_pos_mon():
@@ -883,7 +979,7 @@ def test_backstop_sun_pos_mon():
 2018006.222954700 | ENAB
 2018007.024422649 | DISA
 """
-    compare_backstop_history(history, 'sun_pos_mon')
+    compare_backstop_history(history, "sun_pos_mon")
 
 
 def test_backstop_sun_pos_mon_lunar():
@@ -907,12 +1003,12 @@ def test_backstop_sun_pos_mon_lunar():
 2017:087:23:59:21.087 2099:365:00:00:00.000        DISA
 """
     spm = ascii.read(history, guess=False)
-    cmds = commands.get_cmds('2017:087:03:04:02', '2017:088:00:00:00')
-    sts = states.get_states(state_keys=['sun_pos_mon'], cmds=cmds)
+    cmds = commands.get_cmds("2017:087:03:04:02", "2017:088:00:00:00")
+    sts = states.get_states(state_keys=["sun_pos_mon"], cmds=cmds)
 
     assert len(sts) == len(spm)
-    assert np.all(sts['datestart'] == spm['datestart'])
-    assert np.all(sts['sun_pos_mon'] == spm['sun_pos_mon'])
+    assert np.all(sts["datestart"] == spm["datestart"])
+    assert np.all(sts["sun_pos_mon"] == spm["sun_pos_mon"])
 
 
 def test_backstop_ephem_update():
@@ -923,7 +1019,7 @@ def test_backstop_ephem_update():
 2017115.034040060 | EPHEMERIS
 2017117.190746809 | EPHEMERIS
 """
-    compare_backstop_history(history, 'ephem_update', compare_val=False)
+    compare_backstop_history(history, "ephem_update", compare_val=False)
 
 
 def test_backstop_radmon_no_scs107():
@@ -959,7 +1055,7 @@ def test_backstop_radmon_no_scs107():
 2017312.131224228 | ENAB OORMPEN
 2017314.122303220 | DISA OORMPDS
 """
-    compare_backstop_history(history, 'radmon')
+    compare_backstop_history(history, "radmon")
 
 
 @pytest.mark.xfail()
@@ -1020,7 +1116,7 @@ def test_backstop_radmon_with_scs107():
 2017097.160524315 | DISA OORMPDS
 2017098.065323315 | ENAB OORMPEN
 """
-    compare_backstop_history(history, 'radmon')
+    compare_backstop_history(history, "radmon")
 
 
 def test_backstop_scs98():
@@ -1061,19 +1157,20 @@ def test_backstop_scs98():
 2017078.102835409 | ENAB
 2017078.172100604 | DISA
 """
-    compare_backstop_history(history, 'scs98')
+    compare_backstop_history(history, "scs98")
 
 
 def test_backstop_scs84():
     """
     SCS 84 has not changed from DISA since 2006 due to a change in operations.
     """
-    sts = states.get_states(start='2017:001:12:00:00', stop='2017:300:12:00:00',
-                            state_keys=['scs84'])
+    sts = states.get_states(
+        start="2017:001:12:00:00", stop="2017:300:12:00:00", state_keys=["scs84"]
+    )
     assert len(sts) == 1
-    assert sts[0]['scs84'] == 'DISA'
-    assert sts[0]['datestart'] == '2017:001:12:00:00.000'
-    assert sts[0]['datestop'] == '2017:300:12:00:00.000'
+    assert sts[0]["scs84"] == "DISA"
+    assert sts[0]["datestart"] == "2017:001:12:00:00.000"
+    assert sts[0]["datestop"] == "2017:300:12:00:00.000"
 
 
 def test_backstop_simpos():
@@ -1112,7 +1209,7 @@ def test_backstop_simpos():
 2017073.210544431 | -99616
 2017074.112120865 | 92904
 """
-    compare_backstop_history(history, 'simpos')
+    compare_backstop_history(history, "simpos")
 
 
 def test_backstop_simfa_pos():
@@ -1148,7 +1245,7 @@ def test_backstop_simfa_pos():
 2017075.041328208 | -991
 2017075.150028950 | -418
 """
-    compare_backstop_history(history, 'simfa_pos')
+    compare_backstop_history(history, "simfa_pos")
 
 
 def test_backstop_grating():
@@ -1172,7 +1269,7 @@ def test_backstop_grating():
 #*****< COMBINED WEEKLY LOAD JUL1017A START @ 2017191.062621188 >*****
 2017191.063255527 | NONE HETGRE
 """
-    compare_backstop_history(history, 'grating')
+    compare_backstop_history(history, "grating")
 
 
 def test_backstop_eclipse_entry():
@@ -1186,15 +1283,15 @@ def test_backstop_eclipse_entry():
 2018003.040001000 | 1405 EOECLETO
 2018005.071227278 | 1171 EOECLETO
 """
-    compare_backstop_history(history, 'eclipse_timer')
+    compare_backstop_history(history, "eclipse_timer")
 
 
 def compare_regress_output(regress, state_key):
-    regr = ascii.read(regress, format='fixed_width_two_line', fill_values=None)
-    start = regr['datestart'][0]
-    stop = regr['datestop'][-1]
+    regr = ascii.read(regress, format="fixed_width_two_line", fill_values=None)
+    start = regr["datestart"][0]
+    stop = regr["datestop"][-1]
     sts = states.get_states(start, stop, state_keys=[state_key])
-    for colname in ('datestart', 'datestop', state_key):
+    for colname in ("datestart", "datestop", state_key):
         assert np.all(regr[colname] == sts[colname])
 
 
@@ -1238,7 +1335,7 @@ def test_regress_eclipse():
 2017:087:07:49:55.838 2017:087:08:10:35.838 PENUMBRA    eclipse
 2017:087:08:10:35.838 2017:090:12:00:00.000      DAY    eclipse
 """
-    compare_regress_output(regress, 'eclipse')
+    compare_regress_output(regress, "eclipse")
 
     regress = """
       datestart              datestop       eclipse  trans_keys
@@ -1274,7 +1371,7 @@ def test_regress_eclipse():
 2018:005:05:09:26.278 2018:005:05:12:26.278 PENUMBRA    eclipse
 2018:005:05:12:26.278 2018:006:12:00:00.000      DAY    eclipse
 """
-    compare_regress_output(regress, 'eclipse')
+    compare_regress_output(regress, "eclipse")
 
 
 def test_continuity_just_after_command():
@@ -1282,12 +1379,12 @@ def test_continuity_just_after_command():
     Fix issue where continuity required having at least one other
     command after the relevant continuity command.
     """
-    cont = states.get_continuity('2018:001:12:00:00', 'targ_q1')
-    assert cont['__dates__']['targ_q1'] == '2018:001:11:52:10.175'
+    cont = states.get_continuity("2018:001:12:00:00", "targ_q1")
+    assert cont["__dates__"]["targ_q1"] == "2018:001:11:52:10.175"
 
     # 1 msec later
-    cont = states.get_continuity('2018:001:11:52:10.176', 'targ_q1')
-    assert cont['__dates__']['targ_q1'] == '2018:001:11:52:10.175'
+    cont = states.get_continuity("2018:001:11:52:10.176", "targ_q1")
+    assert cont["__dates__"]["targ_q1"] == "2018:001:11:52:10.175"
 
 
 def test_continuity_far_future():
@@ -1298,9 +1395,9 @@ def test_continuity_far_future():
     # Now + 150 days.  Don't know the answer but just make sure this
     # runs to completion.  The lookbacks of 7 and 30 days should fail
     # but 180 days will get something.
-    cont = states.get_continuity(DateTime() + 150, 'obsid')
-    assert 'obsid' in cont
-    assert 'obsid' in cont['__dates__']
+    cont = states.get_continuity(DateTime() + 150, "obsid")
+    assert "obsid" in cont
+    assert "obsid" in cont["__dates__"]
 
 
 def test_acis_power_cmds():
@@ -1309,11 +1406,14 @@ def test_acis_power_cmds():
     state_keys = ["power_cmd", "ccd_count", "fep_count", "vid_board"]
     cmds = commands.get_cmds(start, stop)
     continuity = states.get_continuity(start, state_keys)
-    test_states = states.get_states(cmds=cmds, continuity=continuity,
-                                    state_keys=state_keys, reduce=False)
+    test_states = states.get_states(
+        cmds=cmds, continuity=continuity, state_keys=state_keys, reduce=False
+    )
     vid_dn = np.where(test_states["power_cmd"] == "WSVIDALLDN")[0]
     assert (test_states["ccd_count"][vid_dn] == 0).all()
-    assert (test_states["fep_count"][vid_dn] == test_states["fep_count"][vid_dn[0] - 1]).all()
+    assert (
+        test_states["fep_count"][vid_dn] == test_states["fep_count"][vid_dn[0] - 1]
+    ).all()
     pow_zero = np.where(test_states["power_cmd"] == "WSPOW00000")[0]
     assert (test_states["ccd_count"][pow_zero] == 0).all()
     assert (test_states["fep_count"][pow_zero] == 0).all()
@@ -1331,24 +1431,28 @@ def test_continuity_with_transitions_SPM():
     continuity start time.  This will be used by get_states() to get things
     right using this continuity dict.
     """
-    start = '2017:087:08:20:35.838'
-    stop = '2017:087:10:20:35.838'
-    cont = states.get_continuity(start, state_keys=['sun_pos_mon'])
-    assert cont == {'__dates__': {'sun_pos_mon': '2017:087:07:44:55.838'},
-                    '__transitions__': [{'date': '2017:087:08:21:35.838', 'sun_pos_mon': 'ENAB'}],
-                    'sun_pos_mon': 'DISA'}
+    start = "2017:087:08:20:35.838"
+    stop = "2017:087:10:20:35.838"
+    cont = states.get_continuity(start, state_keys=["sun_pos_mon"])
+    assert cont == {
+        "__dates__": {"sun_pos_mon": "2017:087:07:44:55.838"},
+        "__transitions__": [{"date": "2017:087:08:21:35.838", "sun_pos_mon": "ENAB"}],
+        "sun_pos_mon": "DISA",
+    }
 
-    exp = ['      datestart              datestop           tstart        tstop     '
-           'sun_pos_mon  trans_keys',
-           '--------------------- --------------------- ------------- ------------- '
-           '----------- -----------',
-           '2017:087:08:20:35.838 2017:087:08:21:35.838 607076505.022 '
-           '607076565.022        DISA            ',
-           '2017:087:08:21:35.838 2017:087:08:30:50.891 607076565.022 '
-           '607077120.075        ENAB sun_pos_mon',
-           '2017:087:08:30:50.891 2017:087:10:20:35.838 607077120.075 '
-           '607083705.022        DISA sun_pos_mon']
-    sts = states.get_states(start, stop, state_keys=['sun_pos_mon'])
+    exp = [
+        "      datestart              datestop           tstart        tstop     "
+        "sun_pos_mon  trans_keys",
+        "--------------------- --------------------- ------------- ------------- "
+        "----------- -----------",
+        "2017:087:08:20:35.838 2017:087:08:21:35.838 607076505.022 "
+        "607076565.022        DISA            ",
+        "2017:087:08:21:35.838 2017:087:08:30:50.891 607076565.022 "
+        "607077120.075        ENAB sun_pos_mon",
+        "2017:087:08:30:50.891 2017:087:10:20:35.838 607077120.075 "
+        "607083705.022        DISA sun_pos_mon",
+    ]
+    sts = states.get_states(start, stop, state_keys=["sun_pos_mon"])
     assert sts.pformat(max_lines=-1, max_width=-1) == exp
 
 
@@ -1357,9 +1461,11 @@ def test_continuity_with_no_transitions_SPM():
     key set if not needed.  Part of fix for #125.
 
     """
-    cont = states.get_continuity('2017:001:12:00:00', state_keys=['sun_pos_mon'])
-    assert cont == {'sun_pos_mon': 'DISA',
-                    '__dates__': {'sun_pos_mon': '2017:001:04:23:55.764'}}
+    cont = states.get_continuity("2017:001:12:00:00", state_keys=["sun_pos_mon"])
+    assert cont == {
+        "sun_pos_mon": "DISA",
+        "__dates__": {"sun_pos_mon": "2017:001:04:23:55.764"},
+    }
 
 
 def test_get_pitch_from_mid_maneuver():
@@ -1367,25 +1473,27 @@ def test_get_pitch_from_mid_maneuver():
     the Maneuver transition class.
 
     """
-    start = '2019:039:14:16:25.002'  # Mid-maneuver
-    stop = '2019:039:16:00:00.000'
-    exp = ['      datestart              datestop           pitch     pcad_mode',
-           '--------------------- --------------------- ------------- ---------',
-           '2019:039:14:16:25.002 2019:039:14:16:54.364 63.2696565838      NMAN',
-           '2019:039:14:16:54.364 2019:039:14:22:01.825 83.0388345752      NMAN',
-           '2019:039:14:22:01.825 2019:039:14:27:09.285 106.057258631      NMAN',
-           '2019:039:14:27:09.285 2019:039:14:32:16.745 129.079427541      NMAN',
-           '2019:039:14:32:16.745 2019:039:14:37:24.205 148.857427163      NMAN',
-           '2019:039:14:37:24.205 2019:039:14:42:31.665 159.541502291      NMAN',
-           '2019:039:14:42:31.665 2019:039:16:00:00.000 161.950922135      NPNT']
-    exp = Table.read(exp, format='ascii')
+    start = "2019:039:14:16:25.002"  # Mid-maneuver
+    stop = "2019:039:16:00:00.000"
+    exp = [
+        "      datestart              datestop           pitch     pcad_mode",
+        "--------------------- --------------------- ------------- ---------",
+        "2019:039:14:16:25.002 2019:039:14:16:54.364 63.2696565838      NMAN",
+        "2019:039:14:16:54.364 2019:039:14:22:01.825 83.0388345752      NMAN",
+        "2019:039:14:22:01.825 2019:039:14:27:09.285 106.057258631      NMAN",
+        "2019:039:14:27:09.285 2019:039:14:32:16.745 129.079427541      NMAN",
+        "2019:039:14:32:16.745 2019:039:14:37:24.205 148.857427163      NMAN",
+        "2019:039:14:37:24.205 2019:039:14:42:31.665 159.541502291      NMAN",
+        "2019:039:14:42:31.665 2019:039:16:00:00.000 161.950922135      NPNT",
+    ]
+    exp = Table.read(exp, format="ascii")
 
-    sts = states.get_states(start, stop, state_keys=['pitch', 'pcad_mode'])
+    sts = states.get_states(start, stop, state_keys=["pitch", "pcad_mode"])
 
-    assert np.all(exp['datestart'] == sts['datestart'])
-    assert np.all(exp['datestop'] == sts['datestop'])
-    assert np.all(exp['pcad_mode'] == sts['pcad_mode'])
-    assert np.all(np.isclose(exp['pitch'], sts['pitch'], rtol=0, atol=1e-8))
+    assert np.all(exp["datestart"] == sts["datestart"])
+    assert np.all(exp["datestop"] == sts["datestop"])
+    assert np.all(exp["pcad_mode"] == sts["pcad_mode"])
+    assert np.all(np.isclose(exp["pitch"], sts["pitch"], rtol=0, atol=1e-8))
 
 
 def test_get_states_start_between_aouptarg_aomanuvr_cmds():
@@ -1405,26 +1513,32 @@ def test_get_states_start_between_aouptarg_aomanuvr_cmds():
     """
     # This fails prior to the fix with ValueError: cannot convert float NaN to
     # integer in Chandra.Maneuver.
-    sts = states.get_states('2021:025:13:56:00.000', '2021:026:00:00:00',
-                            state_keys=('q1', 'pcad_mode'), continuity={})
-    exp = ['      datestart              datestop            q1     pcad_mode',
-           '--------------------- --------------------- ----------- ---------',
-           '2021:025:13:56:00.000 2021:025:23:43:14.731        None      None',
-           '2021:025:23:43:14.731 2021:025:23:43:24.982        None      NMAN',
-           '2021:025:23:43:24.982 2021:025:23:47:24.982 0.129399482      NMAN',
-           '2021:025:23:47:24.982 2021:026:00:00:00.000 0.129399482      NPNT']  # noqa
+    sts = states.get_states(
+        "2021:025:13:56:00.000",
+        "2021:026:00:00:00",
+        state_keys=("q1", "pcad_mode"),
+        continuity={},
+    )
+    exp = [
+        "      datestart              datestop            q1     pcad_mode",
+        "--------------------- --------------------- ----------- ---------",
+        "2021:025:13:56:00.000 2021:025:23:43:14.731        None      None",
+        "2021:025:23:43:14.731 2021:025:23:43:24.982        None      NMAN",
+        "2021:025:23:43:24.982 2021:025:23:47:24.982 0.129399482      NMAN",
+        "2021:025:23:47:24.982 2021:026:00:00:00.000 0.129399482      NPNT",
+    ]  # noqa
 
-    exp = Table.read(exp, format='ascii', fill_values=[('None', '0')])
-    for name in ('datestart', 'datestop', 'pcad_mode'):
+    exp = Table.read(exp, format="ascii", fill_values=[("None", "0")])
+    for name in ("datestart", "datestop", "pcad_mode"):
         assert np.all(sts[name] == exp[name])
-    assert np.allclose(sts['q1'][2:].astype(float), exp['q1'][2:])
-    assert sts['q1'][0] is None
-    assert sts['q1'][1] is None
-    assert sts['pcad_mode'][0] is None
+    assert np.allclose(sts["q1"][2:].astype(float), exp["q1"][2:])
+    assert sts["q1"][0] is None
+    assert sts["q1"][1] is None
+    assert sts["pcad_mode"][0] is None
 
     # Failure example from #198
-    cont = states.get_continuity('2021:032:13:56:00.000')
-    assert cont['__dates__']['q1'] == '2021:032:12:49:45.458'
+    cont = states.get_continuity("2021:032:13:56:00.000")
+    assert cont["__dates__"]["q1"] == "2021:032:12:49:45.458"
 
 
 def test_get_continuity_and_pitch_from_mid_maneuver():
@@ -1433,9 +1547,9 @@ def test_get_continuity_and_pitch_from_mid_maneuver():
 
     Continuity during mid-maneuver was incorrect.
     """
-    start = '2017:207:23:35:00'
-    stop = '2017:208:00:00:00'
-    sts = states.get_states(start, stop, state_keys=['pitch', 'pcad_mode'])
+    start = "2017:207:23:35:00"
+    stop = "2017:208:00:00:00"
+    sts = states.get_states(start, stop, state_keys=["pitch", "pcad_mode"])
     exp = """
     datestart              datestop                   pitch        pcad_mode
     --------------------- --------------------- ------------------ ---------
@@ -1444,71 +1558,80 @@ def test_get_continuity_and_pitch_from_mid_maneuver():
     2017:207:23:42:25.863 2017:207:23:45:30.816  57.13454809508824      NPNT
     2017:207:23:45:30.816 2017:208:00:00:00.000 57.132522367348834      NPNT
     """
-    exp = Table.read(exp, format='ascii')
+    exp = Table.read(exp, format="ascii")
 
-    assert np.all(exp['datestart'] == sts['datestart'])
-    assert np.all(exp['datestop'] == sts['datestop'])
-    assert np.all(exp['pcad_mode'] == sts['pcad_mode'])
-    assert np.all(np.isclose(exp['pitch'], sts['pitch'], rtol=0, atol=1e-8))
+    assert np.all(exp["datestart"] == sts["datestart"])
+    assert np.all(exp["datestop"] == sts["datestop"])
+    assert np.all(exp["pcad_mode"] == sts["pcad_mode"])
+    assert np.all(np.isclose(exp["pitch"], sts["pitch"], rtol=0, atol=1e-8))
 
-    cont = states.get_continuity(start, state_keys=['pitch', 'pcad_mode'])
-    assert np.isclose(cont['pitch'], sts['pitch'][0], rtol=0, atol=1e-8)
-    assert cont['pcad_mode'] == sts['pcad_mode'][0]
+    cont = states.get_continuity(start, state_keys=["pitch", "pcad_mode"])
+    assert np.isclose(cont["pitch"], sts["pitch"][0], rtol=0, atol=1e-8)
+    assert cont["pcad_mode"] == sts["pcad_mode"][0]
 
 
 def test_acisfp_setpoint_state():
-    sts = states.get_states('1999-01-01 12:00:00', '2004-01-01 12:00:00',
-                            state_keys='acisfp_setpoint')
-    del sts['tstart']
-    del sts['tstop']
+    sts = states.get_states(
+        "1999-01-01 12:00:00", "2004-01-01 12:00:00", state_keys="acisfp_setpoint"
+    )
+    del sts["tstart"]
+    del sts["tstop"]
 
     assert repr(sts).splitlines() == [
-        '<Table length=5>',
-        '      datestart              datestop       acisfp_setpoint    trans_keys  ',
-        '        str21                 str21             float64          object    ',
-        '--------------------- --------------------- --------------- ---------------',
-        '1999:001:12:00:00.000 2003:130:05:07:28.341          -121.0                ',
-        '2003:130:05:07:28.341 2003:130:19:09:28.930          -130.0 acisfp_setpoint',
-        '2003:130:19:09:28.930 2003:132:14:22:33.782          -121.0 acisfp_setpoint',
-        '2003:132:14:22:33.782 2003:133:22:04:22.425          -130.0 acisfp_setpoint',
-        '2003:133:22:04:22.425 2004:001:12:00:00.000          -121.0 acisfp_setpoint']
+        "<Table length=5>",
+        "      datestart              datestop       acisfp_setpoint    trans_keys  ",
+        "        str21                 str21             float64          object    ",
+        "--------------------- --------------------- --------------- ---------------",
+        "1999:001:12:00:00.000 2003:130:05:07:28.341          -121.0                ",
+        "2003:130:05:07:28.341 2003:130:19:09:28.930          -130.0 acisfp_setpoint",
+        "2003:130:19:09:28.930 2003:132:14:22:33.782          -121.0 acisfp_setpoint",
+        "2003:132:14:22:33.782 2003:133:22:04:22.425          -130.0 acisfp_setpoint",
+        "2003:133:22:04:22.425 2004:001:12:00:00.000          -121.0 acisfp_setpoint",
+    ]
 
-    sts = states.get_states('2018-01-01 12:00:00', '2020-03-01 12:00:00',
-                            state_keys='acisfp_setpoint')
-    del sts['tstart']
-    del sts['tstop']
+    sts = states.get_states(
+        "2018-01-01 12:00:00", "2020-03-01 12:00:00", state_keys="acisfp_setpoint"
+    )
+    del sts["tstart"]
+    del sts["tstop"]
     assert repr(sts).splitlines() == [
-        '<Table length=6>',
-        '      datestart              datestop       acisfp_setpoint    trans_keys  ',
-        '        str21                 str21             float64          object    ',
-        '--------------------- --------------------- --------------- ---------------',
-        '2018:001:12:00:00.000 2018:249:20:16:04.603          -121.0                ',
-        '2018:249:20:16:04.603 2018:250:07:19:51.657          -126.0 acisfp_setpoint',
-        '2018:250:07:19:51.657 2018:294:22:29:00.000          -121.0 acisfp_setpoint',
-        '2018:294:22:29:00.000 2020:048:20:59:22.304          -121.0 acisfp_setpoint',
-        '2020:048:20:59:22.304 2020:049:13:05:52.537          -126.0 acisfp_setpoint',
-        '2020:049:13:05:52.537 2020:061:12:00:00.000          -121.0 acisfp_setpoint']
+        "<Table length=6>",
+        "      datestart              datestop       acisfp_setpoint    trans_keys  ",
+        "        str21                 str21             float64          object    ",
+        "--------------------- --------------------- --------------- ---------------",
+        "2018:001:12:00:00.000 2018:249:20:16:04.603          -121.0                ",
+        "2018:249:20:16:04.603 2018:250:07:19:51.657          -126.0 acisfp_setpoint",
+        "2018:250:07:19:51.657 2018:294:22:29:00.000          -121.0 acisfp_setpoint",
+        "2018:294:22:29:00.000 2020:048:20:59:22.304          -121.0 acisfp_setpoint",
+        "2020:048:20:59:22.304 2020:049:13:05:52.537          -126.0 acisfp_setpoint",
+        "2020:049:13:05:52.537 2020:061:12:00:00.000          -121.0 acisfp_setpoint",
+    ]
 
 
 def test_grating_motion_states():
-    sts = states.get_states('2021:227:12:00:00', '2021:230:12:00:00',
-                            state_keys=['letg', 'hetg', 'grating'])
-    del sts['tstart']
-    del sts['tstop']
-    exp = ['      datestart              datestop          letg      hetg   grating  trans_keys ',
-           '--------------------- --------------------- --------- --------- ------- ------------',
-           '2021:227:12:00:00.000 2021:227:23:06:03.276      RETR      RETR    NONE             ',
-           '2021:227:23:06:03.276 2021:227:23:08:40.276      RETR INSR_MOVE    HETG grating,hetg',
-           '2021:227:23:08:40.276 2021:228:08:15:00.722      RETR      INSR    HETG         hetg',
-           '2021:228:08:15:00.722 2021:228:08:17:33.722      RETR RETR_MOVE    NONE grating,hetg',
-           '2021:228:08:17:33.722 2021:229:17:41:45.525      RETR      RETR    NONE         hetg',
-           '2021:229:17:41:45.525 2021:229:17:45:08.525 INSR_MOVE      RETR    LETG grating,letg',
-           '2021:229:17:45:08.525 2021:230:00:37:56.002      INSR      RETR    LETG         letg',
-           '2021:230:00:37:56.002 2021:230:00:41:19.002 RETR_MOVE      RETR    NONE grating,letg',
-           '2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg']
+    sts = states.get_states(
+        "2021:227:12:00:00", "2021:230:12:00:00", state_keys=["letg", "hetg", "grating"]
+    )
+    del sts["tstart"]
+    del sts["tstop"]
+    exp = [
+        "      datestart              datestop          letg      hetg   grating  trans_keys ",
+        "--------------------- --------------------- --------- --------- ------- ------------",
+        "2021:227:12:00:00.000 2021:227:23:06:03.276      RETR      RETR    NONE             ",
+        "2021:227:23:06:03.276 2021:227:23:08:40.276      RETR INSR_MOVE    HETG grating,hetg",
+        "2021:227:23:08:40.276 2021:228:08:15:00.722      RETR      INSR    HETG         hetg",
+        "2021:228:08:15:00.722 2021:228:08:17:33.722      RETR RETR_MOVE    NONE grating,hetg",
+        "2021:228:08:17:33.722 2021:229:17:41:45.525      RETR      RETR    NONE         hetg",
+        "2021:229:17:41:45.525 2021:229:17:45:08.525 INSR_MOVE      RETR    LETG grating,letg",
+        "2021:229:17:45:08.525 2021:230:00:37:56.002      INSR      RETR    LETG         letg",
+        "2021:230:00:37:56.002 2021:230:00:41:19.002 RETR_MOVE      RETR    NONE grating,letg",
+        "2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg",
+    ]
     assert sts.pformat_all() == exp
 
 
 def test_early_start_exception():
-    with pytest.raises(ValueError, match="no continuity found for start='2002:001:00:00:00.000'"):
-        states.get_states('2002:001', '2003:001', state_keys=['orbit_point'])
+    with pytest.raises(
+        ValueError, match="no continuity found for start='2002:001:00:00:00.000'"
+    ):
+        states.get_states("2002:001", "2003:001", state_keys=["orbit_point"])

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1,19 +1,19 @@
 import functools
-import os
-import hashlib
-from pathlib import Path
 import gzip
+import hashlib
+import os
+from pathlib import Path
+
 import numpy as np
+import pytest
+from astropy.io import ascii
+from astropy.table import Table
+from Chandra.Time import DateTime
+from Ska.engarchive import fetch
+from testr.test_helper import has_internet
 
 from kadi import commands
 from kadi.commands import states
-import pytest
-from testr.test_helper import has_internet
-
-from Chandra.Time import DateTime
-from Ska.engarchive import fetch
-from astropy.io import ascii
-from astropy.table import Table
 
 try:
     fetch.get_time_range("dp_pitch")

--- a/kadi/config.py
+++ b/kadi/config.py
@@ -11,4 +11,4 @@ from astropy import config
 
 
 class ConfigItem(config.ConfigItem):
-    rootname = 'kadi'
+    rootname = "kadi"

--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -41,8 +41,8 @@ More help available at:
     http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/#details
 """
 
-import os
 import importlib
+import os
 
 # In addition, set DJANGO_ALLOW_ASYNC_UNSAFE, to avoid exception seen running in
 # Jupyter notebook: SynchronousOnlyOperation: You cannot call this from an async

--- a/kadi/events/__init__.py
+++ b/kadi/events/__init__.py
@@ -48,7 +48,7 @@ import importlib
 # Jupyter notebook: SynchronousOnlyOperation: You cannot call this from an async
 # context. See: https://stackoverflow.com/questions/59119396
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'kadi.settings'
+os.environ["DJANGO_SETTINGS_MODULE"] = "kadi.settings"
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 # Below is a list of every event query function + the `kadi.events.models`
@@ -68,29 +68,29 @@ os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 # With this trick of lazy loading, both pathways work!
 
 __all__ = [
-    'EventQuery',
-    'models',
-    'obsids',
-    'tsc_moves',
-    'dark_cal_replicas',
-    'dark_cals',
-    'scs107s',
-    'fa_moves',
-    'grating_moves',
-    'dumps',
-    'eclipses',
-    'manvrs',
-    'dwells',
-    'safe_suns',
-    'normal_suns',
-    'major_events',
-    'caps',
-    'load_segments',
-    'pass_plans',
-    'dsn_comms',
-    'orbits',
-    'rad_zones',
-    'ltt_bads'
+    "EventQuery",
+    "models",
+    "obsids",
+    "tsc_moves",
+    "dark_cal_replicas",
+    "dark_cals",
+    "scs107s",
+    "fa_moves",
+    "grating_moves",
+    "dumps",
+    "eclipses",
+    "manvrs",
+    "dwells",
+    "safe_suns",
+    "normal_suns",
+    "major_events",
+    "caps",
+    "load_segments",
+    "pass_plans",
+    "dsn_comms",
+    "orbits",
+    "rad_zones",
+    "ltt_bads",
 ]
 
 
@@ -99,7 +99,7 @@ def __getattr__(name):
     Get the attribute from the query module.
     """
     if name in __all__:
-        query = importlib.import_module('kadi.events.query')
+        query = importlib.import_module("kadi.events.query")
         out = globals()[name] = getattr(query, name)
         return out
     else:

--- a/kadi/events/json_field.py
+++ b/kadi/events/json_field.py
@@ -27,8 +27,8 @@ class JSONEncoder(simplejson.JSONEncoder):
         if isinstance(obj, Decimal):
             return str(obj)
         elif isinstance(obj, datetime.datetime):
-            assert settings.TIME_ZONE == 'UTC'
-            return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+            assert settings.TIME_ZONE == "UTC"
+            return obj.strftime("%Y-%m-%dT%H:%M:%SZ")
         return simplejson.JSONEncoder.default(self, obj)
 
 
@@ -38,9 +38,7 @@ def dumps(value):
 
 def loads(txt):
     value = simplejson.loads(
-        txt,
-        parse_float=Decimal,
-        encoding=settings.DEFAULT_CHARSET
+        txt, parse_float=Decimal, encoding=settings.DEFAULT_CHARSET
     )
     return value
 
@@ -69,16 +67,16 @@ class JSONField(models.TextField, metaclass=models.SubfieldBase):
     JSON objects seamlessly.  Main thingy must be a dict object."""
 
     def __init__(self, *args, **kwargs):
-        default = kwargs.get('default')
+        default = kwargs.get("default")
         if not default:
-            kwargs['default'] = '{}'
+            kwargs["default"] = "{}"
         elif isinstance(default, (list, dict)):
-            kwargs['default'] = dumps(default)
+            kwargs["default"] = dumps(default)
         models.TextField.__init__(self, *args, **kwargs)
 
     def to_python(self, value):
         """Convert our string value to JSON after we load it from the DB"""
-        if value is None or value == '':
+        if value is None or value == "":
             return {}
         elif isinstance(value, str):
             res = loads(value)
@@ -95,13 +93,15 @@ class JSONField(models.TextField, metaclass=models.SubfieldBase):
         if not isinstance(value, (list, dict)):
             return super(JSONField, self).get_db_prep_save("", connection=connection)
         else:
-            return super(JSONField, self).get_db_prep_save(dumps(value),
-                                                           connection=connection)
+            return super(JSONField, self).get_db_prep_save(
+                dumps(value), connection=connection
+            )
 
     def south_field_triple(self):
         "Returns a suitable description of this field for South."
         # We'll just introspect the _actual_ field.
         from south.modelsinspector import introspector
+
         field_class = "django.db.models.fields.TextField"
         args, kwargs = introspector(self)
         # That's our definition!

--- a/kadi/events/json_field.py
+++ b/kadi/events/json_field.py
@@ -17,8 +17,9 @@ https://github.com/django-extensions/django-extensions/
 
 import datetime
 from decimal import Decimal
-from django.db import models
+
 from django.conf import settings
+from django.db import models
 from django.utils import simplejson
 
 

--- a/kadi/events/manvr_templates.py
+++ b/kadi/events/manvr_templates.py
@@ -13,9 +13,9 @@ def get_manvr_templates():
     """
     templates = []
     dat_str = get_dat_str()
-    tables = dat_str.split('---------------------------------------------------')
+    tables = dat_str.split("---------------------------------------------------")
     for table in tables:
-        lines = [x.split('|')[0].strip() for x in table.splitlines() if x.strip()]
+        lines = [x.split("|")[0].strip() for x in table.splitlines() if x.strip()]
         name = lines[0].split()[0]
         templates.append((name, lines[1:]))
     return templates
@@ -187,5 +187,5 @@ aofattmd_STDY_MNVR | 2000:015:05:46:51.421  40561.3
     return dat
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     get_manvr_templates()

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import sys
 import operator
+import sys
+from itertools import count
 from pathlib import Path
 
-from itertools import count
-
-from django.db import models
 import pyyaks.logger
+from django.db import models
+
 from .manvr_templates import get_manvr_templates
 
 models.query.REPR_OUTPUT_SIZE = 1000  # Increase default number of rows printed
@@ -151,13 +151,13 @@ def import_ska(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        from Chandra.Time import DateTime
-        from Ska.Numpy import interpolate
-        from Quaternion import Quat
-        import Ska.engarchive.fetch_eng as fetch
-        from Ska.engarchive import utils
         import numpy as np
+        import Ska.engarchive.fetch_eng as fetch
         from astropy import table
+        from Chandra.Time import DateTime
+        from Quaternion import Quat
+        from Ska.engarchive import utils
+        from Ska.Numpy import interpolate
 
         globals()["interpolate"] = interpolate
         globals()["DateTime"] = DateTime
@@ -356,6 +356,7 @@ class BaseModel(models.Model):
             :returns: list of overlapping events
             """
             from Chandra.Time import DateTime
+
             from .query import combine_intervals
 
             # First find the intervals corresponding to overlaps between self events and
@@ -2045,8 +2046,9 @@ class MajorEvent(BaseEvent):
         """
         Get Major Events from FDB and FOT tables on the OCCweb
         """
-        from . import scrape
         import hashlib
+
+        from . import scrape
 
         tstart = DateTime(start).secs
         tstop = DateTime(stop).secs

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -23,8 +23,9 @@ ZERO_DT = -1e-4
 MAX_GAP = 328.1  # Max gap (seconds) in telemetry for state intervals
 R2A = 206264.8  # Convert from radians to arcsec
 
-logger = pyyaks.logger.get_logger(name='events', level=pyyaks.logger.INFO,
-                                  format="%(asctime)s %(message)s")
+logger = pyyaks.logger.get_logger(
+    name="events", level=pyyaks.logger.INFO, format="%(asctime)s %(message)s"
+)
 
 
 def msidset_interpolate(msidset, dt, time0):
@@ -51,16 +52,16 @@ def _get_si(simpos):
     """
     Get SI corresponding to the given SIM position.
     """
-    if ((simpos >= 82109) and (simpos <= 104839)):
-        si = 'ACIS-I'
-    elif ((simpos >= 70736) and (simpos <= 82108)):
-        si = 'ACIS-S'
-    elif ((simpos >= -86147) and (simpos <= -20000)):
-        si = ' HRC-I'
-    elif ((simpos >= -104362) and (simpos <= -86148)):
-        si = ' HRC-S'
+    if (simpos >= 82109) and (simpos <= 104839):
+        si = "ACIS-I"
+    elif (simpos >= 70736) and (simpos <= 82108):
+        si = "ACIS-S"
+    elif (simpos >= -86147) and (simpos <= -20000):
+        si = " HRC-I"
+    elif (simpos >= -104362) and (simpos <= -86148):
+        si = " HRC-S"
     else:
-        si = '  NONE'
+        si = "  NONE"
     return si
 
 
@@ -73,11 +74,11 @@ def _get_start_stop_vals(tstart, tstop, msidset, msids):
     out = {}
     rel_msids = [msidset[msid] for msid in msids]
     for rel_msid in rel_msids:
-        vals = interpolate(rel_msid.vals, rel_msid.times,
-                           [tstart, tstop],
-                           method='nearest')
-        out['start_{}'.format(rel_msid.msid)] = vals[0]
-        out['stop_{}'.format(rel_msid.msid)] = vals[1]
+        vals = interpolate(
+            rel_msid.vals, rel_msid.times, [tstart, tstop], method="nearest"
+        )
+        out["start_{}".format(rel_msid.msid)] = vals[0]
+        out["stop_{}".format(rel_msid.msid)] = vals[1]
 
     return out
 
@@ -91,17 +92,33 @@ def _get_msid_changes(msids, sortmsids={}):
     for msid in msids:
         i_changes = np.flatnonzero(msid.vals[1:] != msid.vals[:-1])
         for i in i_changes:
-            change = (msid.msid,
-                      sortmsids.get(msid.msid, 10),
-                      msid.vals[i], msid.vals[i + 1],
-                      DateTime(msid.times[i]).date, DateTime(msid.times[i + 1]).date,
-                      0.0,
-                      msid.times[i], msid.times[i + 1],
-                      )
+            change = (
+                msid.msid,
+                sortmsids.get(msid.msid, 10),
+                msid.vals[i],
+                msid.vals[i + 1],
+                DateTime(msid.times[i]).date,
+                DateTime(msid.times[i + 1]).date,
+                0.0,
+                msid.times[i],
+                msid.times[i + 1],
+            )
             changes.append(change)
-    changes = np.rec.fromrecords(changes, names=('msid', 'sortmsid', 'prev_val', 'val',
-                                                 'prev_date', 'date', 'dt', 'prev_time', 'time'))
-    changes.sort(order=['time', 'sortmsid'])
+    changes = np.rec.fromrecords(
+        changes,
+        names=(
+            "msid",
+            "sortmsid",
+            "prev_val",
+            "val",
+            "prev_date",
+            "date",
+            "dt",
+            "prev_time",
+            "time",
+        ),
+    )
+    changes.sort(order=["time", "sortmsid"])
     return changes
 
 
@@ -141,14 +158,16 @@ def import_ska(func):
         from Ska.engarchive import utils
         import numpy as np
         from astropy import table
-        globals()['interpolate'] = interpolate
-        globals()['DateTime'] = DateTime
-        globals()['fetch'] = fetch
-        globals()['utils'] = utils
-        globals()['np'] = np
-        globals()['Quat'] = Quat
-        globals()['table'] = table
+
+        globals()["interpolate"] = interpolate
+        globals()["DateTime"] = DateTime
+        globals()["fetch"] = fetch
+        globals()["utils"] = utils
+        globals()["np"] = np
+        globals()["Quat"] = Quat
+        globals()["table"] = table
         return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -165,18 +184,18 @@ def fuzz_states(states, t_fuzz):
     :returns fuzzed_states: table
     """
     done = False
-    state_has_val = 'val' in states.dtype.names
+    state_has_val = "val" in states.dtype.names
     while not done:
         for i, state0, state1 in zip(count(), states, states[1:]):
             # Logical intervals all have a 'val' of True by definition, while for state
             # intervals we need to check that adjacent intervals have same value.
-            state_equal = (state0['val'] == state1['val'] if state_has_val else True)
-            if state1['tstart'] - state0['tstop'] < t_fuzz and state_equal:
+            state_equal = state0["val"] == state1["val"] if state_has_val else True
+            if state1["tstart"] - state0["tstop"] < t_fuzz and state_equal:
                 # Merge state1 into state0 and delete state1
-                state0['tstop'] = state1['tstop']
-                state0['datestop'] = state1['datestop']
-                state0['duration'] = state0['tstop'] - state0['tstart']
-                states = table.vstack([states[:i + 1], states[i + 2:]])  # noqa
+                state0["tstop"] = state1["tstop"]
+                state0["datestop"] = state1["datestop"]
+                state0["duration"] = state0["tstop"] - state0["tstart"]
+                states = table.vstack([states[: i + 1], states[i + 2 :]])  # noqa
                 break
         else:
             done = True
@@ -199,8 +218,9 @@ class Pad(object):
         self.stop = stop or 0.0
 
     def __repr__(self):
-        return '<{} start={} stop={} seconds>'.format(
-            self.__class__.__name__, self.start, self.stop)
+        return "<{} start={} stop={} seconds>".format(
+            self.__class__.__name__, self.start, self.stop
+        )
 
 
 class IntervalPad(object):
@@ -211,7 +231,7 @@ class IntervalPad(object):
     """
 
     def __get__(self, instance, owner):
-        if not hasattr(instance, '_pad'):
+        if not hasattr(instance, "_pad"):
             instance._pad = Pad(0, 0)
         return instance._pad
 
@@ -233,7 +253,9 @@ class IntervalPad(object):
                 elif len_val == 2:
                     val_start, val_stop = val[0], val[1]
                 else:
-                    raise ValueError('interval_pad must be a float scalar, or 1 or 2-element list')
+                    raise ValueError(
+                        "interval_pad must be a float scalar, or 1 or 2-element list"
+                    )
 
         instance._pad = Pad(float(val_start), float(val_stop))
 
@@ -242,11 +264,12 @@ class Update(models.Model):
     """
     Last telemetry which was searched for an update.
     """
+
     name = models.CharField(max_length=30, primary_key=True)  # model name
     date = models.CharField(max_length=21)
 
     def __unicode__(self):
-        return ('name={} date={}'.format(self.name, self.date))
+        return "name={} date={}".format(self.name, self.date)
 
 
 class MyManager(models.Manager):
@@ -266,7 +289,8 @@ class BaseModel(models.Model):
     """
     Base class for for all models.
     """
-    _get_obsid_start_attr = 'date'  # Attribute to use for getting event obsid
+
+    _get_obsid_start_attr = "date"  # Attribute to use for getting event obsid
     update_priority = 0  # Priority order in update processing (higher => earlier)
 
     class QuerySet(models.query.QuerySet):
@@ -275,28 +299,32 @@ class BaseModel(models.Model):
         """
 
         def __repr__(self):
-            data = list(self[:models.query.REPR_OUTPUT_SIZE + 1])
+            data = list(self[: models.query.REPR_OUTPUT_SIZE + 1])
             if len(data) > models.query.REPR_OUTPUT_SIZE:
                 data[-1] = "...(remaining elements truncated)..."
-            return '\n'.join(repr(x) for x in data)
+            return "\n".join(repr(x) for x in data)
 
         @property
         def table(self):
             def un_unicode(vals):
-                return tuple(val.encode('ascii') if isinstance(val, str) else val
-                             for val in vals)
+                return tuple(
+                    val.encode("ascii") if isinstance(val, str) else val for val in vals
+                )
 
             from astropy.table import Table
 
             model_fields = self.model.get_model_fields()
             names = [f.name for f in model_fields]
             rows = self.values_list()
-            cols = (list(zip(*rows)) if len(rows) > 0 else None)
+            cols = list(zip(*rows)) if len(rows) > 0 else None
             dat = Table(cols, names=names)
 
-            drop_names = [name for name in dat.dtype.names if dat[name].dtype.kind == 'O']
-            drop_names.extend([f.name for f in model_fields
-                               if getattr(f, '_kadi_hidden', False)])
+            drop_names = [
+                name for name in dat.dtype.names if dat[name].dtype.kind == "O"
+            ]
+            drop_names.extend(
+                [f.name for f in model_fields if getattr(f, "_kadi_hidden", False)]
+            )
             if drop_names:
                 dat.remove_columns(drop_names)
 
@@ -341,17 +369,20 @@ class BaseModel(models.Model):
             datestops = [event.stop for event in events]
             intervals = list(zip(datestarts, datestops))
             qe_intervals = query_event.intervals(start, stop)
-            overlap_intervals = combine_intervals(operator.and_,
-                                                  intervals, qe_intervals, start, stop)
+            overlap_intervals = combine_intervals(
+                operator.and_, intervals, qe_intervals, start, stop
+            )
 
             overlap_starts, overlap_stops = list(zip(*overlap_intervals))
 
-            datestarts = np.array(datestarts, dtype='S21')
-            datestops = np.array(datestops, dtype='S21')
-            overlap_starts = np.array(overlap_starts, dtype='S21')
-            overlap_stops = np.array(overlap_stops, dtype='S21')
+            datestarts = np.array(datestarts, dtype="S21")
+            datestops = np.array(datestops, dtype="S21")
+            overlap_starts = np.array(overlap_starts, dtype="S21")
+            overlap_stops = np.array(overlap_stops, dtype="S21")
 
-            func = self._get_partial_overlaps if allow_partial else self._get_full_overlaps
+            func = (
+                self._get_partial_overlaps if allow_partial else self._get_full_overlaps
+            )
             indices = func(overlap_starts, overlap_stops, datestarts, datestops)
             return [events[i] for i in indices]
 
@@ -371,7 +402,9 @@ class BaseModel(models.Model):
             match_datestarts = datestarts[indices]
             match_datestops = datestops[indices]
 
-            ok = (overlap_starts == match_datestarts) & (overlap_stops == match_datestops)
+            ok = (overlap_starts == match_datestarts) & (
+                overlap_stops == match_datestops
+            )
             return indices[ok]
 
         @staticmethod
@@ -398,7 +431,7 @@ class BaseModel(models.Model):
 
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
     @classmethod
     def from_dict(cls, model_dict, logger=None):
@@ -412,20 +445,23 @@ class BaseModel(models.Model):
         # but "stop" in the case of Manvr).
         if isinstance(model, TlmEvent) and model is not Obsid:
             tstart = DateTime(model_dict[cls._get_obsid_start_attr]).secs
-            obsrq = fetch.Msid('cobsrqid', tstart, tstart + 200)
+            obsrq = fetch.Msid("cobsrqid", tstart, tstart + 200)
             if len(obsrq.vals) == 0:
-                logger.warn(f'WARNING: unable to get COBSRQID near '
-                            f'{model_dict[cls._get_obsid_start_attr]}, '
-                            f'using obsid=-999')
-                model_dict['obsid'] = -999
+                logger.warn(
+                    f"WARNING: unable to get COBSRQID near "
+                    f"{model_dict[cls._get_obsid_start_attr]}, "
+                    f"using obsid=-999"
+                )
+                model_dict["obsid"] = -999
             else:
-                model_dict['obsid'] = obsrq.vals[0]
+                model_dict["obsid"] = obsrq.vals[0]
 
         for key, val in model_dict.items():
             if hasattr(model, key):
                 if logger is not None:
-                    logger.debug('Setting {} model with {}={}'
-                                 .format(model.model_name, key, val))
+                    logger.debug(
+                        "Setting {} model with {}={}".format(model.model_name, key, val)
+                    )
                 setattr(model, key, val)
         return model
 
@@ -438,16 +474,16 @@ class BaseModel(models.Model):
 
     @property
     def model_name(self):
-        if not hasattr(self, '_model_name'):
+        if not hasattr(self, "_model_name"):
             cc_name = self.__class__.__name__
             chars = []
             for c0, c1 in zip(cc_name[:-1], cc_name[1:]):
                 # Lower case followed by Upper case then insert "_"
                 chars.append(c0.lower())
                 if c0.lower() == c0 and c1.lower() != c1:
-                    chars.append('_')
+                    chars.append("_")
             chars.append(c1.lower())
-            self._model_name = ''.join(chars)
+            self._model_name = "".join(chars)
         return self._model_name
 
     @classmethod
@@ -461,19 +497,21 @@ class BaseModel(models.Model):
         if pad is None:
             pad = Pad()
         elif not isinstance(pad, Pad):
-            raise TypeError('pad arg must be a Pad object')
+            raise TypeError("pad arg must be a Pad object")
 
         datestart = (DateTime(start) - cls.lookback).date
         datestop = (DateTime(stop) + cls.lookback).date
-        events = cls.objects.filter(start__gte=datestart, start__lte=datestop, **filter_kwargs)
+        events = cls.objects.filter(
+            start__gte=datestart, start__lte=datestop, **filter_kwargs
+        )
 
         datestart = DateTime(start).date
         datestop = DateTime(stop).date
 
         intervals = []
         for event in events:
-            event_datestart = DateTime(event.tstart - pad.start, format='secs').date
-            event_datestop = DateTime(event.tstop + pad.stop, format='secs').date
+            event_datestart = DateTime(event.tstart - pad.start, format="secs").date
+            event_datestop = DateTime(event.tstop + pad.stop, format="secs").date
 
             # Negative padding might make an interval entirely disappear
             if event_datestart >= event_datestop:
@@ -510,12 +548,13 @@ class BaseModel(models.Model):
         start = getattr(self, self._get_obsid_start_attr)
         obsids = query.obsids.filter(start, start)
         if len(obsids) != 1:
-            raise ValueError('Expected one obsid at {} but got {}'
-                             .format(start, obsids))
+            raise ValueError(
+                "Expected one obsid at {} but got {}".format(start, obsids)
+            )
         return obsids[0].obsid
 
     def __bytes__(self):
-        return str(self).encode('utf-8')
+        return str(self).encode("utf-8")
 
     def __str__(self):
         return self.__unicode__()
@@ -527,11 +566,12 @@ class BaseEvent(BaseModel):
     that BaseModel is the base class for models like ManvrSeq that get
     generated as part of another event class.
     """
+
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
-    _get_obsid_start_attr = 'start'  # Attribute to use for getting event obsid
+    _get_obsid_start_attr = "start"  # Attribute to use for getting event obsid
     lookback = 21  # days of lookback
     interval_pad = IntervalPad()  # interval padding before/ after event start/stop
 
@@ -541,12 +581,14 @@ class BaseEvent(BaseModel):
         Apply padding defined by interval_pad attribute.
         """
         from .. import cmds as commands
-        cmds = commands.filter(self.tstart - self.interval_pad.start,
-                               self.tstop + self.interval_pad.stop)
+
+        cmds = commands.filter(
+            self.tstart - self.interval_pad.start, self.tstop + self.interval_pad.stop
+        )
         return cmds
 
     def __unicode__(self):
-        return ('start={}'.format(self.start))
+        return "start={}".format(self.start)
 
     def get_next(self, queryset=None):
         """
@@ -566,7 +608,7 @@ class BaseEvent(BaseModel):
         """
         if queryset is None:
             queryset = self.__class__.objects.all()
-        prev = queryset.filter(pk__lt=self.pk).order_by('-pk')
+        prev = queryset.filter(pk__lt=self.pk).order_by("-pk")
         try:
             return prev[0]
         except IndexError:
@@ -574,24 +616,25 @@ class BaseEvent(BaseModel):
 
 
 class Event(BaseEvent):
-    start = models.CharField(max_length=21, primary_key=True,
-                             help_text='Start time (YYYY:DDD:HH:MM:SS)')
-    stop = models.CharField(max_length=21, help_text='Stop time (YYYY:DDD:HH:MM:SS)')
-    tstart = models.FloatField(db_index=True, help_text='Start time (CXC secs)')
-    tstop = models.FloatField(help_text='Stop time (CXC secs)')
-    dur = models.FloatField(help_text='Duration (secs)')
-    dur._kadi_format = '{:.1f}'
+    start = models.CharField(
+        max_length=21, primary_key=True, help_text="Start time (YYYY:DDD:HH:MM:SS)"
+    )
+    stop = models.CharField(max_length=21, help_text="Stop time (YYYY:DDD:HH:MM:SS)")
+    tstart = models.FloatField(db_index=True, help_text="Start time (CXC secs)")
+    tstop = models.FloatField(help_text="Stop time (CXC secs)")
+    dur = models.FloatField(help_text="Duration (secs)")
+    dur._kadi_format = "{:.1f}"
 
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
     def __unicode__(self):
-        return ('start={} dur={:.0f}'.format(self.start, self.dur))
+        return "start={} dur={:.0f}".format(self.start, self.dur)
 
 
 class TlmEvent(Event):
-    obsid = models.IntegerField(help_text='Observation ID (COBSRQID)')
+    obsid = models.IntegerField(help_text="Observation ID (COBSRQID)")
 
     event_msids = None  # must be overridden by derived class
     event_val = None
@@ -599,7 +642,7 @@ class TlmEvent(Event):
 
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
     def plot(self, figsize=None, fig=None):
         """
@@ -608,6 +651,7 @@ class TlmEvent(Event):
         for plotting.
         """
         from . import plot
+
         try:
             plot_func = getattr(plot, self.model_name)
         except AttributeError:
@@ -646,11 +690,14 @@ class TlmEvent(Event):
         """
         tstart = DateTime(start).secs
         tstop = DateTime(stop).secs
-        event_time_fuzz = cls.event_time_fuzz if hasattr(cls, 'event_time_fuzz') else None
+        event_time_fuzz = (
+            cls.event_time_fuzz if hasattr(cls, "event_time_fuzz") else None
+        )
 
         # Get the event telemetry MSID objects
-        event_msidset = fetch.MSIDset(cls.event_msids, tstart, tstop,
-                                      filter_bad=cls.event_filter_bad)
+        event_msidset = fetch.MSIDset(
+            cls.event_msids, tstart, tstop, filter_bad=cls.event_filter_bad
+        )
 
         try:
             # Telemetry values for event_msids[0] define the states.  Don't allow a logical
@@ -659,8 +706,9 @@ class TlmEvent(Event):
             states = utils.logical_intervals(times, bools, max_gap=MAX_GAP)
         except (IndexError, ValueError):
             if event_time_fuzz is None:
-                logger.warn('Warning: No telemetry available for {}'
-                            .format(cls.__name__))
+                logger.warn(
+                    "Warning: No telemetry available for {}".format(cls.__name__)
+                )
             return [], event_msidset
 
         if len(states) > 0:
@@ -671,17 +719,19 @@ class TlmEvent(Event):
             # the next search interval will step forward in time, it is sure that
             # eventually the event will be fully contained.
             if event_time_fuzz:
-                while tstop - event_time_fuzz < states[-1]['tstop']:
+                while tstop - event_time_fuzz < states[-1]["tstop"]:
                     # Event tstop is within event_time_fuzz of the stop of states so
                     # bail out and don't return any states.
-                    logger.warn('Warning: dropping state because of '
-                                'insufficent event time pad:\n{}\n'.format(states[-1:]))
+                    logger.warn(
+                        "Warning: dropping state because of "
+                        "insufficent event time pad:\n{}\n".format(states[-1:])
+                    )
                     states = states[:-1]
                     if len(states) == 0:
                         return [], event_msidset
 
             # Select event states that are contained within start/stop interval
-            ok = (states['tstart'] >= tstart) & (states['tstop'] <= tstop)
+            ok = (states["tstart"] >= tstart) & (states["tstop"] <= tstop)
             states = states[ok]
 
             if event_time_fuzz:
@@ -701,16 +751,18 @@ class TlmEvent(Event):
         # Assemble a list of dicts corresponding to events in this tlm interval
         events = []
         for state in states:
-            tstart = state['tstart']
-            tstop = state['tstop']
-            event = dict(tstart=tstart,
-                         tstop=tstop,
-                         dur=tstop - tstart,
-                         start=DateTime(tstart).date,
-                         stop=DateTime(tstop).date)
+            tstart = state["tstart"]
+            tstop = state["tstop"]
+            event = dict(
+                tstart=tstart,
+                tstop=tstop,
+                dur=tstop - tstart,
+                start=DateTime(tstart).date,
+                stop=DateTime(tstop).date,
+            )
 
             # Reject events that are shorter than the minimum duration
-            if hasattr(cls, 'event_min_dur') and event['dur'] < cls.event_min_dur:
+            if hasattr(cls, "event_min_dur") and event["dur"] < cls.event_min_dur:
                 continue
 
             # Custom processing defined by subclasses to add more attrs to event
@@ -725,7 +777,7 @@ class TlmEvent(Event):
         """
         fetch.MSIDset of self.fetch_event_msids.  By default filter_bad is True.
         """
-        if not hasattr(self, '_msidset'):
+        if not hasattr(self, "_msidset"):
             self._msidset = self.fetch_event()
         return self._msidset
 
@@ -739,8 +791,9 @@ class TlmEvent(Event):
         msids = self.fetch_event_msids[:]
         if extra_msids is not None:
             msids.extend(extra_msids)
-        msidset = fetch.MSIDset(msids, self.tstart - pad, self.tstop + pad,
-                                filter_bad=filter_bad)
+        msidset = fetch.MSIDset(
+            msids, self.tstart - pad, self.tstop + pad, filter_bad=filter_bad
+        )
         return msidset
 
 
@@ -763,7 +816,8 @@ class Obsid(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['cobsrqid']
+
+    event_msids = ["cobsrqid"]
 
     update_priority = 1000  # Process Obsid first
 
@@ -777,7 +831,7 @@ class Obsid(TlmEvent):
         events = []
         # Get the event telemetry MSID objects
         event_msidset = fetch.Msidset(cls.event_msids, start, stop)
-        obsid = event_msidset['cobsrqid']
+        obsid = event_msidset["cobsrqid"]
 
         if len(obsid) < 2:
             # Not enough telemetry for state_intervals, return no events
@@ -786,18 +840,19 @@ class Obsid(TlmEvent):
         states = obsid.state_intervals()
         # Skip the first and last states as they are likely incomplete
         for state in states[1:-1]:
-            event = dict(start=state['datestart'],
-                         stop=state['datestop'],
-                         tstart=state['tstart'],
-                         tstop=state['tstop'],
-                         dur=state['tstop'] - state['tstart'],
-                         obsid=state['val'])
+            event = dict(
+                start=state["datestart"],
+                stop=state["datestop"],
+                tstart=state["tstart"],
+                tstop=state["tstop"],
+                dur=state["tstop"] - state["tstart"],
+                obsid=state["val"],
+            )
             events.append(event)
         return events
 
     def __unicode__(self):
-        return ('start={} dur={:.0f} obsid={}'
-                .format(self.start, self.dur, self.obsid))
+        return "start={} dur={:.0f} obsid={}".format(self.start, self.dur, self.obsid)
 
 
 class TscMove(TlmEvent):
@@ -829,16 +884,19 @@ class TscMove(TlmEvent):
            max_pwm    Integer                   Max PWM during translation
     =============== ========== ============================================
     """
-    event_msids = ['3tscmove', '3tscpos', '3mrmmxmv']
-    event_val = 'T'
 
-    start_3tscpos = models.IntegerField(help_text='Start TSC position (steps)')
-    stop_3tscpos = models.IntegerField(help_text='Stop TSC position (steps)')
-    start_det = models.CharField(max_length=6,
-                                 help_text='Start detector (ACIS-I ACIS-S HRC-I HRC-S)')
-    stop_det = models.CharField(max_length=6,
-                                help_text='Stop detector (ACIS-I ACIS-S HRC-I HRC-S)')
-    max_pwm = models.IntegerField(help_text='Max PWM during translation')
+    event_msids = ["3tscmove", "3tscpos", "3mrmmxmv"]
+    event_val = "T"
+
+    start_3tscpos = models.IntegerField(help_text="Start TSC position (steps)")
+    stop_3tscpos = models.IntegerField(help_text="Stop TSC position (steps)")
+    start_det = models.CharField(
+        max_length=6, help_text="Start detector (ACIS-I ACIS-S HRC-I HRC-S)"
+    )
+    stop_det = models.CharField(
+        max_length=6, help_text="Stop detector (ACIS-I ACIS-S HRC-I HRC-S)"
+    )
+    max_pwm = models.IntegerField(help_text="Max PWM during translation")
 
     interval_pad = IntervalPad()  # interval padding before/ after event start/stop
 
@@ -847,17 +905,19 @@ class TscMove(TlmEvent):
         """
         Define start/stop_3tscpos and start/stop_det.
         """
-        out = _get_start_stop_vals(event['tstart'] - 66, event['tstop'] + 66,
-                                   event_msidset, msids=['3tscpos'])
-        out['start_det'] = _get_si(out['start_3tscpos'])
-        out['stop_det'] = _get_si(out['stop_3tscpos'])
-        pwm = event_msidset['3mrmmxmv']
-        out['max_pwm'] = interpolate(pwm.vals, pwm.times, [event['tstop'] + 66])[0]
+        out = _get_start_stop_vals(
+            event["tstart"] - 66, event["tstop"] + 66, event_msidset, msids=["3tscpos"]
+        )
+        out["start_det"] = _get_si(out["start_3tscpos"])
+        out["stop_det"] = _get_si(out["stop_3tscpos"])
+        pwm = event_msidset["3mrmmxmv"]
+        out["max_pwm"] = interpolate(pwm.vals, pwm.times, [event["tstop"] + 66])[0]
         return out
 
     def __unicode__(self):
-        return ('start={} dur={:.0f} start_3tscpos={} stop_3tscpos={}'
-                .format(self.start, self.dur, self.start_3tscpos, self.stop_3tscpos))
+        return "start={} dur={:.0f} start_3tscpos={} stop_3tscpos={}".format(
+            self.start, self.dur, self.start_3tscpos, self.stop_3tscpos
+        )
 
 
 class DarkCalReplica(TlmEvent):
@@ -881,8 +941,9 @@ class DarkCalReplica(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['ciumacac']
-    event_val = 'ON '
+
+    event_msids = ["ciumacac"]
+    event_val = "ON "
     event_min_dur = 300
 
 
@@ -908,8 +969,9 @@ class DarkCal(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['ciumacac']
-    event_val = 'ON '
+
+    event_msids = ["ciumacac"]
+    event_val = "ON "
     event_time_fuzz = 86400  # One full day of fuzz / pad
     event_min_dur = 8000
 
@@ -945,9 +1007,10 @@ class Scs107(TlmEvent):
       notes       Text               Supplemental notes
     ======== ========== ================================
     """
-    notes = models.TextField(help_text='Supplemental notes')
 
-    event_msids = ['3tscmove', 'aorwbias', 'coradmen']
+    notes = models.TextField(help_text="Supplemental notes")
+
+    event_msids = ["3tscmove", "aorwbias", "coradmen"]
     event_time_fuzz = 600  # Earlier in the mission SCS107 resulted in two SIM moves
     event_filter_bad = False
 
@@ -956,11 +1019,13 @@ class Scs107(TlmEvent):
     def get_state_times_bools(cls, msidset):
         # Interpolate all MSIDs to a common time.  Sync to the start of 3tscmove which is
         # sampled at 32.8 seconds
-        msidset_interpolate(msidset, 32.8, msidset['3tscmove'].times[0])
+        msidset_interpolate(msidset, 32.8, msidset["3tscmove"].times[0])
 
-        scs107 = ((msidset['3tscmove'].vals == 'T')
-                  & (msidset['aorwbias'].vals == 'DISA')
-                  & (msidset['coradmen'].vals == 'DISA'))
+        scs107 = (
+            (msidset["3tscmove"].vals == "T")
+            & (msidset["aorwbias"].vals == "DISA")
+            & (msidset["coradmen"].vals == "DISA")
+        )
 
         return msidset.times, scs107
 
@@ -986,24 +1051,30 @@ class FaMove(TlmEvent):
       stop_3fapos    Integer         Stop FA position (steps)
     ============== ========== ================================
     """
-    event_msids = ['3famove', '3fapos']
-    event_val = 'T'
 
-    start_3fapos = models.IntegerField(help_text='Start FA position (steps)')
-    stop_3fapos = models.IntegerField(help_text='Stop FA position (steps)')
+    event_msids = ["3famove", "3fapos"]
+    event_val = "T"
+
+    start_3fapos = models.IntegerField(help_text="Start FA position (steps)")
+    stop_3fapos = models.IntegerField(help_text="Stop FA position (steps)")
 
     @classmethod
     def get_extras(cls, event, event_msidset):
         """
         Define start/stop_3fapos.
         """
-        out = _get_start_stop_vals(event['tstart'] - 16.4, event['tstop'] + 16.4,
-                                   event_msidset, msids=['3fapos'])
+        out = _get_start_stop_vals(
+            event["tstart"] - 16.4,
+            event["tstop"] + 16.4,
+            event_msidset,
+            msids=["3fapos"],
+        )
         return out
 
     def __unicode__(self):
-        return ('start={} dur={:.0f} start_3fapos={} stop_3fapos={}'
-                .format(self.start, self.dur, self.start_3fapos, self.stop_3fapos))
+        return "start={} dur={:.0f} start_3fapos={} stop_3fapos={}".format(
+            self.start, self.dur, self.start_3fapos, self.stop_3fapos
+        )
 
 
 class GratingMove(TlmEvent):
@@ -1039,21 +1110,24 @@ class GratingMove(TlmEvent):
           direction    Char(4)        Grating direction (UNKN INSR RETR)
     ================ ========== =========================================
     """
-    start_4lposaro = models.FloatField(help_text='Start LETG position (degrees)')
-    stop_4lposaro = models.FloatField(help_text='Stop LETG position (degrees)')
-    start_4hposaro = models.FloatField(help_text='Start HETG position (degrees)')
-    stop_4hposaro = models.FloatField(help_text='Stop HETG position (degrees)')
-    grating = models.CharField(max_length=4,
-                               help_text='Grating in motion (UNKN LETG HETG BUMP)')
-    direction = models.CharField(max_length=4,
-                                 help_text='Grating direction (UNKN INSR RETR)')
 
-    event_msids = ['4mp28av', '4lposaro', '4hposaro']
+    start_4lposaro = models.FloatField(help_text="Start LETG position (degrees)")
+    stop_4lposaro = models.FloatField(help_text="Stop LETG position (degrees)")
+    start_4hposaro = models.FloatField(help_text="Start HETG position (degrees)")
+    stop_4hposaro = models.FloatField(help_text="Stop HETG position (degrees)")
+    grating = models.CharField(
+        max_length=4, help_text="Grating in motion (UNKN LETG HETG BUMP)"
+    )
+    direction = models.CharField(
+        max_length=4, help_text="Grating direction (UNKN INSR RETR)"
+    )
+
+    event_msids = ["4mp28av", "4lposaro", "4hposaro"]
     event_time_fuzz = 10
 
     @classmethod
     def get_state_times_bools(cls, event_msidset):
-        event_msid = event_msidset['4mp28av']
+        event_msid = event_msidset["4mp28av"]
         moving = event_msid.vals > 2.0
         return event_msid.times, moving
 
@@ -1062,34 +1136,43 @@ class GratingMove(TlmEvent):
         """
         Define start/stop grating positions for HETG and LETG
         """
-        out = _get_start_stop_vals(event['tstart'], event['tstop'],
-                                   event_msidset, msids=['4lposaro', '4hposaro'])
+        out = _get_start_stop_vals(
+            event["tstart"],
+            event["tstop"],
+            event_msidset,
+            msids=["4lposaro", "4hposaro"],
+        )
 
-        if event['dur'] < 4:
-            grating = 'BUMP'
+        if event["dur"] < 4:
+            grating = "BUMP"
         else:
-            grating = 'UNKN'  # Should never stay as 'UNKN'
-            if abs(out['start_4lposaro'] - out['stop_4lposaro']) > 5:
-                grating = 'LETG'
-            if abs(out['start_4hposaro'] - out['stop_4hposaro']) > 5:
+            grating = "UNKN"  # Should never stay as 'UNKN'
+            if abs(out["start_4lposaro"] - out["stop_4lposaro"]) > 5:
+                grating = "LETG"
+            if abs(out["start_4hposaro"] - out["stop_4hposaro"]) > 5:
                 # If BOTH this is not good (maybe two moves fuzzed together)
-                grating = 'BOTH' if grating == 'LETG' else 'HETG'
+                grating = "BOTH" if grating == "LETG" else "HETG"
 
-        if grating == 'LETG':
-            direction = 'INSR' if out['start_4lposaro'] > out['stop_4lposaro'] else 'RETR'
-        elif grating == 'HETG':
-            direction = 'INSR' if out['start_4hposaro'] > out['stop_4hposaro'] else 'RETR'
+        if grating == "LETG":
+            direction = (
+                "INSR" if out["start_4lposaro"] > out["stop_4lposaro"] else "RETR"
+            )
+        elif grating == "HETG":
+            direction = (
+                "INSR" if out["start_4hposaro"] > out["stop_4hposaro"] else "RETR"
+            )
         else:
-            direction = 'UNKN'
+            direction = "UNKN"
 
-        out['direction'] = direction
-        out['grating'] = grating
+        out["direction"] = direction
+        out["grating"] = grating
 
         return out
 
     def __unicode__(self):
-        return ('start={} dur={:.0f} grating={} direction={}'
-                .format(self.start, self.dur, self.grating, self.direction))
+        return "start={} dur={:.0f} grating={} direction={}".format(
+            self.start, self.dur, self.grating, self.direction
+        )
 
 
 class Dump(TlmEvent):
@@ -1111,8 +1194,9 @@ class Dump(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['aounload']
-    event_val = 'GRND'
+
+    event_msids = ["aounload"]
+    event_val = "GRND"
 
 
 class Eclipse(TlmEvent):
@@ -1134,9 +1218,10 @@ class Eclipse(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['aoeclips']
-    event_val = 'ECL '
-    fetch_event_msids = ['aoeclips', 'eb1k5', 'eb2k5', 'eb3k5']
+
+    event_msids = ["aoeclips"]
+    event_val = "ECL "
+    fetch_event_msids = ["aoeclips", "eb1k5", "eb2k5", "eb3k5"]
 
 
 class Manvr(TlmEvent):
@@ -1240,88 +1325,139 @@ class Manvr(TlmEvent):
     ``one_shot_roll``, ``one_shot_pitch``, and ``one_shot_yaw`` are the values of AOATTER1, 2, and 3
         from samples after the guide transition.
     """
-    _get_obsid_start_attr = 'stop'  # Attribute to use for getting event obsid
-    event_msids = ['aofattmd', 'aopcadmd', 'aoacaseq', 'aopsacpr']
-    event_val = 'MNVR'
 
-    fetch_event_msids = ['one_shot', 'aofattmd', 'aopcadmd', 'aoacaseq',
-                         'aopsacpr', 'aounload',
-                         'aoattqt1', 'aoattqt2', 'aoattqt3', 'aoattqt4',
-                         'aogyrct1', 'aogyrct2', 'aogyrct3', 'aogyrct4',
-                         'aoatupq1', 'aoatupq2', 'aoatupq3',
-                         'aotarqt1', 'aotarqt2', 'aotarqt3',
-                         'aoatter1', 'aoatter2', 'aoatter3',
-                         'aogbias1', 'aogbias2', 'aogbias3']
+    _get_obsid_start_attr = "stop"  # Attribute to use for getting event obsid
+    event_msids = ["aofattmd", "aopcadmd", "aoacaseq", "aopsacpr"]
+    event_val = "MNVR"
+
+    fetch_event_msids = [
+        "one_shot",
+        "aofattmd",
+        "aopcadmd",
+        "aoacaseq",
+        "aopsacpr",
+        "aounload",
+        "aoattqt1",
+        "aoattqt2",
+        "aoattqt3",
+        "aoattqt4",
+        "aogyrct1",
+        "aogyrct2",
+        "aogyrct3",
+        "aogyrct4",
+        "aoatupq1",
+        "aoatupq2",
+        "aoatupq3",
+        "aotarqt1",
+        "aotarqt2",
+        "aotarqt3",
+        "aoatter1",
+        "aoatter2",
+        "aoatter3",
+        "aogbias1",
+        "aogbias2",
+        "aogbias3",
+    ]
     fetch_event_pad = 600
 
     interval_pad = IntervalPad()  # interval padding before/ after event start/stop
 
-    prev_manvr_stop = models.CharField(max_length=21, null=True,
-                                       help_text='Stop time of previous AOFATTMD=MNVR before manvr')
-    prev_npnt_start = models.CharField(max_length=21, null=True, help_text='Start time of previous '
-                                       'AOPCADMD=NPNT before manvr')
-    nman_start = models.CharField(max_length=21, null=True,
-                                  help_text='Start time of AOPCADMD=NMAN for manvr')
-    manvr_start = models.CharField(max_length=21, null=True,
-                                   help_text='Start time of AOFATTMD=MNVR for manvr')
-    manvr_stop = models.CharField(max_length=21, null=True,
-                                  help_text='Stop time of AOFATTMD=MNVR for manvr')
-    npnt_start = models.CharField(max_length=21, null=True,
-                                  help_text='Start time of AOPCADMD=NPNT after manvr')
-    acq_start = models.CharField(max_length=21, null=True,
-                                 help_text='Start time of AOACASEQ=AQXN after manvr')
-    guide_start = models.CharField(max_length=21, null=True,
-                                   help_text='Start time of AOACASEQ=GUID after manvr')
-    kalman_start = models.CharField(max_length=21, null=True,
-                                    help_text='Start time of AOACASEQ=KALM after manvr')
-    aca_proc_act_start = models.CharField(max_length=21, null=True,
-                                          help_text='Start time of AOPSACPR=ACT after manvr')
-    npnt_stop = models.CharField(max_length=21, null=True,
-                                 help_text='Stop time of AOPCADMD=NPNT after manvr')
-    next_nman_start = models.CharField(max_length=21, null=True,
-                                       help_text='Start time of next AOPCADMD=NMAN after manvr')
-    next_manvr_start = models.CharField(max_length=21, null=True,
-                                        help_text='Start time of next AOFATTMD=MNVR after manvr')
+    prev_manvr_stop = models.CharField(
+        max_length=21,
+        null=True,
+        help_text="Stop time of previous AOFATTMD=MNVR before manvr",
+    )
+    prev_npnt_start = models.CharField(
+        max_length=21,
+        null=True,
+        help_text="Start time of previous " "AOPCADMD=NPNT before manvr",
+    )
+    nman_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOPCADMD=NMAN for manvr"
+    )
+    manvr_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOFATTMD=MNVR for manvr"
+    )
+    manvr_stop = models.CharField(
+        max_length=21, null=True, help_text="Stop time of AOFATTMD=MNVR for manvr"
+    )
+    npnt_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOPCADMD=NPNT after manvr"
+    )
+    acq_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOACASEQ=AQXN after manvr"
+    )
+    guide_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOACASEQ=GUID after manvr"
+    )
+    kalman_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOACASEQ=KALM after manvr"
+    )
+    aca_proc_act_start = models.CharField(
+        max_length=21, null=True, help_text="Start time of AOPSACPR=ACT after manvr"
+    )
+    npnt_stop = models.CharField(
+        max_length=21, null=True, help_text="Stop time of AOPCADMD=NPNT after manvr"
+    )
+    next_nman_start = models.CharField(
+        max_length=21,
+        null=True,
+        help_text="Start time of next AOPCADMD=NMAN after manvr",
+    )
+    next_manvr_start = models.CharField(
+        max_length=21,
+        null=True,
+        help_text="Start time of next AOFATTMD=MNVR after manvr",
+    )
     n_dwell = models.IntegerField(
-        help_text='Number of kalman dwells after manvr and before next manvr')
-    n_acq = models.IntegerField(help_text='Number of AQXN intervals after '
-                                'manvr and before next manvr')
-    n_guide = models.IntegerField(help_text='Number of GUID intervals after '
-                                  'manvr and before next manvr')
-    n_kalman = models.IntegerField(help_text='Number of KALM intervals after '
-                                   'manvr and before next manvr')
-    anomalous = models.BooleanField(help_text='Key MSID shows off-nominal value')
-    template = models.CharField(max_length=16, help_text='Matched maneuver template')
-    start_ra = models.FloatField(help_text='Start right ascension before manvr')
-    start_dec = models.FloatField(help_text='Start declination before manvr')
-    start_roll = models.FloatField(help_text='Start roll angle before manvr')
-    stop_ra = models.FloatField(help_text='Stop right ascension after manvr')
-    stop_dec = models.FloatField(help_text='Stop declination after manvr')
-    stop_roll = models.FloatField(help_text='Stop roll angle after manvr')
-    angle = models.FloatField(help_text='Maneuver angle (deg)')
-    one_shot = models.FloatField(help_text='One shot attitude update (arcsec)')
-    one_shot_roll = models.FloatField(help_text='One shot attitude update roll (arcsec)')
-    one_shot_pitch = models.FloatField(help_text='One shot attitude update pitch (arcsec)')
-    one_shot_yaw = models.FloatField(help_text='One shot attitude update yaw (arcsec)')
+        help_text="Number of kalman dwells after manvr and before next manvr"
+    )
+    n_acq = models.IntegerField(
+        help_text="Number of AQXN intervals after " "manvr and before next manvr"
+    )
+    n_guide = models.IntegerField(
+        help_text="Number of GUID intervals after " "manvr and before next manvr"
+    )
+    n_kalman = models.IntegerField(
+        help_text="Number of KALM intervals after " "manvr and before next manvr"
+    )
+    anomalous = models.BooleanField(help_text="Key MSID shows off-nominal value")
+    template = models.CharField(max_length=16, help_text="Matched maneuver template")
+    start_ra = models.FloatField(help_text="Start right ascension before manvr")
+    start_dec = models.FloatField(help_text="Start declination before manvr")
+    start_roll = models.FloatField(help_text="Start roll angle before manvr")
+    stop_ra = models.FloatField(help_text="Stop right ascension after manvr")
+    stop_dec = models.FloatField(help_text="Stop declination after manvr")
+    stop_roll = models.FloatField(help_text="Stop roll angle after manvr")
+    angle = models.FloatField(help_text="Maneuver angle (deg)")
+    one_shot = models.FloatField(help_text="One shot attitude update (arcsec)")
+    one_shot_roll = models.FloatField(
+        help_text="One shot attitude update roll (arcsec)"
+    )
+    one_shot_pitch = models.FloatField(
+        help_text="One shot attitude update pitch (arcsec)"
+    )
+    one_shot_yaw = models.FloatField(help_text="One shot attitude update yaw (arcsec)")
 
-    one_shot._kadi_format = '{:.1f}'
-    one_shot_roll._kadi_format = '{:.1f}'
-    one_shot_pitch._kadi_format = '{:.1f}'
-    one_shot_yaw._kadi_format = '{:.1f}'
-    angle._kadi_format = '{:.2f}'
-    start_ra._kadi_format = '{:.5f}'
-    start_dec._kadi_format = '{:.5f}'
-    start_roll._kadi_format = '{:.5f}'
-    stop_ra._kadi_format = '{:.5f}'
-    stop_dec._kadi_format = '{:.5f}'
-    stop_roll._kadi_format = '{:.5f}'
+    one_shot._kadi_format = "{:.1f}"
+    one_shot_roll._kadi_format = "{:.1f}"
+    one_shot_pitch._kadi_format = "{:.1f}"
+    one_shot_yaw._kadi_format = "{:.1f}"
+    angle._kadi_format = "{:.2f}"
+    start_ra._kadi_format = "{:.5f}"
+    start_dec._kadi_format = "{:.5f}"
+    start_roll._kadi_format = "{:.5f}"
+    stop_ra._kadi_format = "{:.5f}"
+    stop_dec._kadi_format = "{:.5f}"
+    stop_roll._kadi_format = "{:.5f}"
 
     class Meta:
-        ordering = ['start']
+        ordering = ["start"]
 
     def __unicode__(self):
-        return ('start={} dur={:.0f} n_dwell={} template={}'
-                .format(self.start, self.dur, self.n_dwell, self.template))
+        return "start={} dur={:.0f} n_dwell={} template={}".format(
+            self.start, self.dur, self.n_dwell, self.template
+        )
 
     @classmethod
     def get_dwells(cls, event, changes):
@@ -1342,44 +1478,49 @@ class Manvr(TlmEvent):
         dwells = []
         state = None
         t0 = 0
-        ok = changes['dt'] >= ZERO_DT
+        ok = changes["dt"] >= ZERO_DT
         dwell = {}
         for change in changes[ok]:
             # Not in a dwell and ACA sequence is KALMAN => start dwell.
-            if (state is None
-                    and change['msid'] == 'aoacaseq'
-                    and change['val'] == 'KALM'):
-                t0 = change['time']
-                dwell['rel_tstart'] = change['dt']
-                dwell['tstart'] = change['time']
-                dwell['start'] = change['date']
-                state = 'dwell'
+            if (
+                state is None
+                and change["msid"] == "aoacaseq"
+                and change["val"] == "KALM"
+            ):
+                t0 = change["time"]
+                dwell["rel_tstart"] = change["dt"]
+                dwell["tstart"] = change["time"]
+                dwell["start"] = change["date"]
+                state = "dwell"
 
             # Another KALMAN within 400 secs of previous KALMAN in dwell.
             # This is another acquisition sequence and moves the dwell start back.
-            elif (state == 'dwell'
-                  and change['msid'] == 'aoacaseq'
-                  and change['val'] == 'KALM'
-                  and change['time'] - t0 < 400):
-                t0 = change['time']
-                dwell['rel_tstart'] = change['dt']
-                dwell['tstart'] = change['time']
-                dwell['start'] = change['date']
+            elif (
+                state == "dwell"
+                and change["msid"] == "aoacaseq"
+                and change["val"] == "KALM"
+                and change["time"] - t0 < 400
+            ):
+                t0 = change["time"]
+                dwell["rel_tstart"] = change["dt"]
+                dwell["tstart"] = change["time"]
+                dwell["start"] = change["date"]
 
             # End of dwell because of NPNT => NMAN transition OR another acquisition
-            elif (state == 'dwell'
-                  and ((change['msid'] == 'aopcadmd' and change['val'] == 'NMAN')
-                       or (change['msid'] == 'aoacaseq' and change['time'] - t0 > 400))):
-                dwell['tstop'] = change['prev_time']
-                dwell['stop'] = change['prev_date']
-                dwell['dur'] = dwell['tstop'] - dwell['tstart']
+            elif state == "dwell" and (
+                (change["msid"] == "aopcadmd" and change["val"] == "NMAN")
+                or (change["msid"] == "aoacaseq" and change["time"] - t0 > 400)
+            ):
+                dwell["tstop"] = change["prev_time"]
+                dwell["stop"] = change["prev_date"]
+                dwell["dur"] = dwell["tstop"] - dwell["tstart"]
                 dwells.append(dwell)
                 dwell = {}
                 state = None
 
         for dwell in dwells:
-            for att in ('ra', 'dec', 'roll'):
-                dwell[att] = event['stop_' + att]
+            for att in ("ra", "dec", "roll"):
+                dwell[att] = event["stop_" + att]
 
         return dwells
 
@@ -1389,6 +1530,7 @@ class Manvr(TlmEvent):
         Get attributes of the maneuver event and possible dwells based on
         the MSID `changes`.
         """
+
         def match(msid, val, idx=None, filter=None):
             """
             Find a match for the given `msid` and `val`.  The `filter` can
@@ -1396,68 +1538,79 @@ class Manvr(TlmEvent):
             the maneuver end.  The `idx` value then selects form the matching
             changes.  If the desired match is not available then None is returned.
             """
-            ok = (changes['msid'] == msid)
-            if val.startswith('!'):
-                ok &= (changes['val'] != val[1:])
+            ok = changes["msid"] == msid
+            if val.startswith("!"):
+                ok &= changes["val"] != val[1:]
             else:
-                ok &= (changes['val'] == val)
-            if filter == 'before':
-                ok &= (changes['dt'] < ZERO_DT)
-            elif filter == 'after':
-                ok &= (changes['dt'] >= ZERO_DT)
+                ok &= changes["val"] == val
+            if filter == "before":
+                ok &= changes["dt"] < ZERO_DT
+            elif filter == "after":
+                ok &= changes["dt"] >= ZERO_DT
             try:
                 if idx is None:
-                    return changes[ok]['date']
+                    return changes[ok]["date"]
                 else:
-                    return changes[ok][idx]['date']
+                    return changes[ok][idx]["date"]
             except IndexError:
                 return None
 
         # Check for any telemetry values that are off-nominal
-        nom_vals = {'aopcadmd': ('NPNT', 'NMAN'),
-                    'aoacaseq': ('GUID', 'KALM', 'AQXN'),
-                    'aofattmd': ('MNVR', 'STDY'),
-                    'aopsacpr': ('INIT', 'INAC', 'ACT '),
-                    'aounload': ('MON ', 'GRND')}
+        nom_vals = {
+            "aopcadmd": ("NPNT", "NMAN"),
+            "aoacaseq": ("GUID", "KALM", "AQXN"),
+            "aofattmd": ("MNVR", "STDY"),
+            "aopsacpr": ("INIT", "INAC", "ACT "),
+            "aounload": ("MON ", "GRND"),
+        }
         anomalous = False
-        for change in changes[changes['dt'] >= ZERO_DT]:
-            if change['val'] not in nom_vals[change['msid']]:
+        for change in changes[changes["dt"] >= ZERO_DT]:
+            if change["val"] not in nom_vals[change["msid"]]:
                 anomalous = True
                 break
 
         # Templates of previously seen maneuver sequences. These cover sequences seen at
         # least twice as of ~Mar 2012.
         manvr_templates = get_manvr_templates()
-        seqs = ['{}_{}_{}'.format(c['msid'], c['prev_val'], c['val']) for c in changes
-                if (c['msid'] in ('aopcadmd', 'aofattmd', 'aoacaseq')
-                    and c['dt'] >= ZERO_DT)]
+        seqs = [
+            "{}_{}_{}".format(c["msid"], c["prev_val"], c["val"])
+            for c in changes
+            if (
+                c["msid"] in ("aopcadmd", "aofattmd", "aoacaseq") and c["dt"] >= ZERO_DT
+            )
+        ]
         for name, manvr_template in manvr_templates:
-            if seqs == manvr_template[2:]:  # skip first two which are STDY-MNVR and MNVR-STDY
+            if (
+                seqs == manvr_template[2:]
+            ):  # skip first two which are STDY-MNVR and MNVR-STDY
                 template = name
                 break
         else:
-            template = 'unknown'
+            template = "unknown"
 
         manvr_attrs = dict(
-            prev_manvr_stop=match('aofattmd', '!MNVR', -1, 'before'),  # Last STDY before this manvr
-            prev_npnt_start=match('aopcadmd', 'NPNT', -1, 'before'),  # Last NPNT before this manvr
-
-            nman_start=match('aopcadmd', 'NMAN', -1, 'before'),  # NMAN that precedes this manvr
-            manvr_start=match('aofattmd', 'MNVR', -1, 'before'),  # start of this manvr
-            manvr_stop=match('aofattmd', '!MNVR', 0, 'after'),
-
-            npnt_start=match('aopcadmd', 'NPNT', 0, 'after'),
-            acq_start=match('aoacaseq', 'AQXN', 0, 'after'),
-            guide_start=match('aoacaseq', 'GUID', 0, 'after'),
-            kalman_start=match('aoacaseq', 'KALM', 0, 'after'),
-            aca_proc_act_start=match('aopsacpr', 'ACT ', 0, 'after'),
-            npnt_stop=match('aopcadmd', '!NPNT', -1, 'after'),
-
-            next_nman_start=match('aopcadmd', 'NMAN', -1, 'after'),
-            next_manvr_start=match('aofattmd', 'MNVR', -1, 'after'),
-            n_acq=len(match('aoacaseq', 'AQXN', None, 'after')),
-            n_guide=len(match('aoacaseq', 'GUID', None, 'after')),
-            n_kalman=len(match('aoacaseq', 'KALM', None, 'after')),
+            prev_manvr_stop=match(
+                "aofattmd", "!MNVR", -1, "before"
+            ),  # Last STDY before this manvr
+            prev_npnt_start=match(
+                "aopcadmd", "NPNT", -1, "before"
+            ),  # Last NPNT before this manvr
+            nman_start=match(
+                "aopcadmd", "NMAN", -1, "before"
+            ),  # NMAN that precedes this manvr
+            manvr_start=match("aofattmd", "MNVR", -1, "before"),  # start of this manvr
+            manvr_stop=match("aofattmd", "!MNVR", 0, "after"),
+            npnt_start=match("aopcadmd", "NPNT", 0, "after"),
+            acq_start=match("aoacaseq", "AQXN", 0, "after"),
+            guide_start=match("aoacaseq", "GUID", 0, "after"),
+            kalman_start=match("aoacaseq", "KALM", 0, "after"),
+            aca_proc_act_start=match("aopsacpr", "ACT ", 0, "after"),
+            npnt_stop=match("aopcadmd", "!NPNT", -1, "after"),
+            next_nman_start=match("aopcadmd", "NMAN", -1, "after"),
+            next_manvr_start=match("aofattmd", "MNVR", -1, "after"),
+            n_acq=len(match("aoacaseq", "AQXN", None, "after")),
+            n_guide=len(match("aoacaseq", "GUID", None, "after")),
+            n_kalman=len(match("aoacaseq", "KALM", None, "after")),
             anomalous=anomalous,
             template=template,
         )
@@ -1472,33 +1625,35 @@ class Manvr(TlmEvent):
         """
         out = {}
         quats = {}
-        for label, dt in (('start', -60), ('stop', 60)):
-            time = event['tstart'] + dt
+        for label, dt in (("start", -60), ("stop", 60)):
+            time = event["tstart"] + dt
             q123 = []
             for i in range(1, 4):
-                name = 'aotarqt{}'.format(i)
+                name = "aotarqt{}".format(i)
                 msid = msidset[name]
-                q123.append(interpolate(msid.vals, msid.times, [time], method='nearest')[0])
+                q123.append(
+                    interpolate(msid.vals, msid.times, [time], method="nearest")[0]
+                )
             q123 = np.array(q123)
-            sum_q123_sq = np.sum(q123 ** 2)
+            sum_q123_sq = np.sum(q123**2)
             q4 = np.sqrt(np.abs(1.0 - sum_q123_sq))
-            norm = np.sqrt(sum_q123_sq + q4 ** 2)
+            norm = np.sqrt(sum_q123_sq + q4**2)
             quat = Quat(np.concatenate([q123, [q4]]) / norm)
             quats[label] = quat
-            out[label + '_aotarqt1'] = float(quat.q[0])
-            out[label + '_aotarqt2'] = float(quat.q[1])
-            out[label + '_aotarqt3'] = float(quat.q[2])
-            out[label + '_aotarqt4'] = float(quat.q[3])
-            out[label + '_ra'] = float(quat.ra)
-            out[label + '_dec'] = float(quat.dec)
-            out[label + '_roll'] = float(quat.roll)
+            out[label + "_aotarqt1"] = float(quat.q[0])
+            out[label + "_aotarqt2"] = float(quat.q[1])
+            out[label + "_aotarqt3"] = float(quat.q[2])
+            out[label + "_aotarqt4"] = float(quat.q[3])
+            out[label + "_ra"] = float(quat.ra)
+            out[label + "_dec"] = float(quat.dec)
+            out[label + "_roll"] = float(quat.roll)
 
-        dq = quats['stop'] / quats['start']  # = (wx * sa2, wy * sa2, wz * sa2, ca2)
+        dq = quats["stop"] / quats["start"]  # = (wx * sa2, wy * sa2, wz * sa2, ca2)
         q3 = np.abs(dq.q[3])
         if q3 >= 1.0:  # Floating point error possible
-            out['angle'] = 0.0
+            out["angle"] = 0.0
         else:
-            out['angle'] = float(np.arccos(q3) * 2 * 180 / np.pi)
+            out["angle"] = float(np.arccos(q3) * 2 * 180 / np.pi)
 
         return out
 
@@ -1511,23 +1666,32 @@ class Manvr(TlmEvent):
         # No acq => guide transition so no one-shot defined.  Use -99.0 as a convenience for
         # the one shot length, -999.0 for the axis values.
         if guide_start is None:
-            return {'one_shot': -99.0,
-                    'one_shot_roll': -999.0, 'one_shot_pitch': -999.0, 'one_shot_yaw': -999.0}
+            return {
+                "one_shot": -99.0,
+                "one_shot_roll": -999.0,
+                "one_shot_pitch": -999.0,
+                "one_shot_yaw": -999.0,
+            }
         # Save the first post maneuver / post ACQ attitude error sample for each AOATTER axis
         pm_att_err = {}
         for ax in [1, 2, 3]:
-            msid = aux_msidset['aoatter{}'.format(ax)]
-            ok = ((msid.times >= DateTime(guide_start).secs + 1.1)
-                  & (msid.times < DateTime(guide_start).secs + 30))
+            msid = aux_msidset["aoatter{}".format(ax)]
+            ok = (msid.times >= DateTime(guide_start).secs + 1.1) & (
+                msid.times < DateTime(guide_start).secs + 30
+            )
             if not np.any(ok):
-                raise ValueError("No AOATTER{} times for guide transition at {} for one shot"
-                                 .format(ax, guide_start))
+                raise ValueError(
+                    "No AOATTER{} times for guide transition at {} for one shot".format(
+                        ax, guide_start
+                    )
+                )
             pm_att_err[ax] = msid.vals[ok][0] * R2A
-        return {'one_shot': np.sqrt(pm_att_err[2] ** 2
-                                    + pm_att_err[3] ** 2),
-                'one_shot_roll': pm_att_err[1],
-                'one_shot_pitch': pm_att_err[2],
-                'one_shot_yaw': pm_att_err[3]}
+        return {
+            "one_shot": np.sqrt(pm_att_err[2] ** 2 + pm_att_err[3] ** 2),
+            "one_shot_roll": pm_att_err[1],
+            "one_shot_pitch": pm_att_err[2],
+            "one_shot_yaw": pm_att_err[3],
+        }
 
     @classmethod
     @import_ska
@@ -1537,9 +1701,11 @@ class Manvr(TlmEvent):
         """
         events = []
         # Auxiliary information
-        aux_msidset = fetch.Msidset(['aotarqt1', 'aotarqt2', 'aotarqt3',
-                                     'aoatter1', 'aoatter2', 'aoatter3'],
-                                    start, stop)
+        aux_msidset = fetch.Msidset(
+            ["aotarqt1", "aotarqt2", "aotarqt3", "aoatter1", "aoatter2", "aoatter3"],
+            start,
+            stop,
+        )
 
         # Need at least 2 samples to get states. Having no samples typically
         # happens when building the event tables and telemetry queries are just
@@ -1548,48 +1714,59 @@ class Manvr(TlmEvent):
             return events
 
         states, event_msidset = cls.get_msids_states(start, stop)
-        changes = _get_msid_changes(list(event_msidset.values()),
-                                    sortmsids={'aofattmd': 1, 'aopcadmd': 2,
-                                               'aoacaseq': 3, 'aopsacpr': 4})
+        changes = _get_msid_changes(
+            list(event_msidset.values()),
+            sortmsids={"aofattmd": 1, "aopcadmd": 2, "aoacaseq": 3, "aopsacpr": 4},
+        )
 
         for manvr_prev, manvr, manvr_next in zip(states, states[1:], states[2:]):
-            tstart = manvr['tstart']
-            tstop = manvr['tstop']
+            tstart = manvr["tstart"]
+            tstop = manvr["tstop"]
 
             # Make sure the aux_msidset (used for stop/stop target attitudes and one shot)
             # is complete through the end of maneuver + one hour.  Finish event processing
             # if that is not the case.
             min_aux_tstop = min(aux_msid.times[-1] for aux_msid in aux_msidset.values())
             if min_aux_tstop < tstop + 3600:
-                logger.info('Breaking out of maneuver processing at manvr start={} because '
-                            'min_aux_stop={} < manvr stop + 1hr={}'
-                            .format(DateTime(tstart).date, DateTime(min_aux_tstop).date,
-                                    DateTime(tstop + 3600).date))
+                logger.info(
+                    "Breaking out of maneuver processing at manvr start={} because "
+                    "min_aux_stop={} < manvr stop + 1hr={}".format(
+                        DateTime(tstart).date,
+                        DateTime(min_aux_tstop).date,
+                        DateTime(tstop + 3600).date,
+                    )
+                )
                 break
 
-            i0 = np.searchsorted(changes['time'], manvr_prev['tstop'])
-            i1 = np.searchsorted(changes['time'], manvr_next['tstart'])
-            sequence = changes[i0:i1 + 1]
-            sequence['dt'] = (sequence['time'] + sequence['prev_time']) / 2.0 - manvr['tstop']
-            ok = ((sequence['dt'] >= ZERO_DT) | (sequence['msid'] == 'aofattmd')
-                  | (sequence['msid'] == 'aopcadmd'))
+            i0 = np.searchsorted(changes["time"], manvr_prev["tstop"])
+            i1 = np.searchsorted(changes["time"], manvr_next["tstart"])
+            sequence = changes[i0 : i1 + 1]
+            sequence["dt"] = (sequence["time"] + sequence["prev_time"]) / 2.0 - manvr[
+                "tstop"
+            ]
+            ok = (
+                (sequence["dt"] >= ZERO_DT)
+                | (sequence["msid"] == "aofattmd")
+                | (sequence["msid"] == "aopcadmd")
+            )
             sequence = sequence[ok]
             manvr_attrs = cls.get_manvr_attrs(sequence)
 
-            event = dict(tstart=tstart,
-                         tstop=tstop,
-                         dur=tstop - tstart,
-                         start=DateTime(tstart).date,
-                         stop=DateTime(tstop).date,
-                         foreign={'ManvrSeq': sequence},
-                         )
+            event = dict(
+                tstart=tstart,
+                tstop=tstop,
+                dur=tstop - tstart,
+                start=DateTime(tstart).date,
+                stop=DateTime(tstop).date,
+                foreign={"ManvrSeq": sequence},
+            )
             event.update(manvr_attrs)
             event.update(cls.get_target_attitudes(event, aux_msidset))
-            one_shot = cls.get_one_shot(manvr_attrs['guide_start'], aux_msidset)
+            one_shot = cls.get_one_shot(manvr_attrs["guide_start"], aux_msidset)
             event.update(one_shot)
             dwells = cls.get_dwells(event, sequence)
-            event['foreign']['Dwell'] = dwells
-            event['n_dwell'] = len(dwells)
+            event["foreign"]["Dwell"] = dwells
+            event["n_dwell"] = len(dwells)
 
             events.append(event)
 
@@ -1628,23 +1805,24 @@ class Dwell(Event):
            roll        Float                         Roll angle (deg)
     ============ ============ ========================================
     """
-    rel_tstart = models.FloatField(help_text='Start time relative to manvr end (sec)')
-    manvr = models.ForeignKey(Manvr, on_delete=models.CASCADE,
-                              help_text='Maneuver that contains this dwell')
-    ra = models.FloatField(help_text='Right ascension (deg)')
-    dec = models.FloatField(help_text='Declination (deg)')
-    roll = models.FloatField(help_text='Roll angle (deg)')
-    rel_tstart._kadi_format = '{:.2f}'
-    ra._kadi_format = '{:.5f}'
-    dec._kadi_format = '{:.5f}'
-    roll._kadi_format = '{:.5f}'
+
+    rel_tstart = models.FloatField(help_text="Start time relative to manvr end (sec)")
+    manvr = models.ForeignKey(
+        Manvr, on_delete=models.CASCADE, help_text="Maneuver that contains this dwell"
+    )
+    ra = models.FloatField(help_text="Right ascension (deg)")
+    dec = models.FloatField(help_text="Declination (deg)")
+    roll = models.FloatField(help_text="Roll angle (deg)")
+    rel_tstart._kadi_format = "{:.2f}"
+    ra._kadi_format = "{:.5f}"
+    dec._kadi_format = "{:.5f}"
+    roll._kadi_format = "{:.5f}"
 
     # To do: add ra dec roll quaternion
 
     def __unicode__(self):
         # TODO add ra, dec, roll
-        return ('start={} dur={:.0f}'
-                .format(self.start, self.dur))
+        return "start={} dur={:.0f}".format(self.start, self.dur)
 
 
 class ManvrSeq(BaseModel):
@@ -1682,11 +1860,12 @@ class ManvrSeq(BaseModel):
     prev_time = models.FloatField()
 
     class Meta:
-        ordering = ['manvr', 'date']
+        ordering = ["manvr", "date"]
 
     def __unicode__(self):
-        return ('{}: {} => {} at {}'
-                .format(self.msid.upper(), self.prev_val, self.val, self.date))
+        return "{}: {} => {} at {}".format(
+            self.msid.upper(), self.prev_val, self.val, self.date
+        )
 
 
 class SafeSun(TlmEvent):
@@ -1716,14 +1895,15 @@ class SafeSun(TlmEvent):
       notes       Text
     ======== ========== ================================
     """
+
     notes = models.TextField()
-    event_msids = ['conlofp', 'ctufmtsl', 'c1sqax']
+    event_msids = ["conlofp", "ctufmtsl", "c1sqax"]
     event_filter_bad = False
     event_time_fuzz = 86400  # One full day of fuzz / pad
     event_min_dur = 36000
 
     fetch_event_pad = 86400 / 2
-    fetch_event_msids = ['conlofp', 'ctufmtsl', 'c1sqax', 'aopcadmd', '61psts02']
+    fetch_event_msids = ["conlofp", "ctufmtsl", "c1sqax", "aopcadmd", "61psts02"]
 
     @classmethod
     @import_ska
@@ -1731,26 +1911,30 @@ class SafeSun(TlmEvent):
         # Second safemode has bad telemetry for the entire event so the standard
         # detection algorithm fails.  Just hardwire safemode #1 and fix up the
         # telemetry within this range so that the standard detection works.
-        safemode2_tstart = DateTime('1999:269:20:22:45').secs
-        safemode2_tstop = DateTime('1999:270:08:22:30').secs
+        safemode2_tstart = DateTime("1999:269:20:22:45").secs
+        safemode2_tstop = DateTime("1999:270:08:22:30").secs
         if msidset.tstart < safemode2_tstop and msidset.tstop > safemode2_tstart:
             for msid in msidset.values():
                 ok = (msid.times > safemode2_tstart) & (msid.times < safemode2_tstop)
                 msid.bads[ok] = False
-                force_val = {'conlofp': 'NRML', 'ctufmtsl': 'FMT5', 'c1sqax': 'ENAB'}[msid.msid]
+                force_val = {"conlofp": "NRML", "ctufmtsl": "FMT5", "c1sqax": "ENAB"}[
+                    msid.msid
+                ]
                 msid.vals[ok] = force_val
 
         # Interpolate all MSIDs to a common time.  Sync to the start of CTUFMTSL which is
         # sampled at 32.8 seconds
-        msidset_interpolate(msidset, 32.8, msidset['ctufmtsl'].times[0])
+        msidset_interpolate(msidset, 32.8, msidset["ctufmtsl"].times[0])
 
         # Define intervals when in safe mode ~(A & B & C) == (~A | ~B | ~C)
-        safe_mode = ((msidset['conlofp'].vals != 'NRML')
-                     | (msidset['ctufmtsl'].vals == 'FMT5')
-                     | (msidset['c1sqax'].vals != 'ENAB'))
+        safe_mode = (
+            (msidset["conlofp"].vals != "NRML")
+            | (msidset["ctufmtsl"].vals == "FMT5")
+            | (msidset["c1sqax"].vals != "ENAB")
+        )
 
         # Telemetry indicates a safemode around 1999:221 which isn't real
-        bogus_tstart = DateTime('1999:225:12:00:00').secs
+        bogus_tstart = DateTime("1999:225:12:00:00").secs
         if msidset.tstart < bogus_tstart:
             ok = msidset.times < bogus_tstart
             safe_mode[ok] = False
@@ -1780,8 +1964,9 @@ class NormalSun(TlmEvent):
       obsid    Integer        Observation ID (COBSRQID)
     ======== ========== ================================
     """
-    event_msids = ['aopcadmd']
-    event_val = 'NSUN'
+
+    event_msids = ["aopcadmd"]
+    event_val = "NSUN"
     event_time_fuzz = 86400  # One full day of fuzz
 
 
@@ -1816,18 +2001,25 @@ class MajorEvent(BaseEvent):
      source    Char(3)                     Event source (FDB or FOT)
     ======== ========== =============================================
     """
-    key = models.CharField(max_length=24, primary_key=True,
-                           help_text='Unique key for this event')
+
+    key = models.CharField(
+        max_length=24, primary_key=True, help_text="Unique key for this event"
+    )
     key._kadi_hidden = True
-    start = models.CharField(max_length=8, db_index=True,
-                             help_text='Event time to the nearest day (YYYY:DOY)')
-    date = models.CharField(max_length=11,
-                            help_text='Event time to the nearest day (YYYY-Mon-DD)')
-    tstart = models.FloatField(db_index=True,
-                               help_text='Event time to the nearest day (CXC sec)')
-    descr = models.TextField(help_text='Event description')
-    note = models.TextField(help_text='Note (comments or CAP # or FSW PR #)')
-    source = models.CharField(max_length=3, help_text='Event source (FDB or FOT)')
+    start = models.CharField(
+        max_length=8,
+        db_index=True,
+        help_text="Event time to the nearest day (YYYY:DOY)",
+    )
+    date = models.CharField(
+        max_length=11, help_text="Event time to the nearest day (YYYY-Mon-DD)"
+    )
+    tstart = models.FloatField(
+        db_index=True, help_text="Event time to the nearest day (CXC sec)"
+    )
+    descr = models.TextField(help_text="Event description")
+    note = models.TextField(help_text="Note (comments or CAP # or FSW PR #)")
+    source = models.CharField(max_length=3, help_text="Event source (FDB or FOT)")
 
     # Allow for hand-edits of the source HTML tables back about two years. Make
     # sure the lookback for getting new events is a bit further back than delete
@@ -1836,16 +2028,16 @@ class MajorEvent(BaseEvent):
     lookback_delete = 365 * 2
 
     class Meta:
-        ordering = ['key']
+        ordering = ["key"]
 
     def __unicode__(self):
         descr = self.descr
         if len(descr) > 30:
-            descr = descr[:27] + '...'
+            descr = descr[:27] + "..."
         note = self.note
         if note:
-            descr += ' (' + (note if len(note) < 30 else note[:27] + '...') + ')'
-        return ('{} ({}) {}: {}'.format(self.start, self.date[5:], self.source, descr))
+            descr += " (" + (note if len(note) < 30 else note[:27] + "...") + ")"
+        return "{} ({}) {}: {}".format(self.start, self.date[5:], self.source, descr)
 
     @classmethod
     @import_ska
@@ -1862,14 +2054,18 @@ class MajorEvent(BaseEvent):
         events = scrape.get_fot_major_events() + scrape.get_fdb_major_events()
 
         # Select events within time range and sort by tstart key
-        events = sorted((x for x in events if tstart <= x['tstart'] <= tstop),
-                        key=lambda x: x['tstart'])
+        events = sorted(
+            (x for x in events if tstart <= x["tstart"] <= tstop),
+            key=lambda x: x["tstart"],
+        )
 
         # Manually generate a unique key for event since date is not unique
         for event in events:
-            key = ''.join(event[x] for x in ('start', 'descr', 'note', 'source'))
-            key = key.encode('ascii', 'replace')  # Should already be clean ASCII but make sure
-            event['key'] = event['start'] + ':' + hashlib.sha1(key).hexdigest()[:6]
+            key = "".join(event[x] for x in ("start", "descr", "note", "source"))
+            key = key.encode(
+                "ascii", "replace"
+            )  # Should already be clean ASCII but make sure
+            event["key"] = event["start"] + ":" + hashlib.sha1(key).hexdigest()[:6]
 
         return events
 
@@ -1878,19 +2074,22 @@ class IFotEvent(BaseEvent):
     """
     Base class for events from the iFOT database
     """
-    ifot_id = models.IntegerField(primary_key=True, help_text='iFOT identifier')
-    start = models.CharField(max_length=21, db_index=True, help_text='Start time (date)')
-    stop = models.CharField(max_length=21, help_text='Stop time (date)')
-    tstart = models.FloatField(db_index=True, help_text='Start time (CXC secs)')
-    tstop = models.FloatField(help_text='Stop time (CXC secs)')
-    dur = models.FloatField(help_text='Duration (secs)')
-    dur._kadi_format = '{:.1f}'
+
+    ifot_id = models.IntegerField(primary_key=True, help_text="iFOT identifier")
+    start = models.CharField(
+        max_length=21, db_index=True, help_text="Start time (date)"
+    )
+    stop = models.CharField(max_length=21, help_text="Stop time (date)")
+    tstart = models.FloatField(db_index=True, help_text="Start time (CXC secs)")
+    tstop = models.FloatField(help_text="Stop time (CXC secs)")
+    dur = models.FloatField(help_text="Duration (secs)")
+    dur._kadi_format = "{:.1f}"
 
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
-    ifot_columns = ['id', 'tstart', 'tstop']
+    ifot_columns = ["id", "tstart", "tstop"]
     ifot_props = []
     ifot_types = {}  # Override automatic type inference for properties or columns
 
@@ -1906,17 +2105,24 @@ class IFotEvent(BaseEvent):
         datestop = DateTime(stop).date
 
         # def get_ifot(event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT):
-        ifot_evts = occweb.get_ifot(cls.ifot_type_desc, start=datestart, stop=datestop,
-                                    props=cls.ifot_props, columns=cls.ifot_columns,
-                                    types=cls.ifot_types)
+        ifot_evts = occweb.get_ifot(
+            cls.ifot_type_desc,
+            start=datestart,
+            stop=datestop,
+            props=cls.ifot_props,
+            columns=cls.ifot_columns,
+            types=cls.ifot_types,
+        )
 
         events = []
         for ifot_evt in ifot_evts:
-            event = {key.lower(): ifot_evt[cls.ifot_type_desc + '.' + key].tolist()
-                     for key in cls.ifot_props}
+            event = {
+                key.lower(): ifot_evt[cls.ifot_type_desc + "." + key].tolist()
+                for key in cls.ifot_props
+            }
             # Prefer start or stop from props, but if not there use column tstart/tstop
-            for st in ('start', 'stop'):
-                tst = 't{}'.format(st)
+            for st in ("start", "stop"):
+                tst = "t{}".format(st)
                 if st not in event or not event[st].strip():
                     event[st] = ifot_evt[tst]
                 # The above still might not be OK because sometimes what is in the
@@ -1925,17 +2131,20 @@ class IFotEvent(BaseEvent):
                     DateTime(event[st]).date
                 except Exception:
                     # Fail, roll back to the tstart/tstop version
-                    logger.info('WARNING: Bad value of ifot_evt[{}.{}] = "{}" at {}'
-                                .format(cls.ifot_type_desc, st, event[st], ifot_evt['tstart']))
+                    logger.info(
+                        'WARNING: Bad value of ifot_evt[{}.{}] = "{}" at {}'.format(
+                            cls.ifot_type_desc, st, event[st], ifot_evt["tstart"]
+                        )
+                    )
                     event[st] = ifot_evt[tst]
 
-            event['ifot_id'] = ifot_evt['id']
-            event['tstart'] = DateTime(event['start']).secs
-            event['tstop'] = DateTime(event['stop']).secs
-            event['dur'] = event['tstop'] - event['tstart']
+            event["ifot_id"] = ifot_evt["id"]
+            event["tstart"] = DateTime(event["start"]).secs
+            event["tstop"] = DateTime(event["stop"]).secs
+            event["dur"] = event["tstop"] - event["tstart"]
 
             # Custom processing defined by subclasses to add more attrs to event
-            if hasattr(cls, 'get_extras'):
+            if hasattr(cls, "get_extras"):
                 event.update(cls.get_extras(event, None))
 
             events.append(event)
@@ -1943,7 +2152,7 @@ class IFotEvent(BaseEvent):
         return events
 
     def __unicode__(self):
-        return ('{}: {}'.format(self.ifot_id, self.start[:17]))
+        return "{}: {}".format(self.ifot_id, self.start[:17])
 
 
 class CAP(IFotEvent):
@@ -1970,18 +2179,18 @@ class CAP(IFotEvent):
         link   Char(250)                CAP link
     ========= =========== =======================
     """
-    num = models.CharField(max_length=15, help_text='CAP number')
-    title = models.TextField(help_text='CAP title')
-    descr = models.TextField(help_text='CAP description')
-    notes = models.TextField(help_text='CAP notes')
-    link = models.CharField(max_length=250, help_text='CAP link')
 
-    ifot_type_desc = 'CAP'
-    ifot_props = ['NUM', 'START', 'STOP', 'TITLE', 'LINK', 'DESC']
+    num = models.CharField(max_length=15, help_text="CAP number")
+    title = models.TextField(help_text="CAP title")
+    descr = models.TextField(help_text="CAP description")
+    notes = models.TextField(help_text="CAP notes")
+    link = models.CharField(max_length=250, help_text="CAP link")
+
+    ifot_type_desc = "CAP"
+    ifot_props = ["NUM", "START", "STOP", "TITLE", "LINK", "DESC"]
 
     def __unicode__(self):
-        return ('{}: {} {}'
-                .format(self.num, self.start[:17], self.title))
+        return "{}: {} {}".format(self.num, self.start[:17], self.title)
 
 
 class LoadSegment(IFotEvent):
@@ -2007,13 +2216,14 @@ class LoadSegment(IFotEvent):
        comment       Text                 Comment
     =========== ========== =======================
     """
-    name = models.CharField(max_length=12, help_text='Load segment name')
-    scs = models.IntegerField(help_text='SCS slot')
-    load_name = models.CharField(max_length=10, help_text='Load name')
-    comment = models.TextField(help_text='Comment')
 
-    ifot_type_desc = 'LOADSEG'
-    ifot_props = ['NAME', 'SCS', 'LOAD_NAME', 'COMMENT']
+    name = models.CharField(max_length=12, help_text="Load segment name")
+    scs = models.IntegerField(help_text="SCS slot")
+    load_name = models.CharField(max_length=10, help_text="Load name")
+    comment = models.TextField(help_text="Comment")
+
+    ifot_type_desc = "LOADSEG"
+    ifot_props = ["NAME", "SCS", "LOAD_NAME", "COMMENT"]
 
     lookback = 40  # days of lookback
     lookback_delete = 20  # Remove load segments in database prior to 20 days ago
@@ -2021,8 +2231,9 @@ class LoadSegment(IFotEvent):
     lookforward = 28  # Accept load segments planned up to 28 days in advance
 
     def __unicode__(self):
-        return ('{}: {} {} scs={}'
-                .format(self.name, self.start[:17], self.load_name, self.scs))
+        return "{}: {} {} scs={}".format(
+            self.name, self.start[:17], self.load_name, self.scs
+        )
 
 
 class PassPlan(IFotEvent):
@@ -2061,28 +2272,31 @@ class PassPlan(IFotEvent):
               cmd_count   Char(15)           Command count
     ==================== ========== =======================
     """
-    oc = models.CharField(max_length=30, help_text='OC crew')
-    cc = models.CharField(max_length=30, help_text='CC crew')
-    got = models.CharField(max_length=30, help_text='GOT crew')
-    station = models.CharField(max_length=6, help_text='DSN station')
-    est_datetime = models.CharField(max_length=20, help_text='Date local')
-    sched_support_time = models.CharField(max_length=13, help_text='Support time')
-    activity = models.CharField(max_length=20, help_text='Activity')
-    bot = models.CharField(max_length=4, help_text='Beginning of track')
-    eot = models.CharField(max_length=4, help_text='End of track')
-    data_rate = models.CharField(max_length=10, help_text='Data rate')
-    config = models.CharField(max_length=8, help_text='Configuration')
-    lga = models.CharField(max_length=1, help_text='LGA')
-    power = models.CharField(max_length=6, help_text='Power')
-    rxa_rsl = models.CharField(max_length=10, help_text='Rx-A RSL')
-    rxb_rsl = models.CharField(max_length=10, help_text='Rx-B RSL')
-    err_log = models.CharField(max_length=10, help_text='Error log')
-    cmd_count = models.CharField(max_length=15, help_text='Command count')
 
-    ifot_type_desc = 'PASSPLAN'
-    ifot_props = ("oc cc got station EST_datetime sched_support_time activity bot eot "
-                  "data_rate config lga power rxa_rsl rxb_rsl "
-                  "err_log cmd_count").split()
+    oc = models.CharField(max_length=30, help_text="OC crew")
+    cc = models.CharField(max_length=30, help_text="CC crew")
+    got = models.CharField(max_length=30, help_text="GOT crew")
+    station = models.CharField(max_length=6, help_text="DSN station")
+    est_datetime = models.CharField(max_length=20, help_text="Date local")
+    sched_support_time = models.CharField(max_length=13, help_text="Support time")
+    activity = models.CharField(max_length=20, help_text="Activity")
+    bot = models.CharField(max_length=4, help_text="Beginning of track")
+    eot = models.CharField(max_length=4, help_text="End of track")
+    data_rate = models.CharField(max_length=10, help_text="Data rate")
+    config = models.CharField(max_length=8, help_text="Configuration")
+    lga = models.CharField(max_length=1, help_text="LGA")
+    power = models.CharField(max_length=6, help_text="Power")
+    rxa_rsl = models.CharField(max_length=10, help_text="Rx-A RSL")
+    rxb_rsl = models.CharField(max_length=10, help_text="Rx-B RSL")
+    err_log = models.CharField(max_length=10, help_text="Error log")
+    cmd_count = models.CharField(max_length=15, help_text="Command count")
+
+    ifot_type_desc = "PASSPLAN"
+    ifot_props = (
+        "oc cc got station EST_datetime sched_support_time activity bot eot "
+        "data_rate config lga power rxa_rsl rxb_rsl "
+        "err_log cmd_count"
+    ).split()
 
     lookback = 21  # days of lookback
     lookback_delete = 7  # Remove all comms in database prior to 7 days ago to account
@@ -2092,8 +2306,9 @@ class PassPlan(IFotEvent):
     update_priority = 500  # Must be before DsnComm
 
     def __unicode__(self):
-        return ('{} {} {} OC:{} CC:{}'
-                .format(self.station, self.start[:17], self.est_datetime, self.oc, self.cc))
+        return "{} {} {} OC:{} CC:{}".format(
+            self.station, self.start[:17], self.est_datetime, self.oc, self.cc
+        )
 
 
 class DsnComm(IFotEvent):
@@ -2127,23 +2342,37 @@ class DsnComm(IFotEvent):
      pass_plan   OneToOne                Pass plan
     =========== ========== ========================
     """
-    bot = models.CharField(max_length=4, help_text='Beginning of track')
-    eot = models.CharField(max_length=4, help_text='End of track')
-    activity = models.CharField(max_length=30, help_text='Activity description')
-    config = models.CharField(max_length=10, help_text='Configuration')
-    data_rate = models.CharField(max_length=9, help_text='Data rate')
-    site = models.CharField(max_length=12, help_text='DSN site')
-    soe = models.CharField(max_length=4, help_text='DSN Sequence Of Events')
-    station = models.CharField(max_length=6, help_text='DSN station')
-    oc = models.CharField(max_length=30, help_text='OC crew')
-    cc = models.CharField(max_length=30, help_text='CC crew')
-    pass_plan = models.OneToOneField(PassPlan, help_text='Pass plan', null=True,
-                                     related_name='dsn_comm',
-                                     on_delete=models.CASCADE)
 
-    ifot_type_desc = 'DSN_COMM'
-    ifot_props = ['bot', 'eot', 'activity', 'config', 'data_rate', 'site', 'soe', 'station']
-    ifot_types = {'DSN_COMM.bot': 'str', 'DSN_COMM.eot': 'str'}
+    bot = models.CharField(max_length=4, help_text="Beginning of track")
+    eot = models.CharField(max_length=4, help_text="End of track")
+    activity = models.CharField(max_length=30, help_text="Activity description")
+    config = models.CharField(max_length=10, help_text="Configuration")
+    data_rate = models.CharField(max_length=9, help_text="Data rate")
+    site = models.CharField(max_length=12, help_text="DSN site")
+    soe = models.CharField(max_length=4, help_text="DSN Sequence Of Events")
+    station = models.CharField(max_length=6, help_text="DSN station")
+    oc = models.CharField(max_length=30, help_text="OC crew")
+    cc = models.CharField(max_length=30, help_text="CC crew")
+    pass_plan = models.OneToOneField(
+        PassPlan,
+        help_text="Pass plan",
+        null=True,
+        related_name="dsn_comm",
+        on_delete=models.CASCADE,
+    )
+
+    ifot_type_desc = "DSN_COMM"
+    ifot_props = [
+        "bot",
+        "eot",
+        "activity",
+        "config",
+        "data_rate",
+        "site",
+        "soe",
+        "station",
+    ]
+    ifot_types = {"DSN_COMM.bot": "str", "DSN_COMM.eot": "str"}
 
     lookback = 21  # days of lookback
     lookback_delete = 7  # Remove all comms in database prior to 7 days ago to account
@@ -2156,22 +2385,24 @@ class DsnComm(IFotEvent):
         Define OC, CC and pass_plan if available
         """
         out = {}
-        pass_plans = PassPlan.objects.filter(start=event['start'])
+        pass_plans = PassPlan.objects.filter(start=event["start"])
         if len(pass_plans) > 0:
             # Multiple pass plans possible (e.g. two stations), just take first
             pass_plan = pass_plans[0]
-            out['oc'] = pass_plan.oc
-            out['cc'] = pass_plan.cc
-            out['pass_plan'] = pass_plan
+            out["oc"] = pass_plan.oc
+            out["cc"] = pass_plan.cc
+            out["pass_plan"] = pass_plan
         if len(pass_plans) > 1:
-            logger.warn('Multiple pass plans found at {}: {}'
-                        .format(event['start'], pass_plans))
+            logger.warn(
+                "Multiple pass plans found at {}: {}".format(event["start"], pass_plans)
+            )
 
         return out
 
     def __unicode__(self):
-        return ('{}: {} {}-{} {}'
-                .format(self.station, self.start[:17], self.bot, self.eot, self.activity))
+        return "{}: {} {}-{} {}".format(
+            self.station, self.start[:17], self.bot, self.eot, self.activity
+        )
 
 
 class Orbit(BaseEvent):
@@ -2206,28 +2437,36 @@ class Orbit(BaseEvent):
       dt_stop_radzone      Float    Stop time of rad zone relative to perigee (sec)
     ================== ========== ==================================================
     """
-    start = models.CharField(max_length=21,
-                             help_text='Start time (orbit ascending node crossing)')
-    stop = models.CharField(max_length=21,
-                            help_text='Stop time (next orbit ascending node crossing)')
-    tstart = models.FloatField(db_index=True,
-                               help_text='Start time (orbit ascending node crossing)')
-    tstop = models.FloatField(help_text='Stop time (next orbit ascending node crossing)')
-    dur = models.FloatField(help_text='Orbit duration (sec)')
-    orbit_num = models.IntegerField(primary_key=True, help_text='Orbit number')
-    perigee = models.CharField(max_length=21, help_text='Perigee time')
-    apogee = models.CharField(max_length=21, help_text='Apogee time')
-    t_perigee = models.FloatField(help_text='Perigee time (CXC sec)')
-    start_radzone = models.CharField(max_length=21, help_text='Start time of rad zone')
-    stop_radzone = models.CharField(max_length=21, help_text='Stop time of rad zone')
-    dt_start_radzone = models.FloatField(help_text='Start time of rad zone relative '
-                                         'to perigee (sec)')
-    dt_stop_radzone = models.FloatField(help_text='Stop time of rad zone relative '
-                                        'to perigee (sec)')
-    dur._kadi_format = '{:.1f}'
-    t_perigee._kadi_format = '{:.1f}'
-    dt_start_radzone._kadi_format = '{:.1f}'
-    dt_stop_radzone._kadi_format = '{:.1f}'
+
+    start = models.CharField(
+        max_length=21, help_text="Start time (orbit ascending node crossing)"
+    )
+    stop = models.CharField(
+        max_length=21, help_text="Stop time (next orbit ascending node crossing)"
+    )
+    tstart = models.FloatField(
+        db_index=True, help_text="Start time (orbit ascending node crossing)"
+    )
+    tstop = models.FloatField(
+        help_text="Stop time (next orbit ascending node crossing)"
+    )
+    dur = models.FloatField(help_text="Orbit duration (sec)")
+    orbit_num = models.IntegerField(primary_key=True, help_text="Orbit number")
+    perigee = models.CharField(max_length=21, help_text="Perigee time")
+    apogee = models.CharField(max_length=21, help_text="Apogee time")
+    t_perigee = models.FloatField(help_text="Perigee time (CXC sec)")
+    start_radzone = models.CharField(max_length=21, help_text="Start time of rad zone")
+    stop_radzone = models.CharField(max_length=21, help_text="Stop time of rad zone")
+    dt_start_radzone = models.FloatField(
+        help_text="Start time of rad zone relative " "to perigee (sec)"
+    )
+    dt_stop_radzone = models.FloatField(
+        help_text="Stop time of rad zone relative " "to perigee (sec)"
+    )
+    dur._kadi_format = "{:.1f}"
+    t_perigee._kadi_format = "{:.1f}"
+    dt_start_radzone._kadi_format = "{:.1f}"
+    dt_stop_radzone._kadi_format = "{:.1f}"
 
     @classmethod
     @import_ska
@@ -2243,7 +2482,9 @@ class Orbit(BaseEvent):
         file_dates = []
         for year in years:
             file_dates.extend(orbit_funcs.get_tlr_files(year))
-        tlr_files = [x['name'] for x in file_dates if datestart <= x['date'] <= datestop]
+        tlr_files = [
+            x["name"] for x in file_dates if datestart <= x["date"] <= datestop
+        ]
 
         # Get all orbit points from the tlr files as a list of tuples
         orbit_points = orbit_funcs.get_orbit_points(tlr_files)
@@ -2256,18 +2497,24 @@ class Orbit(BaseEvent):
 
         events = []
         for orbit in orbits:
-            ok = orbit_points['orbit_num'] == orbit['orbit_num']
+            ok = orbit_points["orbit_num"] == orbit["orbit_num"]
             event = {key: orbit[key] for key in orbit.dtype.names}
-            event['foreign'] = {'OrbitPoint': orbit_points[ok],
-                                'RadZone': [orbit_funcs.get_radzone_from_orbit(orbit)]}
+            event["foreign"] = {
+                "OrbitPoint": orbit_points[ok],
+                "RadZone": [orbit_funcs.get_radzone_from_orbit(orbit)],
+            }
             events.append(event)
 
         return events
 
     def __unicode__(self):
-        return ('{} {} dur={:.1f} radzone={:.1f} to {:.1f} ksec'
-                .format(self.orbit_num, self.start[:17], self.dur / 1000,
-                        self.dt_start_radzone / 1000, self.dt_stop_radzone / 1000))
+        return "{} {} dur={:.1f} radzone={:.1f} to {:.1f} ksec".format(
+            self.orbit_num,
+            self.start[:17],
+            self.dur / 1000,
+            self.dt_start_radzone / 1000,
+            self.dt_stop_radzone / 1000,
+        )
 
 
 class OrbitPoint(BaseModel):
@@ -2286,6 +2533,7 @@ class OrbitPoint(BaseModel):
          descr     Char(50)
     =========== ============ ===========
     """
+
     orbit = models.ForeignKey(Orbit, on_delete=models.CASCADE)
     date = models.CharField(max_length=21)
     name = models.CharField(max_length=9)
@@ -2293,11 +2541,12 @@ class OrbitPoint(BaseModel):
     descr = models.CharField(max_length=50)
 
     class Meta:
-        ordering = ['date']
+        ordering = ["date"]
 
     def __unicode__(self):
-        return ('{} (orbit {}) {}: {}'
-                .format(self.date[:17], self.orbit_num, self.name, self.descr[:30]))
+        return "{} (orbit {}) {}: {}".format(
+            self.date[:17], self.orbit_num, self.name, self.descr[:30]
+        )
 
 
 class RadZone(Event):
@@ -2319,14 +2568,15 @@ class RadZone(Event):
        perigee     Char(21)
     =========== ============ ================================
     """
+
     orbit = models.ForeignKey(Orbit, on_delete=models.CASCADE)
     orbit_num = models.IntegerField()
     perigee = models.CharField(max_length=21)
 
     def __unicode__(self):
-        return ('{} {} {} dur={:.1f} ksec'
-                .format(self.orbit_num, self.start[:17], self.stop[:17],
-                        self.dur / 1000))
+        return "{} {} {} dur={:.1f} ksec".format(
+            self.orbit_num, self.start[:17], self.stop[:17], self.dur / 1000
+        )
 
 
 class AsciiTableEvent(BaseEvent):
@@ -2335,9 +2585,10 @@ class AsciiTableEvent(BaseEvent):
     Subclasses need to define the file name (lives in DATA_DIR()/<filename>)
     and the start and stop column names.
     """
+
     class Meta:
         abstract = True
-        ordering = ['start']
+        ordering = ["start"]
 
     @classmethod
     def get_extras(cls, event, interval):
@@ -2367,22 +2618,25 @@ class AsciiTableEvent(BaseEvent):
         # Custom in-place processing of raw intervals
         cls.process_intervals(intervals)
 
-        ok = ((DateTime(intervals[cls.start_column]).date > start)
-              & (DateTime(intervals[cls.stop_column]).date < stop))
+        ok = (DateTime(intervals[cls.start_column]).date > start) & (
+            DateTime(intervals[cls.stop_column]).date < stop
+        )
 
         # Assemble a list of dicts corresponding to events in this tlm interval
         events = []
         for interval in intervals[ok]:
             tstart = DateTime(interval[cls.start_column]).secs
             tstop = DateTime(interval[cls.stop_column]).secs
-            event = dict(tstart=tstart,
-                         tstop=tstop,
-                         dur=tstop - tstart,
-                         start=DateTime(tstart).date,
-                         stop=DateTime(tstop).date)
+            event = dict(
+                tstart=tstart,
+                tstop=tstop,
+                dur=tstop - tstart,
+                start=DateTime(tstart).date,
+                stop=DateTime(tstop).date,
+            )
 
             # Reject events that are shorter than the minimum duration
-            if hasattr(cls, 'event_min_dur') and event['dur'] < cls.event_min_dur:
+            if hasattr(cls, "event_min_dur") and event["dur"] < cls.event_min_dur:
                 continue
 
             # Custom processing defined by subclasses to add more attrs to event
@@ -2412,39 +2666,42 @@ class LttBad(AsciiTableEvent):
        flag    Char(2)                             Flag
     ======== ========== ================================
     """
-    key = models.CharField(max_length=38, primary_key=True,
-                           help_text='Unique key for this event')
-    start = models.CharField(max_length=21, help_text='Start time (YYYY:DDD:HH:MM:SS)')
-    stop = models.CharField(max_length=21, help_text='Stop time (YYYY:DDD:HH:MM:SS)')
-    tstart = models.FloatField(db_index=True, help_text='Start time (CXC secs)')
-    tstop = models.FloatField(help_text='Stop time (CXC secs)')
-    dur = models.FloatField(help_text='Duration (secs)')
-    msid = models.CharField(max_length=20, help_text='MSID')
-    flag = models.CharField(max_length=2, help_text='Flag')
+
+    key = models.CharField(
+        max_length=38, primary_key=True, help_text="Unique key for this event"
+    )
+    start = models.CharField(max_length=21, help_text="Start time (YYYY:DDD:HH:MM:SS)")
+    stop = models.CharField(max_length=21, help_text="Stop time (YYYY:DDD:HH:MM:SS)")
+    tstart = models.FloatField(db_index=True, help_text="Start time (CXC secs)")
+    tstop = models.FloatField(help_text="Stop time (CXC secs)")
+    dur = models.FloatField(help_text="Duration (secs)")
+    msid = models.CharField(max_length=20, help_text="MSID")
+    flag = models.CharField(max_length=2, help_text="Flag")
 
     key._kadi_hidden = True
-    dur._kadi_format = '{:.1f}'
+    dur._kadi_format = "{:.1f}"
 
-    intervals_file = Path(sys.prefix) / 'share' / 'kadi' / 'ltt_bads.dat'
+    intervals_file = Path(sys.prefix) / "share" / "kadi" / "ltt_bads.dat"
     # Table.read keyword args
-    table_read_kwargs = dict(format='ascii', data_start=2, delimiter='|',
-                             guess=False, fill_values=())
-    start_column = 'start'
-    stop_column = 'stop'
+    table_read_kwargs = dict(
+        format="ascii", data_start=2, delimiter="|", guess=False, fill_values=()
+    )
+    start_column = "start"
+    stop_column = "stop"
 
     @classmethod
     def process_intervals(cls, intervals):
-        intervals['start'] = DateTime(intervals['tstart']).date
-        intervals['stop'] = (DateTime(intervals['tstart']) + 1).date
-        intervals.sort('start')
+        intervals["start"] = DateTime(intervals["tstart"]).date
+        intervals["stop"] = (DateTime(intervals["tstart"]) + 1).date
+        intervals.sort("start")
 
     @classmethod
     def get_extras(cls, event, interval):
         out = {}
-        for key in ('msid', 'flag'):
+        for key in ("msid", "flag"):
             out[key] = interval[key].tolist()
-        out['key'] = event['start'][:17] + out['msid']
+        out["key"] = event["start"][:17] + out["msid"]
         return out
 
     def __unicode__(self):
-        return ('start={} msid={} flag={}'.format(self.start, self.msid, self.flag))
+        return "start={} msid={} flag={}".format(self.start, self.msid, self.flag)

--- a/kadi/events/orbit_funcs.py
+++ b/kadi/events/orbit_funcs.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import division
 
-import re
-import os
 import logging
+import os
+import re
 from pathlib import Path
 
 import numpy as np
-
 from Chandra.Time import DateTime
 
 

--- a/kadi/events/orbit_funcs.py
+++ b/kadi/events/orbit_funcs.py
@@ -15,59 +15,73 @@ class NotFoundError(Exception):
     pass
 
 
-ORBIT_POINTS_DTYPE = [('date', 'U21'), ('name', 'U8'),
-                      ('orbit_num', 'i4'), ('descr', 'U50')]
+ORBIT_POINTS_DTYPE = [
+    ("date", "U21"),
+    ("name", "U8"),
+    ("orbit_num", "i4"),
+    ("descr", "U50"),
+]
 
-ORBITS_DTYPE = [('orbit_num', 'i4'),
-                ('start', 'U21'), ('stop', 'U21'),
-                ('tstart', 'f8'), ('tstop', 'f8'), ('dur', 'f4'),
-                ('perigee', 'U21'), ('t_perigee', 'f8'), ('apogee', 'U21'),
-                ('start_radzone', 'U21'), ('stop_radzone', 'U21'),
-                ('dt_start_radzone', 'f4'), ('dt_stop_radzone', 'f4')]
+ORBITS_DTYPE = [
+    ("orbit_num", "i4"),
+    ("start", "U21"),
+    ("stop", "U21"),
+    ("tstart", "f8"),
+    ("tstop", "f8"),
+    ("dur", "f4"),
+    ("perigee", "U21"),
+    ("t_perigee", "f8"),
+    ("apogee", "U21"),
+    ("start_radzone", "U21"),
+    ("stop_radzone", "U21"),
+    ("dt_start_radzone", "f4"),
+    ("dt_stop_radzone", "f4"),
+]
 
-logger = logging.getLogger('events')
+logger = logging.getLogger("events")
 
-MPLOGS_DIR = Path(os.environ['SKA'], 'data', 'mpcrit1', 'mplogs')
+MPLOGS_DIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs")
 
 # Just for reference, all name=descr pairs between 2000 to 2013:001
 NAMES = {
-    'EALT0': 'ALTITUDE ZONE ENTRY0',
-    'EALT1': 'ALTITUDE ZONE ENTRY 1',
-    'EALT2': 'ALTITUDE ZONE ENTRY2',
-    'EALT3': 'ALTITUDE ZONE ENTRY3',
-    'EAPOGEE': 'ORBIT APOGEE',
-    'EASCNCR': 'ORBIT ASCENDING NODE CROSSING',
-    'EE1RADZ0': 'ELECTRON1 RADIATION ENTRY0',
-    'EE2RADZ0': 'ELECTRON2 RADIATION ENTRY0',
-    'EEF1000': 'ELECTRON 1 RADIATION ENTRY 0',
-    'EODAY': 'EARTH SHADOW (UMBRA) EXIT',
-    'EONIGHT': 'EARTH SHADOW (UMBRA) ENTRY',
-    'EP1RADZ0': 'PROTON1 RADIATION ENTRY0',
-    'EP2RADZ0': 'PROTON2 RADIATION ENTRY0',
-    'EPERIGEE': 'ORBIT PERIGEE',
-    'EPF1000': 'PROTON 1 RADIATION ENTRY 0',
-    'EQF003M': 'PROTON FLUX ENTRY FOR ENERGY 0 LEVEL 0 KP 3 MEAN',
-    'EQF013M': 'PROTON FLUX ENTRY FOR ENERGY 0 LEVEL 1 KP 3 MEAN',
-    'LSDAY': 'LUNAR SHADOW (UMBRA) EXIT',
-    'LSNIGHT': 'LUNAR SHADOW (UMBRA) ENTRY',
-    'LSPENTRY': 'LUNAR SHADOW (PENUMBRA) ENTRY',
-    'LSPEXIT': 'LUNAR SHADOW (PENUMBRA) EXIT',
-    'OORMPDS': 'RADMON DISABLE',
-    'OORMPEN': 'RADMON ENABLE',
-    'PENTRY': 'EARTH SHADOW (PENUMBRA) ENTRY',
-    'PEXIT': 'EARTH SHADOW (PENUMBRA) EXIT',
-    'XALT0': 'ALTITUDE ZONE EXIT 0',
-    'XALT1': 'ALTITUDE ZONE EXIT 1',
-    'XALT2': 'ALTITUDE ZONE EXIT2',
-    'XALT3': 'ALTITUDE ZONE EXIT3',
-    'XE1RADZ0': 'ELECTRON1 RADIATION EXIT0',
-    'XE2RADZ0': 'ELECTRON2 RADIATION EXIT0',
-    'XEF1000': 'ELECTRON 1 RADIATION EXIT 0',
-    'XP1RADZ0': 'PROTON1 RADIATION EXIT0',
-    'XP2RADZ0': 'PROTON2 RADIATION EXIT0',
-    'XPF1000': 'PROTON 1 RADIATION EXIT 0',
-    'XQF003M': 'PROTON FLUX EXIT FOR ENERGY 0 LEVEL 0 KP 3 MEAN',
-    'XQF013M': 'PROTON FLUX EXIT FOR ENERGY 0 LEVEL 1 KP 3 MEAN'}
+    "EALT0": "ALTITUDE ZONE ENTRY0",
+    "EALT1": "ALTITUDE ZONE ENTRY 1",
+    "EALT2": "ALTITUDE ZONE ENTRY2",
+    "EALT3": "ALTITUDE ZONE ENTRY3",
+    "EAPOGEE": "ORBIT APOGEE",
+    "EASCNCR": "ORBIT ASCENDING NODE CROSSING",
+    "EE1RADZ0": "ELECTRON1 RADIATION ENTRY0",
+    "EE2RADZ0": "ELECTRON2 RADIATION ENTRY0",
+    "EEF1000": "ELECTRON 1 RADIATION ENTRY 0",
+    "EODAY": "EARTH SHADOW (UMBRA) EXIT",
+    "EONIGHT": "EARTH SHADOW (UMBRA) ENTRY",
+    "EP1RADZ0": "PROTON1 RADIATION ENTRY0",
+    "EP2RADZ0": "PROTON2 RADIATION ENTRY0",
+    "EPERIGEE": "ORBIT PERIGEE",
+    "EPF1000": "PROTON 1 RADIATION ENTRY 0",
+    "EQF003M": "PROTON FLUX ENTRY FOR ENERGY 0 LEVEL 0 KP 3 MEAN",
+    "EQF013M": "PROTON FLUX ENTRY FOR ENERGY 0 LEVEL 1 KP 3 MEAN",
+    "LSDAY": "LUNAR SHADOW (UMBRA) EXIT",
+    "LSNIGHT": "LUNAR SHADOW (UMBRA) ENTRY",
+    "LSPENTRY": "LUNAR SHADOW (PENUMBRA) ENTRY",
+    "LSPEXIT": "LUNAR SHADOW (PENUMBRA) EXIT",
+    "OORMPDS": "RADMON DISABLE",
+    "OORMPEN": "RADMON ENABLE",
+    "PENTRY": "EARTH SHADOW (PENUMBRA) ENTRY",
+    "PEXIT": "EARTH SHADOW (PENUMBRA) EXIT",
+    "XALT0": "ALTITUDE ZONE EXIT 0",
+    "XALT1": "ALTITUDE ZONE EXIT 1",
+    "XALT2": "ALTITUDE ZONE EXIT2",
+    "XALT3": "ALTITUDE ZONE EXIT3",
+    "XE1RADZ0": "ELECTRON1 RADIATION EXIT0",
+    "XE2RADZ0": "ELECTRON2 RADIATION EXIT0",
+    "XEF1000": "ELECTRON 1 RADIATION EXIT 0",
+    "XP1RADZ0": "PROTON1 RADIATION EXIT0",
+    "XP2RADZ0": "PROTON2 RADIATION EXIT0",
+    "XPF1000": "PROTON 1 RADIATION EXIT 0",
+    "XQF003M": "PROTON FLUX EXIT FOR ENERGY 0 LEVEL 0 KP 3 MEAN",
+    "XQF013M": "PROTON FLUX EXIT FOR ENERGY 0 LEVEL 1 KP 3 MEAN",
+}
 
 
 def prune_dirs(dirs, regex):
@@ -83,7 +97,7 @@ def prune_dirs(dirs, regex):
 get_tlr_files_cache = {}
 
 
-def get_tlr_files(mpdir=''):
+def get_tlr_files(mpdir=""):
     """
     Get all timeline report files within the specified SOT MP directory
     ``mpdir`` relative to the root of /data/mpcrit1/mplogs.
@@ -96,41 +110,43 @@ def get_tlr_files(mpdir=''):
     except KeyError:
         pass
 
-    logger.info('Looking for TLR files in {}'.format(rootdir))
+    logger.info("Looking for TLR files in {}".format(rootdir))
 
     tlrfiles = []
     for root, dirs, files in os.walk(rootdir):
-        root = root.rstrip('/')
+        root = root.rstrip("/")
         depth = len(Path(root).parts) - len(MPLOGS_DIR.parts)
-        logger.debug(f'get_trl_files: root={root} {depth} {rootdir}')
+        logger.debug(f"get_trl_files: root={root} {depth} {rootdir}")
         if depth == 0:
-            prune_dirs(dirs, r'\d{4}$')
+            prune_dirs(dirs, r"\d{4}$")
         elif depth == 1:
-            prune_dirs(dirs, r'[A-Z]{3}\d{4}$')
+            prune_dirs(dirs, r"[A-Z]{3}\d{4}$")
         elif depth == 2:
-            prune_dirs(dirs, r'ofls[a-z]$')
+            prune_dirs(dirs, r"ofls[a-z]$")
         elif depth > 2:
-            tlrs = [x for x in files if re.match(r'.+\.tlr$', x)]
+            tlrs = [x for x in files if re.match(r".+\.tlr$", x)]
             if len(tlrs) == 0:
-                logger.info('NO tlr file found in {}'.format(root))
+                logger.info("NO tlr file found in {}".format(root))
             else:
-                logger.info('Located TLR file {}'.format(os.path.join(root, tlrs[0])))
+                logger.info("Located TLR file {}".format(os.path.join(root, tlrs[0])))
                 tlrfiles.append(os.path.join(root, tlrs[0]))
             while dirs:
                 dirs.pop()
 
     files = []
     for tlrfile in tlrfiles:
-        monddyy, oflsv = tlrfile.split('/')[-3:-1]
+        monddyy, oflsv = tlrfile.split("/")[-3:-1]
         mon = monddyy[:3].capitalize()
         dd = monddyy[3:5]
         yy = int(monddyy[5:7])
         yyyy = 1900 + yy if yy > 95 else 2000 + yy
-        caldate = '{}{}{} at 12:00:00.000'.format(yyyy, mon, dd)
-        files.append((tlrfile, DateTime(caldate).date[:8] + oflsv, DateTime(caldate).date))
+        caldate = "{}{}{} at 12:00:00.000".format(yyyy, mon, dd)
+        files.append(
+            (tlrfile, DateTime(caldate).date[:8] + oflsv, DateTime(caldate).date)
+        )
 
     files = sorted(files, key=lambda x: x[1])
-    out = [{'name': x[0], 'date': x[2]} for x in files]
+    out = [{"name": x[0], "date": x[2]} for x in files]
     get_tlr_files_cache[rootdir] = out
 
     return out
@@ -144,8 +160,8 @@ def prune_a_loads(tlrfiles):
     outs = []
     last_monddyy = None
     for tlrfile in reversed(tlrfiles):
-        monddyy, oflsv = tlrfile.split('/')[-3:-1]
-        if monddyy == last_monddyy and oflsv == 'oflsa':
+        monddyy, oflsv = tlrfile.split("/")[-3:-1]
+        if monddyy == last_monddyy and oflsv == "oflsa":
             continue
         else:
             outs.append(tlrfile)
@@ -160,8 +176,8 @@ def filter_known_bad(orbit_points):
     """
     ops = orbit_points
     bad = np.zeros(len(orbit_points), dtype=bool)
-    bad |= (ops['name'] == 'OORMPEN') & (ops['date'] == '2002:253:10:08:52.239')
-    bad |= (ops['name'] == 'OORMPEN') & (ops['date'] == '2004:010:10:00:00.000')
+    bad |= (ops["name"] == "OORMPEN") & (ops["date"] == "2002:253:10:08:52.239")
+    bad |= (ops["name"] == "OORMPEN") & (ops["date"] == "2004:010:10:00:00.000")
     return orbit_points[~bad]
 
 
@@ -178,39 +194,39 @@ def get_orbit_points(tlrfiles):
         # Parse thing like this:
         #  2012:025:21:22:21.732 EQF013M     1722   PROTON FLUX ENTRY FOR ENERGY 0 LEVEL ...
         # 012345678901234567890123456789012345678901234567890123456789
-        logger.info('Getting points from {}'.format(tlrfile))
+        logger.info("Getting points from {}".format(tlrfile))
         try:
-            fh = open(tlrfile, 'r', encoding='ascii', errors='ignore')
+            fh = open(tlrfile, "r", encoding="ascii", errors="ignore")
         except IOError as err:
             logger.warn(err)
             continue
         for line in fh:
-            if len(line) < 30 or line[:2] != ' 2':
+            if len(line) < 30 or line[:2] != " 2":
                 continue
             try:
                 date, name, orbit_num, descr = line.split(None, 3)
             except ValueError:
                 continue
 
-            if name.startswith('OORMP'):
+            if name.startswith("OORMP"):
                 orbit_num = -1
-                descr = 'RADMON {}ABLE'.format('EN' if name.endswith('EN') else 'DIS')
-            elif line[23] in ' -':
+                descr = "RADMON {}ABLE".format("EN" if name.endswith("EN") else "DIS")
+            elif line[23] in " -":
                 continue
 
-            if 'DSS-' in name:
+            if "DSS-" in name:
                 continue
-            if not re.match(r'\d{4}:\d{3}:\d{2}:\d{2}:\d{2}\.\d{3}', date):
+            if not re.match(r"\d{4}:\d{3}:\d{2}:\d{2}:\d{2}\.\d{3}", date):
                 logger.info('Failed for date: "{}"'.format(date))
                 continue
-            if not re.match(r'[A-Z]+', name):
+            if not re.match(r"[A-Z]+", name):
                 logger.info('Failed for name: "{}"'.format(name))
                 continue
 
             try:
                 orbit_num = int(orbit_num)
             except TypeError:
-                logger.info('Failed for orbit_num: {}'.format(orbit_num))
+                logger.info("Failed for orbit_num: {}".format(orbit_num))
                 continue
 
             descr = descr.strip()
@@ -228,7 +244,7 @@ def get_nearest_orbit_num(orbit_nums, idx, d_idx):
     while True:
         idx += d_idx
         if idx < 0 or idx >= len(orbit_nums):
-            raise NotFoundError('No nearest orbit num found')
+            raise NotFoundError("No nearest orbit num found")
         if orbit_nums[idx] != -1:
             break
     return orbit_nums[idx], idx
@@ -241,23 +257,25 @@ def interpolate_orbit_points(orbit_points, name):
     if len(orbit_points) == 0:
         return []
 
-    ok = orbit_points['name'] == name
+    ok = orbit_points["name"] == name
     ops = orbit_points[ok]
     # Get the indexes of missing orbits
-    idxs = np.flatnonzero(np.diff(ops['orbit_num']) > 1)
+    idxs = np.flatnonzero(np.diff(ops["orbit_num"]) > 1)
     new_orbit_points = []
     for idx in idxs:
         op0 = ops[idx]
         op1 = ops[idx + 1]
-        orb_num0 = op0['orbit_num']
-        orb_num1 = op1['orbit_num']
-        time0 = DateTime(op0['date']).secs
-        time1 = DateTime(op1['date']).secs
+        orb_num0 = op0["orbit_num"]
+        orb_num1 = op1["orbit_num"]
+        time0 = DateTime(op0["date"]).secs
+        time1 = DateTime(op1["date"]).secs
         for orb_num in range(orb_num0 + 1, orb_num1):
-            time = time0 + (orb_num - orb_num0) / (orb_num1 - orb_num0) * (time1 - time0)
+            time = time0 + (orb_num - orb_num0) / (orb_num1 - orb_num0) * (
+                time1 - time0
+            )
             date = DateTime(time).date
-            new_orbit_point = (date, name, orb_num, op0['descr'])
-            logger.info('Adding new orbit point {}'.format(new_orbit_point))
+            new_orbit_point = (date, name, orb_num, op0["descr"])
+            logger.info("Adding new orbit point {}".format(new_orbit_point))
             new_orbit_points.append(new_orbit_point)
 
     return new_orbit_points
@@ -302,43 +320,51 @@ def process_orbit_points(orbit_points):
 
     # For key orbit points linearly interpolate across gaps in orbit coverage.
     new_ops = []
-    for name in ('EPERIGEE', 'EAPOGEE', 'EASCNCR'):
+    for name in ("EPERIGEE", "EAPOGEE", "EASCNCR"):
         new_ops.extend(interpolate_orbit_points(orbit_points, name))
 
     # Add a new orbit point for the ascending node EXIT which is the end of each orbit.
     # This simplifies bookkeeping later.
-    for op in orbit_points[orbit_points['name'] == 'EASCNCR']:
-        new_ops.append((op['date'], 'XASCNCR', op['orbit_num'] - 1, op['descr'] + ' EXIT'))
+    for op in orbit_points[orbit_points["name"] == "EASCNCR"]:
+        new_ops.append(
+            (op["date"], "XASCNCR", op["orbit_num"] - 1, op["descr"] + " EXIT")
+        )
 
     # Add corresponding XASCNCR for any new EASCNCR points
     for op in new_ops:
-        if op[1] == 'EASCNCR':
-            new_ops.append((op[0], 'XASCNCR', op[2] - 1, op[3] + ' EXIT'))
+        if op[1] == "EASCNCR":
+            new_ops.append((op[0], "XASCNCR", op[2] - 1, op[3] + " EXIT"))
 
-    logger.info('Adding {} new orbit points'.format(len(new_ops)))
+    logger.info("Adding {} new orbit points".format(len(new_ops)))
     new_ops = np.array(new_ops, dtype=ORBIT_POINTS_DTYPE)
     orbit_points = np.concatenate([orbit_points, new_ops])
-    orbit_points.sort(order=['date', 'orbit_num'])
+    orbit_points.sort(order=["date", "orbit_num"])
 
     # Fill in orbit number for RADMON enable / disable points
-    radmon_idxs = np.flatnonzero(orbit_points['orbit_num'] == -1)
-    orbit_nums = orbit_points['orbit_num']
+    radmon_idxs = np.flatnonzero(orbit_points["orbit_num"] == -1)
+    orbit_nums = orbit_points["orbit_num"]
     for idx in radmon_idxs:
         try:
             prev_num, prev_idx = get_nearest_orbit_num(orbit_nums, idx, -1)
             next_num, next_idx = get_nearest_orbit_num(orbit_nums, idx, +1)
         except NotFoundError:
-            logger.info('No nearest orbit point for orbit_points[{}] (len={})'
-                        .format(idx, len(orbit_points)))
+            logger.info(
+                "No nearest orbit point for orbit_points[{}] (len={})".format(
+                    idx, len(orbit_points)
+                )
+            )
         else:
             if prev_num == next_num:
                 orbit_nums[idx] = next_num
             else:
-                logger.info('Unable to assign orbit num idx={} prev={} next={}'
-                            .format(idx, prev_num, next_num))
-                logger.info('  {} {}'.format(prev_idx, orbit_points[prev_idx]))
-                logger.info(' * {} {}'.format(idx, orbit_points[idx]))
-                logger.info('  {} {}'.format(next_idx, orbit_points[next_idx]))
+                logger.info(
+                    "Unable to assign orbit num idx={} prev={} next={}".format(
+                        idx, prev_num, next_num
+                    )
+                )
+                logger.info("  {} {}".format(prev_idx, orbit_points[prev_idx]))
+                logger.info(" * {} {}".format(idx, orbit_points[idx]))
+                logger.info("  {} {}".format(next_idx, orbit_points[next_idx]))
 
     return orbit_points
 
@@ -360,24 +386,31 @@ def get_orbits(orbit_points):
                       ('start_radzone', 'U21'), ('stop_radzone', 'U21'),
                       ('dt_start_radzone', 'f4'), ('dt_stop_radzone', 'f4')]
     """
+
     def get_idx(ops, name):
-        ok = ops['name'] == name
+        ok = ops["name"] == name
         if np.sum(ok) != 1:
-            raise NotFoundError('Expected one match for {} but found {} in orbit {}\n{}'
-                                .format(name, np.sum(ok), orbit_num, ops))
+            raise NotFoundError(
+                "Expected one match for {} but found {} in orbit {}\n{}".format(
+                    name, np.sum(ok), orbit_num, ops
+                )
+            )
         return np.flatnonzero(ok)[0]
 
     def get_date(ops, name):
         idx = get_idx(ops, name)
-        return ops['date'][idx]
+        return ops["date"][idx]
 
     def get_nearest_orbit_point(name, idx, d_idx):
         while True:
             idx += d_idx
             if idx < 0 or idx >= len(orbit_points):
-                raise NotFoundError('Skipping orbit {}: no nearest orbit point {} found'
-                                    .format(orbit_num, name))
-            if orbit_points['name'][idx] == name:
+                raise NotFoundError(
+                    "Skipping orbit {}: no nearest orbit point {} found".format(
+                        orbit_num, name
+                    )
+                )
+            if orbit_points["name"][idx] == name:
                 break
         return orbit_points[idx]
 
@@ -391,24 +424,31 @@ def get_orbits(orbit_points):
         while True:
             idx -= 1
             if idx < 0:
-                raise NotFoundError('Did not find RADMON enable prior to {}'
-                                    .format(orbit_points[idx_perigee]))
-            if orbit_points['name'][idx] == 'OORMPDS':
-                start_radzone = orbit_points['date'][idx]
-            if orbit_points['name'][idx] == 'OORMPEN':
+                raise NotFoundError(
+                    "Did not find RADMON enable prior to {}".format(
+                        orbit_points[idx_perigee]
+                    )
+                )
+            if orbit_points["name"][idx] == "OORMPDS":
+                start_radzone = orbit_points["date"][idx]
+            if orbit_points["name"][idx] == "OORMPEN":
                 if start_radzone is None:
-                    raise NotFoundError('Found radmon enable before first disable at idx {}'
-                                        .format(idx))
+                    raise NotFoundError(
+                        "Found radmon enable before first disable at idx {}".format(idx)
+                    )
                 break
 
         idx = idx_perigee
         while True:
             idx += 1
             if idx >= len(orbit_points):
-                raise NotFoundError('Did not find RADMON enable after to {}'
-                                    .format(str(orbit_points[idx_perigee])))
-            if orbit_points['name'][idx] == 'OORMPEN':
-                stop_radzone = orbit_points['date'][idx]
+                raise NotFoundError(
+                    "Did not find RADMON enable after to {}".format(
+                        str(orbit_points[idx_perigee])
+                    )
+                )
+            if orbit_points["name"][idx] == "OORMPEN":
+                stop_radzone = orbit_points["date"][idx]
                 break
 
         return start_radzone, stop_radzone
@@ -419,43 +459,56 @@ def get_orbits(orbit_points):
     # orbit boundaries by a few seconds.  This is related to the technique of
     # reading in every TLR to get maximal coverage of orbit points.
     orbit_points = orbit_points.copy()
-    orbit_points.sort(order=['orbit_num', 'date'])
+    orbit_points.sort(order=["orbit_num", "date"])
 
-    orbit_nums = orbit_points['orbit_num']
+    orbit_nums = orbit_points["orbit_num"]
     uniq_orbit_nums = sorted(set(orbit_nums[orbit_nums > 0]))
 
     orbits = []
     for orbit_num in uniq_orbit_nums:
-        i0 = np.searchsorted(orbit_nums, orbit_num, side='left')
-        i1 = np.searchsorted(orbit_nums, orbit_num, side='right')
-        ops = orbit_points[i0: i1]
+        i0 = np.searchsorted(orbit_nums, orbit_num, side="left")
+        i1 = np.searchsorted(orbit_nums, orbit_num, side="right")
+        ops = orbit_points[i0:i1]
 
         try:
-            if 'EASCNCR' not in ops['name'] or 'XASCNCR' not in ops['name']:
-                raise NotFoundError('Skipping orbit {} incomplete'.format(orbit_num))
+            if "EASCNCR" not in ops["name"] or "XASCNCR" not in ops["name"]:
+                raise NotFoundError("Skipping orbit {} incomplete".format(orbit_num))
 
-            start = get_date(ops, 'EASCNCR')
-            stop = get_date(ops, 'XASCNCR')
-            date_apogee = get_date(ops, 'EAPOGEE')
-            date_perigee = get_date(ops, 'EPERIGEE')
+            start = get_date(ops, "EASCNCR")
+            stop = get_date(ops, "XASCNCR")
+            date_apogee = get_date(ops, "EAPOGEE")
+            date_perigee = get_date(ops, "EPERIGEE")
 
-            idx_perigee = get_idx(ops, 'EPERIGEE') + i0
+            idx_perigee = get_idx(ops, "EPERIGEE") + i0
             start_radzone, stop_radzone = find_radzone(idx_perigee)
         except NotFoundError as err:
             logger.info(err)
             continue
         else:
-            dt_radzones = [(DateTime(date) - DateTime(date_perigee)) * 86400.0
-                           for date in (start_radzone, stop_radzone)]
+            dt_radzones = [
+                (DateTime(date) - DateTime(date_perigee)) * 86400.0
+                for date in (start_radzone, stop_radzone)
+            ]
             tstart = DateTime(start).secs
             tstop = DateTime(stop).secs
-            orbit = (orbit_num,
-                     start, stop,
-                     tstart, tstop, tstop - tstart,
-                     date_perigee, DateTime(date_perigee).secs, date_apogee,
-                     start_radzone, stop_radzone,
-                     dt_radzones[0], dt_radzones[1])
-            logger.info('get_orbits: Adding orbit {} {} {}'.format(orbit_num, start, stop))
+            orbit = (
+                orbit_num,
+                start,
+                stop,
+                tstart,
+                tstop,
+                tstop - tstart,
+                date_perigee,
+                DateTime(date_perigee).secs,
+                date_apogee,
+                start_radzone,
+                stop_radzone,
+                dt_radzones[0],
+                dt_radzones[1],
+            )
+            logger.info(
+                "get_orbits: Adding orbit {} {} {}".format(orbit_num, start, stop)
+            )
             orbits.append(orbit)
 
     orbits = np.array(orbits, dtype=ORBITS_DTYPE)
@@ -467,17 +520,19 @@ def get_radzone_from_orbit(orbit):
     Extract the RadZone fields from an orbit descriptor (which is one row
     of the orbits structured array).
     """
-    start_radzone = DateTime(orbit['start_radzone'], format='date')
-    stop_radzone = DateTime(orbit['stop_radzone'], format='date')
+    start_radzone = DateTime(orbit["start_radzone"], format="date")
+    stop_radzone = DateTime(orbit["stop_radzone"], format="date")
     tstart = start_radzone.secs
     tstop = stop_radzone.secs
     dur = tstop - tstart
-    radzone = {'start': start_radzone.date,
-               'stop': stop_radzone.date,
-               'tstart': tstart,
-               'tstop': tstop,
-               'dur': dur,
-               'orbit_num': orbit['orbit_num'],
-               'perigee': orbit['perigee']}
+    radzone = {
+        "start": start_radzone.date,
+        "stop": stop_radzone.date,
+        "tstart": tstart,
+        "tstop": tstop,
+        "dur": dur,
+        "orbit_num": orbit["orbit_num"],
+        "perigee": orbit["perigee"],
+    }
 
     return radzone

--- a/kadi/events/plot.py
+++ b/kadi/events/plot.py
@@ -39,13 +39,18 @@ def tlm_event(evt, figsize=None, fig=None):
             continue
 
         ax.set_ymargin(0.15)
-        plot_cxctime(ms[msid].times, ms[msid].raw_vals, state_codes=ms[msid].state_codes,
-                     label=msid, ax=ax)
+        plot_cxctime(
+            ms[msid].times,
+            ms[msid].raw_vals,
+            state_codes=ms[msid].state_codes,
+            label=msid,
+            ax=ax,
+        )
         ax.set_ymargin(0)
-        plot_cxctime([evt.tstart, evt.tstart], ax.get_ylim(), 'm--', ax=ax)
-        plot_cxctime([evt.tstop, evt.tstop], ax.get_ylim(), 'm--', ax=ax)
+        plot_cxctime([evt.tstart, evt.tstart], ax.get_ylim(), "m--", ax=ax)
+        plot_cxctime([evt.tstop, evt.tstop], ax.get_ylim(), "m--", ax=ax)
         ax.grid()
-        leg = ax.legend(loc='upper left', fontsize='small', fancybox=True)
+        leg = ax.legend(loc="upper left", fontsize="small", fancybox=True)
         if leg is not None:
             leg.get_frame().set_alpha(0.7)
 
@@ -65,40 +70,63 @@ def manvr(evt, figsize=(8, 10), fig=None):
     fig.clf()
     tstarts = [evt.tstart, evt.tstart]
     tstops = [evt.tstop, evt.tstop]
-    colors = ['r', 'b', 'g', 'm']
+    colors = ["r", "b", "g", "m"]
 
     # AOATTQT estimated quaternion
     ax1 = fig.add_subplot(3, 1, 1)
     for i, color in zip(range(1, 5), colors):
-        msid = 'aoattqt{}'.format(i)
-        plot_cxctime(ms[msid].times, ms[msid].vals, fig=fig, ax=ax1,
-                     color=color, linestyle='-', label=msid, interactive=False)
+        msid = "aoattqt{}".format(i)
+        plot_cxctime(
+            ms[msid].times,
+            ms[msid].vals,
+            fig=fig,
+            ax=ax1,
+            color=color,
+            linestyle="-",
+            label=msid,
+            interactive=False,
+        )
     ax1.set_ylim(-1.05, 1.05)
-    ax1.set_title('Maneuver at {}'.format(evt.start[:-4]))
+    ax1.set_title("Maneuver at {}".format(evt.start[:-4]))
 
     # AOATTER attitude error (arcsec)
     ax2 = fig.add_subplot(3, 1, 2, sharex=ax1)
-    msids = ['aoatter{}'.format(i) for i in range(1, 4)] + ['one_shot']
+    msids = ["aoatter{}".format(i) for i in range(1, 4)] + ["one_shot"]
     scales = [R2A, R2A, R2A, 1.0]
     for color, msid, scale in zip(colors, msids, scales):
-        plot_cxctime(ms[msid].times, ms[msid].vals * scale, fig=fig, ax=ax2,
-                     color=color, linestyle='-', label=msid, interactive=False)
-    ax2.set_ylabel('Attitude error (arcsec)')
+        plot_cxctime(
+            ms[msid].times,
+            ms[msid].vals * scale,
+            fig=fig,
+            ax=ax2,
+            color=color,
+            linestyle="-",
+            label=msid,
+            interactive=False,
+        )
+    ax2.set_ylabel("Attitude error (arcsec)")
     fix_ylim(ax2, 10)
 
     # ACA sequence
     ax3 = fig.add_subplot(3, 1, 3, sharex=ax1)
-    msid = ms['aoacaseq']
-    plot_cxctime(msid.times, msid.raw_vals, state_codes=msid.state_codes, fig=fig, ax=ax3,
-                 interactive=False, label='aoacaseq')
+    msid = ms["aoacaseq"]
+    plot_cxctime(
+        msid.times,
+        msid.raw_vals,
+        state_codes=msid.state_codes,
+        fig=fig,
+        ax=ax3,
+        interactive=False,
+        label="aoacaseq",
+    )
     fix_ylim(ax3, 2.2)
 
     for ax in [ax1, ax2, ax3]:
-        ax.callbacks.connect('xlim_changed', remake_ticks)
-        plot_cxctime(tstarts, ax.get_ylim(), '--r', fig=fig, ax=ax, interactive=False)
-        plot_cxctime(tstops, ax.get_ylim(), '--r', fig=fig, ax=ax, interactive=False)
+        ax.callbacks.connect("xlim_changed", remake_ticks)
+        plot_cxctime(tstarts, ax.get_ylim(), "--r", fig=fig, ax=ax, interactive=False)
+        plot_cxctime(tstops, ax.get_ylim(), "--r", fig=fig, ax=ax, interactive=False)
         ax.grid()
-        leg = ax.legend(loc='upper left', fontsize='small', fancybox=True)
+        leg = ax.legend(loc="upper left", fontsize="small", fancybox=True)
         if leg is not None:
             leg.get_frame().set_alpha(0.7)
 

--- a/kadi/events/query.py
+++ b/kadi/events/query.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import sys
 import operator
+import sys
 import warnings
 
-import numpy as np
-
-from Chandra.Time import DateTime
-
 import django
+import numpy as np
+from Chandra.Time import DateTime
 
 try:
     django.setup()

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -6,13 +6,15 @@ from bs4 import BeautifulSoup as parse_html
 from Chandra.Time import DateTime
 from .. import occweb
 
-REPLACES = ((r'&#150', '-'),
-            (r'&amp;', '&'),
-            (r'&nbsp;', ' '),
-            (r'&quot;', '"'),
-            (r'&gt;', '>'),
-            (r'&lt;', '<'),
-            (r'&#14[678];', ''))
+REPLACES = (
+    (r"&#150", "-"),
+    (r"&amp;", "&"),
+    (r"&nbsp;", " "),
+    (r"&quot;", '"'),
+    (r"&gt;", ">"),
+    (r"&lt;", "<"),
+    (r"&#14[678];", ""),
+)
 
 # Cache of events dicts to prevent hitting the web page or re-parsing multiple times
 # (which is also slow).
@@ -24,9 +26,9 @@ def cleantext(text):
     Clean up some HTML or unicode special characters and replace with ASCII equivalents.
     """
     # Convert any non-ASCII characters to XML like '&#40960;abcd&#1972;'
-    text = text.encode('ascii', 'xmlcharrefreplace').decode('ascii')
+    text = text.encode("ascii", "xmlcharrefreplace").decode("ascii")
     lines = [x.strip() for x in text.splitlines()]
-    text = ' '.join(lines)
+    text = " ".join(lines)
     for match, out in REPLACES:
         text = re.sub(match, out, text)
     text = text.strip()  # some spaces may have been generated
@@ -39,10 +41,10 @@ def get_table_rows(table):
     Use BeautifulSoup to extract table entries as a list of lists.
     """
     rows = []
-    trs = table.findAll('tr')
+    trs = table.findAll("tr")
     for tr in trs:
-        tds = tr.findAll('td')
-        if 'colspan' in dict(tds[0].attrs):
+        tds = tr.findAll("td")
+        if "colspan" in dict(tds[0].attrs):
             continue
         vals = tuple(cleantext(td.text) for td in tds)
         rows.append(vals)
@@ -52,6 +54,7 @@ def get_table_rows(table):
 
 # TODO refactor these two mostly-similar routines
 
+
 def get_fdb_major_events():
     """
     Get the FDB major events.
@@ -59,35 +62,37 @@ def get_fdb_major_events():
     Some events in the early mission have multiple CAPs, which causes run-together CAP
     numbers.
     """
-    page = 'fdb_major_events'
+    page = "fdb_major_events"
     if page in evts_cache:
         return evts_cache[page]
 
     html = occweb.get_url(page)
-    soup = parse_html(html, 'lxml')
-    table = soup.find('table')
+    soup = parse_html(html, "lxml")
+    table = soup.find("table")
     rows = get_table_rows(table)
     evts = []
 
-    mons = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split()
+    mons = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split()
     for i, row_vals in enumerate(rows[:0:-1]):
         try:
-            mm, dd, yy = (int(x) for x in row_vals[0].split('/'))
+            mm, dd, yy = (int(x) for x in row_vals[0].split("/"))
         except ValueError:
             continue
         yyyy = yy + (1900 if yy > 97 else 2000)
-        start = DateTime('{}{}{:02d} at 12:00:00'.format(yyyy, mons[mm - 1], dd))
+        start = DateTime("{}{}{:02d} at 12:00:00".format(yyyy, mons[mm - 1], dd))
         notes = []
         if row_vals[2]:
-            notes.append('CAP {}'.format(row_vals[2]))
+            notes.append("CAP {}".format(row_vals[2]))
         if row_vals[3]:
-            notes.append('FSW PR {}'.format(row_vals[3]))
-        evt = dict(start=start.date[:8],
-                   date='{}-{}-{:02d}'.format(yyyy, mons[mm - 1], dd),
-                   tstart=start.secs + i + 1000,  # add i + 1000 for later sorting
-                   descr=row_vals[1],
-                   note=', '.join(notes),
-                   source='FDB')
+            notes.append("FSW PR {}".format(row_vals[3]))
+        evt = dict(
+            start=start.date[:8],
+            date="{}-{}-{:02d}".format(yyyy, mons[mm - 1], dd),
+            tstart=start.secs + i + 1000,  # add i + 1000 for later sorting
+            descr=row_vals[1],
+            note=", ".join(notes),
+            source="FDB",
+        )
         evts.append(evt)
 
     evts_cache[page] = evts
@@ -103,25 +108,27 @@ def get_fot_major_events():
     which ends up causing words run together.  E.g. Lunar eclipse 2000:302 that
     "Required Solar arrayoffpointing".
     """
-    page = 'fot_major_events'
+    page = "fot_major_events"
     if page in evts_cache:
         return evts_cache[page]
 
     html = occweb.get_url(page)
-    soup = parse_html(html, 'lxml')
-    table = soup.find('table', attrs={'class': 'MsoNormalTable'})
+    soup = parse_html(html, "lxml")
+    table = soup.find("table", attrs={"class": "MsoNormalTable"})
     rows = get_table_rows(table)
     evts = []
 
     for i, row_vals in enumerate(rows[1:]):
         start = DateTime(row_vals[0])
         caldate = start.caldate
-        evt = dict(start=start.date[:8],
-                   date='{}-{}-{}'.format(caldate[:4], caldate[4:7], caldate[7:9]),
-                   tstart=start.secs + i,  # add i for later sorting
-                   descr=row_vals[1],
-                   note=row_vals[2],
-                   source='FOT')
+        evt = dict(
+            start=start.date[:8],
+            date="{}-{}-{}".format(caldate[:4], caldate[4:7], caldate[7:9]),
+            tstart=start.secs + i,  # add i for later sorting
+            descr=row_vals[1],
+            note=row_vals[2],
+            source="FOT",
+        )
         evts.append(evt)
 
     evts_cache[page] = evts

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -2,8 +2,8 @@
 import re
 
 from bs4 import BeautifulSoup as parse_html
-
 from Chandra.Time import DateTime
+
 from .. import occweb
 
 REPLACES = (

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -22,21 +22,22 @@ from astropy.table import Table
 from astropy.utils.data import download_file
 
 # This is for deprecated functionality to cache to a local directory
-CACHE_DIR = 'cache'
+CACHE_DIR = "cache"
 CACHE_TIME = 86000
 TIMEOUT = 60
 
-ROOTURL = 'https://occweb.cfa.harvard.edu'
-URLS = {'fdb_major_events': '/occweb/web/fdb_web/Major_Events.html',
-        'fot_major_events': '/occweb/web/fot_web/eng/reports/Chandra_major_events.htm',
-        'ifot': '/occweb/web/webapps/ifot/ifot.php',
-        }
-LUCKY = 'lucky.cfa.harvard.edu'
+ROOTURL = "https://occweb.cfa.harvard.edu"
+URLS = {
+    "fdb_major_events": "/occweb/web/fdb_web/Major_Events.html",
+    "fot_major_events": "/occweb/web/fot_web/eng/reports/Chandra_major_events.htm",
+    "ifot": "/occweb/web/webapps/ifot/ifot.php",
+}
+LUCKY = "lucky.cfa.harvard.edu"
 
 NOODLE_OCCWEB_MAP = {
-    'FOT': 'occweb/FOT',
-    'GRETA/mission/Backstop': 'Backstop',
-    'vweb': 'occweb/web',
+    "FOT": "occweb/FOT",
+    "GRETA/mission/Backstop": "Backstop",
+    "vweb": "occweb/web",
 }
 
 # Initialize 'kadi.occweb' logger.
@@ -47,21 +48,24 @@ def get_auth(username=None, password=None):
     if username and password:
         return (username, password)
 
-    ska = os.environ.get('SKA')
+    ska = os.environ.get("SKA")
     if ska:
-        user = username or os.environ.get('USER') or os.environ.get('LOGNAME')
-        authfile = Path(ska, 'data', 'aspect_authorization', f'occweb-{user}')
+        user = username or os.environ.get("USER") or os.environ.get("LOGNAME")
+        authfile = Path(ska, "data", "aspect_authorization", f"occweb-{user}")
         config = configobj.ConfigObj(str(authfile))
-        username = config.get('username')
-        password = config.get('password')
+        username = config.get("username")
+        password = config.get("password")
 
     # If $SKA doesn't have occweb credentials try .netrc.
     if username is None:
         try:
             import Ska.ftp
+
             # Do this as a tuple so the operation is atomic
-            username, password = (Ska.ftp.parse_netrc()['occweb']['login'],
-                                  Ska.ftp.parse_netrc()['occweb']['password'])
+            username, password = (
+                Ska.ftp.parse_netrc()["occweb"]["login"],
+                Ska.ftp.parse_netrc()["occweb"]["password"],
+            )
         except Exception:
             pass
 
@@ -79,51 +83,56 @@ def get_url(page, timeout=TIMEOUT):
     """
     url = ROOTURL + URLS[page]
 
-    cachefile = os.path.join(CACHE_DIR, hashlib.sha1(url.encode('utf-8')).hexdigest())
+    cachefile = os.path.join(CACHE_DIR, hashlib.sha1(url.encode("utf-8")).hexdigest())
     now = time.time()
     if os.path.exists(cachefile) and now - os.stat(cachefile).st_mtime < CACHE_TIME:
-        with open(cachefile, 'rb') as f:
-            html = f.read().decode('utf8')
+        with open(cachefile, "rb") as f:
+            html = f.read().decode("utf8")
     else:
         response = requests.get(url, auth=get_auth(), timeout=timeout)
         html = response.text
 
         if os.path.exists(CACHE_DIR):
-            with open(cachefile, 'wb') as f:
-                f.write(html.encode('utf8'))
+            with open(cachefile, "wb") as f:
+                f.write(html.encode("utf8"))
 
     return html
 
 
-def get_ifot(event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT, types={}):
-    start = DateTime('1998:001:12:00:00' if start is None else start)
+def get_ifot(
+    event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT, types={}
+):
+    start = DateTime("1998:001:12:00:00" if start is None else start)
     stop = DateTime(stop)
-    event_props = '.'.join([event_type] + props)
+    event_props = ".".join([event_type] + props)
 
-    params = odict(r='home',
-                   t='qserver',
-                   format='tsv',
-                   tstart=start.date,
-                   tstop=stop.date,
-                   e=event_props,
-                   ul='7',
-                   )
+    params = odict(
+        r="home",
+        t="qserver",
+        format="tsv",
+        tstart=start.date,
+        tstop=stop.date,
+        e=event_props,
+        ul="7",
+    )
     if columns:
-        params['columns'] = ','.join(columns)
+        params["columns"] = ",".join(columns)
 
     # Get the TSV data for the iFOT event table
-    url = ROOTURL + URLS['ifot']
+    url = ROOTURL + URLS["ifot"]
     response = requests.get(url, auth=get_auth(), params=params, timeout=timeout)
 
     # For Py2 convert from unicode to ASCII str
     text = response.text
-    text = re.sub(r'\r\n', ' ', text)
-    lines = [x for x in text.split('\t\n') if x.strip()]
+    text = re.sub(r"\r\n", " ", text)
+    lines = [x for x in text.split("\t\n") if x.strip()]
 
-    converters = {key: [ascii.convert_numpy(getattr(np, type_))]
-                  for key, type_ in types.items()}
-    dat = ascii.read(lines, format='tab', guess=False, converters=converters,
-                     fill_values=None)
+    converters = {
+        key: [ascii.convert_numpy(getattr(np, type_))] for key, type_ in types.items()
+    }
+    dat = ascii.read(
+        lines, format="tab", guess=False, converters=converters, fill_values=None
+    )
     return dat
 
 
@@ -142,7 +151,7 @@ def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
     ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
-    ftp.cd('/home/{}'.format(user))
+    ftp.cd("/home/{}".format(user))
     files = ftp.ls()
 
     if ftp_dirname not in files:
@@ -177,7 +186,7 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
     ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
-    ftp.cd('/home/{}/{}'.format(user, ftp_dirname))
+    ftp.cd("/home/{}/{}".format(user, ftp_dirname))
     for local_file in local_files:
         file_dir, file_base = os.path.split(os.path.abspath(local_file))
         if file_base in ftp.ls():
@@ -191,14 +200,17 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
 def get_auth_http_headers(username, password):
     """Get HTTP header for basic authentication"""
     from base64 import b64encode
-    authorization = ('Basic '
-                     + b64encode(f'{username}:{password}'.encode('utf-8')).decode('utf-8'))
-    headers = {'Authorization': authorization}
+
+    authorization = "Basic " + b64encode(
+        f"{username}:{password}".encode("utf-8")
+    ).decode("utf-8")
+    headers = {"Authorization": authorization}
     return headers
 
 
-def get_occweb_page(path, timeout=30, cache=False, binary=False,
-                    user=None, password=None):
+def get_occweb_page(
+    path, timeout=30, cache=False, binary=False, user=None, password=None
+):
     r"""Get contents of ``path`` on OCCweb.
 
     This returns the contents of the OCCweb page at ``path`` where it assumed
@@ -237,29 +249,35 @@ def get_occweb_page(path, timeout=30, cache=False, binary=False,
         File contents (str if ``binary`` is False, bytes if ``binary`` is True)
     """
     if isinstance(path, str):
-        path = path.replace('\\', '/')
-        if path.startswith('//noodle/'):
+        path = path.replace("\\", "/")
+        if path.startswith("//noodle/"):
             for noodle_prefix, occweb_prefix in NOODLE_OCCWEB_MAP.items():
-                if path.startswith(noodle := '//noodle/' + noodle_prefix):
-                    path = path.replace(noodle, ROOTURL + '/' + occweb_prefix)
+                if path.startswith(noodle := "//noodle/" + noodle_prefix):
+                    path = path.replace(noodle, ROOTURL + "/" + occweb_prefix)
                     break
             else:
-                raise ValueError(f'unrecognized noodle path: {path}')
+                raise ValueError(f"unrecognized noodle path: {path}")
 
-    if isinstance(path, str) and path.startswith('https://occweb'):
+    if isinstance(path, str) and path.startswith("https://occweb"):
         url = path
     else:
-        url = ROOTURL + (Path('/occweb') / path).as_posix()
+        url = ROOTURL + (Path("/occweb") / path).as_posix()
 
-    logger.info(f'Getting OCCweb {path} with {cache=}')
+    logger.info(f"Getting OCCweb {path} with {cache=}")
     if cache:
         from urllib.request import HTTPError
+
         user, password = get_auth(user, password)
         headers = get_auth_http_headers(user, password)
         try:
-            cachefile = download_file(url, cache=cache, show_progress=False,
-                                      http_headers=headers, timeout=timeout,
-                                      pkgname='kadi')
+            cachefile = download_file(
+                url,
+                cache=cache,
+                show_progress=False,
+                http_headers=headers,
+                timeout=timeout,
+                pkgname="kadi",
+            )
         except HTTPError as err:
             # Re-raise so caller can handle it with one exception class
             raise requests.exceptions.HTTPError(str(err))
@@ -302,7 +320,7 @@ def get_occweb_dir(path, timeout=30, cache=False, user=None, password=None):
         Table of directory entries
     """
     html = get_occweb_page(path, timeout=timeout, cache=cache)
-    out = Table.read(html, format='ascii.html', guess=False)
-    del out['col0']
-    del out['Description']
+    out = Table.read(html, format="ascii.html", guess=False)
+    del out["col0"]
+    del out["Description"]
     return out

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -4,22 +4,21 @@ Provide an interface for getting pages from the OCCweb.  For good measure leave
 this off of github.
 """
 
-import re
-import os
-import configobj
 import hashlib
+import logging
+import os
+import re
 import time
 from collections import OrderedDict as odict
 from pathlib import Path
-import logging
 
+import configobj
 import numpy as np
 import requests
-
-from Chandra.Time import DateTime
 from astropy.io import ascii
 from astropy.table import Table
 from astropy.utils.data import download_file
+from Chandra.Time import DateTime
 
 # This is for deprecated functionality to cache to a local directory
 CACHE_DIR = "cache"
@@ -144,9 +143,10 @@ def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
     The directory paths of ``local_files`` are stripped off so they all wind up
     in a flat structure within ``ftp_dirname``.
     """
+    import uuid
+
     import Ska.File
     import Ska.ftp
-    import uuid
 
     ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
@@ -180,8 +180,8 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
     are copied to the corresponding local_files names.  This is the converse
     of ftp_put_to_lucky and thus requires unique basenames for all files.
     """
-    import Ska.ftp
     import Ska.File
+    import Ska.ftp
 
     ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:

--- a/kadi/paths.py
+++ b/kadi/paths.py
@@ -5,29 +5,29 @@ from pathlib import Path
 
 def _version_str(version):
     """Legacy version string"""
-    return '' if version in (None, 1, '1') else str(version)
+    return "" if version in (None, 1, "1") else str(version)
 
 
 def SKA_DATA():
-    return Path(os.environ.get('SKA', '/proj/sot/ska'), 'data/kadi')
+    return Path(os.environ.get("SKA", "/proj/sot/ska"), "data/kadi")
 
 
 def DATA_DIR():
-    return Path(os.environ.get('KADI', SKA_DATA())).absolute()
+    return Path(os.environ.get("KADI", SKA_DATA())).absolute()
 
 
 def EVENTS_DB_PATH():
-    return DATA_DIR() / 'events3.db3'
+    return DATA_DIR() / "events3.db3"
 
 
 def IDX_CMDS_PATH(version=None):
     version = _version_str(version)
-    return DATA_DIR() / f'cmds{version}.h5'
+    return DATA_DIR() / f"cmds{version}.h5"
 
 
 def PARS_DICT_PATH(version=None):
     version = _version_str(version)
-    return DATA_DIR() / f'cmds{version}.pkl'
+    return DATA_DIR() / f"cmds{version}.pkl"
 
 
 def CMDS_DIR(scenario=None):
@@ -35,7 +35,7 @@ def CMDS_DIR(scenario=None):
 
     # Special case for "flight" scenario. This is hardwired to $SKA/data/kadi
     # and is intended for use in load review tools run on HEAD.
-    if scenario == 'flight':
+    if scenario == "flight":
         cmds_dir = SKA_DATA()
     else:
         cmds_dir = Path(conf.commands_dir).expanduser()
@@ -44,32 +44,33 @@ def CMDS_DIR(scenario=None):
 
 
 def LOADS_ARCHIVE_DIR():
-    out = CMDS_DIR() / 'loads'
+    out = CMDS_DIR() / "loads"
     return out
 
 
 def LOADS_BACKSTOP_PATH(load_name):
-    out = LOADS_ARCHIVE_DIR() / f'{load_name}.pkl.gz'
+    out = LOADS_ARCHIVE_DIR() / f"{load_name}.pkl.gz"
     return out
 
 
 def SCENARIO_DIR(scenario=None):
     scenario_dir = CMDS_DIR(scenario)
     if scenario is None:
-        scenario = os.environ.get('KADI_SCENARIO')
+        scenario = os.environ.get("KADI_SCENARIO")
     if scenario:
         scenario_dir = scenario_dir / scenario
     return scenario_dir
 
 
 def LOADS_TABLE_PATH(scenario=None):
-    return SCENARIO_DIR(scenario) / 'loads.csv'
+    return SCENARIO_DIR(scenario) / "loads.csv"
 
 
 def CMD_EVENTS_PATH(scenario=None):
-    return SCENARIO_DIR(scenario) / 'cmd_events.csv'
+    return SCENARIO_DIR(scenario) / "cmd_events.csv"
 
 
 def STARCATS_CACHE_PATH():
     from kadi.commands import conf
-    return Path(conf.commands_dir).expanduser() / 'starcats'
+
+    return Path(conf.commands_dir).expanduser() / "starcats"

--- a/kadi/scripts/update_cmds_v1.py
+++ b/kadi/scripts/update_cmds_v1.py
@@ -18,18 +18,20 @@ from ska_helpers.retry import retry_call
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 from kadi import __version__
 
-MPLOGS_DIR = Path(os.environ['SKA'], 'data', 'mpcrit1', 'mplogs')
+MPLOGS_DIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs")
 
 MIN_MATCHING_BLOCK_SIZE = 500
 BACKSTOP_CACHE = {}
-CMDS_DTYPE = [('idx', np.int32),
-              ('date', '|S21'),
-              ('type', '|S12'),
-              ('tlmsid', '|S10'),
-              ('scs', np.uint8),
-              ('step', np.uint16),
-              ('timeline_id', np.uint32),
-              ('vcdu', np.int32)]
+CMDS_DTYPE = [
+    ("idx", np.int32),
+    ("date", "|S21"),
+    ("type", "|S12"),
+    ("tlmsid", "|S10"),
+    ("scs", np.uint8),
+    ("step", np.uint16),
+    ("timeline_id", np.uint32),
+    ("vcdu", np.int32),
+]
 
 logger = None  # This is set as a global in main.  Define here for pyflakes.
 
@@ -38,6 +40,7 @@ class UpdatedDict(dict):
     """
     Dict with an ``n_updated`` attribute that gets incremented when any key value is set.
     """
+
     n_updated = 0
 
     def __setitem__(self, *args, **kwargs):
@@ -49,23 +52,28 @@ def get_opt(args=None):
     """
     Get options for command line interface to update_cmd_states.
     """
-    parser = argparse.ArgumentParser(description='Update HDF5 cmds table')
-    parser.add_argument("--mp-dir",
-                        help=("MP load directory (default=/data/mpcrit1/mplogs) "
-                              "or $SKA/data/mpcrit1/mplogs)"))
-    parser.add_argument("--start",
-                        help="Start date for update (default=stop-42 days)")
-    parser.add_argument("--stop",
-                        help="Stop date for update (default=Now+21 days)")
-    parser.add_argument("--log-level",
-                        type=int,
-                        default=10,
-                        help='Log level (10=debug, 20=info, 30=warnings)')
-    parser.add_argument("--data-root",
-                        default='.',
-                        help="Data root (default='.')")
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s {version}'.format(version=__version__))
+    parser = argparse.ArgumentParser(description="Update HDF5 cmds table")
+    parser.add_argument(
+        "--mp-dir",
+        help=(
+            "MP load directory (default=/data/mpcrit1/mplogs) "
+            "or $SKA/data/mpcrit1/mplogs)"
+        ),
+    )
+    parser.add_argument("--start", help="Start date for update (default=stop-42 days)")
+    parser.add_argument("--stop", help="Stop date for update (default=Now+21 days)")
+    parser.add_argument(
+        "--log-level",
+        type=int,
+        default=10,
+        help="Log level (10=debug, 20=info, 30=warnings)",
+    )
+    parser.add_argument("--data-root", default=".", help="Data root (default='.')")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s {version}".format(version=__version__),
+    )
 
     args = parser.parse_args(args)
     return args
@@ -90,22 +98,22 @@ def fix_nonload_cmds(nl_cmds):
     new_cmds = []
     for cmd in nl_cmds:
         new_cmd = {}
-        new_cmd['date'] = str(cmd['date'])
-        new_cmd['type'] = str(cmd['cmd'])
-        new_cmd['tlmsid'] = str(cmd['tlmsid'])
-        for key in ('scs', 'step', 'timeline_id'):
+        new_cmd["date"] = str(cmd["date"])
+        new_cmd["type"] = str(cmd["cmd"])
+        new_cmd["tlmsid"] = str(cmd["tlmsid"])
+        for key in ("scs", "step", "timeline_id"):
             new_cmd[key] = 0
-        new_cmd['vcdu'] = -1
+        new_cmd["vcdu"] = -1
 
-        new_cmd['params'] = {}
-        new_cmd['params']['nonload_id'] = int(cmd['id'])
-        if cmd['msid'] is not None:
-            new_cmd['params']['msid'] = str(cmd['msid'])
+        new_cmd["params"] = {}
+        new_cmd["params"]["nonload_id"] = int(cmd["id"])
+        if cmd["msid"] is not None:
+            new_cmd["params"]["msid"] = str(cmd["msid"])
 
         # De-numpy (otherwise unpickling on PY3 has problems).
-        if 'params' in cmd:
-            params = new_cmd['params']
-            for key, val in cmd['params'].items():
+        if "params" in cmd:
+            params = new_cmd["params"]
+            for key, val in cmd["params"].items():
                 key = str(key)
                 try:
                     val = val.item()
@@ -131,22 +139,22 @@ def _tl_to_bs_cmds(tl_cmds, tl_id, db):
 
     :returns: list of command dicts
     """
-    bs_cmds = [dict((col, row[col]) for col in tl_cmds.dtype.names)
-               for row in tl_cmds]
-    cmd_index = dict((x['id'], x) for x in bs_cmds)
+    bs_cmds = [dict((col, row[col]) for col in tl_cmds.dtype.names) for row in tl_cmds]
+    cmd_index = dict((x["id"], x) for x in bs_cmds)
 
     # Add 'params' dict of command parameter key=val pairs to each tl_cmd
-    for par_table in ('cmd_intpars', 'cmd_fltpars'):
-        tl_params = db.fetchall("SELECT * FROM %s WHERE timeline_id %s" %
-                                (par_table,
-                                 '= %d' % tl_id if tl_id else 'IS NULL'))
+    for par_table in ("cmd_intpars", "cmd_fltpars"):
+        tl_params = db.fetchall(
+            "SELECT * FROM %s WHERE timeline_id %s"
+            % (par_table, "= %d" % tl_id if tl_id else "IS NULL")
+        )
 
         # Build up the params dict for each command in timeline load segment
         for par in tl_params:
             # I.e. cmd_index[par.cmd_id]['params'][par.name] = par.value
             # but create the ['params'] dict as needed.
             if par.cmd_id in cmd_index:
-                cmd_index[par.cmd_id].setdefault('params', {})[par.name] = par.value
+                cmd_index[par.cmd_id].setdefault("params", {})[par.name] = par.value
 
     return bs_cmds
 
@@ -162,42 +170,52 @@ def get_cmds(start, stop, mp_dir=MPLOGS_DIR):
 
     # Get timeline_loads within date range.  Also get non-load commands
     # within the date range covered by the timelines.
-    server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-    with Ska.DBI.DBI(dbi='sqlite', server=server) as db:
-        timeline_loads = db.fetchall("""SELECT * from timeline_loads
+    server = os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3")
+    with Ska.DBI.DBI(dbi="sqlite", server=server) as db:
+        timeline_loads = db.fetchall(
+            """SELECT * from timeline_loads
                                         WHERE datestop > '{}' AND datestart < '{}'
-                                        ORDER BY id"""
-                                     .format(start.date, stop.date))
+                                        ORDER BY id""".format(
+                start.date, stop.date
+            )
+        )
 
         # Get non-load commands (from autonomous or ground SCS107, NSM, etc) in the
         # time range that the timelines span.
-        tl_datestart = min(timeline_loads['datestart'])
-        nl_cmds = db.fetchall('SELECT * from cmds where timeline_id IS NULL and '
-                              'date >= "{}" and date <= "{}"'
-                              .format(tl_datestart, stop.date))
+        tl_datestart = min(timeline_loads["datestart"])
+        nl_cmds = db.fetchall(
+            "SELECT * from cmds where timeline_id IS NULL and "
+            'date >= "{}" and date <= "{}"'.format(tl_datestart, stop.date)
+        )
 
         # Private method from cmd_states.py fetches the actual int/float param values
         # and returns list of dict.
         nl_cmds = _tl_to_bs_cmds(nl_cmds, None, db)
         nl_cmds = fix_nonload_cmds(nl_cmds)
-        logger.info(f'Found {len(nl_cmds)} non-load commands between {tl_datestart} : {stop.date}')
+        logger.info(
+            f"Found {len(nl_cmds)} non-load commands between {tl_datestart} : {stop.date}"
+        )
 
-    logger.info('Found {} timelines included within {} to {}'
-                .format(len(timeline_loads), start.date, stop.date))
+    logger.info(
+        "Found {} timelines included within {} to {}".format(
+            len(timeline_loads), start.date, stop.date
+        )
+    )
 
-    if np.min(np.diff(timeline_loads['id'])) < 1:
-        raise ValueError('Timeline loads id not monotonically increasing')
+    if np.min(np.diff(timeline_loads["id"])) < 1:
+        raise ValueError("Timeline loads id not monotonically increasing")
 
     cmds = []
     orbit_cmds = []
     orbit_cmd_files = set()
 
     for tl in timeline_loads:
-        bs_file = Ska.File.get_globfiles(os.path.join(mp_dir + tl.mp_dir,
-                                                      '*.backstop'))[0]
+        bs_file = Ska.File.get_globfiles(
+            os.path.join(mp_dir + tl.mp_dir, "*.backstop")
+        )[0]
         if bs_file not in BACKSTOP_CACHE:
             bs_cmds = read_backstop(bs_file)
-            logger.info('Read {} commands from {}'.format(len(bs_cmds), bs_file))
+            logger.info("Read {} commands from {}".format(len(bs_cmds), bs_file))
             BACKSTOP_CACHE[bs_file] = bs_cmds
         else:
             bs_cmds = BACKSTOP_CACHE[bs_file]
@@ -207,38 +225,45 @@ def get_cmds(start, stop, mp_dir=MPLOGS_DIR):
         # or shutdown we still want these ORBPOINT to be in the cmds archive
         # and not be excluded by timeline intervals.
         if bs_file not in orbit_cmd_files:
-            bs_orbit_cmds = [x for x in bs_cmds if x['type'] == 'ORBPOINT']
+            bs_orbit_cmds = [x for x in bs_cmds if x["type"] == "ORBPOINT"]
             for orbit_cmd in bs_orbit_cmds:
-                orbit_cmd['timeline_id'] = tl['id']
-                if 'EVENT_TYPE' not in orbit_cmd['params']:
-                    orbit_cmd['params']['EVENT_TYPE'] = orbit_cmd['params']['TYPE']
-                    del orbit_cmd['params']['TYPE']
+                orbit_cmd["timeline_id"] = tl["id"]
+                if "EVENT_TYPE" not in orbit_cmd["params"]:
+                    orbit_cmd["params"]["EVENT_TYPE"] = orbit_cmd["params"]["TYPE"]
+                    del orbit_cmd["params"]["TYPE"]
             orbit_cmds.extend(bs_orbit_cmds)
             orbit_cmd_files.add(bs_file)
 
         # Only store commands for this timeline (match SCS and date)
-        bs_cmds = [x for x in bs_cmds
-                   if tl['datestart'] <= x['date'] <= tl['datestop']
-                   and x['scs'] == tl['scs']]
+        bs_cmds = [
+            x
+            for x in bs_cmds
+            if tl["datestart"] <= x["date"] <= tl["datestop"] and x["scs"] == tl["scs"]
+        ]
 
         for bs_cmd in bs_cmds:
-            bs_cmd['timeline_id'] = tl['id']
+            bs_cmd["timeline_id"] = tl["id"]
 
-        logger.info('  Got {} backstop commands for timeline_id={} and SCS={}'
-                    .format(len(bs_cmds), tl['id'], tl['scs']))
+        logger.info(
+            "  Got {} backstop commands for timeline_id={} and SCS={}".format(
+                len(bs_cmds), tl["id"], tl["scs"]
+            )
+        )
         cmds.extend(bs_cmds)
 
     orbit_cmds = get_unique_orbit_cmds(orbit_cmds)
-    logger.debug('Read total of {} orbit commands'
-                 .format(len(orbit_cmds)))
+    logger.debug("Read total of {} orbit commands".format(len(orbit_cmds)))
 
     cmds.extend(nl_cmds)
     cmds.extend(orbit_cmds)
 
     # Sort by date and SCS step number.
-    cmds = sorted(cmds, key=lambda y: (y['date'], y['step']))
-    logger.debug('Read total of {} commands ({} non-load commands)'
-                 .format(len(cmds), len(nl_cmds)))
+    cmds = sorted(cmds, key=lambda y: (y["date"], y["step"]))
+    logger.debug(
+        "Read total of {} commands ({} non-load commands)".format(
+            len(cmds), len(nl_cmds)
+        )
+    )
 
     return cmds
 
@@ -254,24 +279,26 @@ def get_unique_orbit_cmds(orbit_cmds):
         return []
 
     # Sort by (event_type, date)
-    orbit_cmds.sort(key=lambda y: (y['params']['EVENT_TYPE'], y['date']))
+    orbit_cmds.sort(key=lambda y: (y["params"]["EVENT_TYPE"], y["date"]))
 
     uniq_cmds = [orbit_cmds[0]]
     # Step through one at a time and add to uniq_cmds only if the candidate is
     # "different" from uniq_cmds[-1].
     for cmd in orbit_cmds:
         last_cmd = uniq_cmds[-1]
-        if (cmd['params']['EVENT_TYPE'] == last_cmd['params']['EVENT_TYPE']
-                and abs(DateTime(cmd['date']).secs - DateTime(last_cmd['date']).secs) < 180):
+        if (
+            cmd["params"]["EVENT_TYPE"] == last_cmd["params"]["EVENT_TYPE"]
+            and abs(DateTime(cmd["date"]).secs - DateTime(last_cmd["date"]).secs) < 180
+        ):
             # Same event as last (even if date is a bit different).  Now if this one
             # has a larger timeline_id that means it is from a more recent schedule, so
             # use that one.
-            if cmd['timeline_id'] > last_cmd['timeline_id']:
+            if cmd["timeline_id"] > last_cmd["timeline_id"]:
                 uniq_cmds[-1] = cmd
         else:
             uniq_cmds.append(cmd)
 
-    uniq_cmds.sort(key=lambda y: y['date'])
+    uniq_cmds.sort(key=lambda y: y["date"])
 
     return uniq_cmds
 
@@ -289,12 +316,12 @@ def get_idx_cmds(cmds, pars_dict):
 
     for i, cmd in enumerate(cmds):
         if i % 10000 == 9999:
-            logger.info('   Iteration {}'.format(i))
+            logger.info("   Iteration {}".format(i))
 
         # Define a consistently ordered tuple that has all command parameter information
-        pars = cmd['params']
-        keys = set(pars.keys()) - set(('SCS', 'STEP', 'TLMSID'))
-        if cmd['tlmsid'] == 'AOSTRCAT':
+        pars = cmd["params"]
+        keys = set(pars.keys()) - set(("SCS", "STEP", "TLMSID"))
+        if cmd["tlmsid"] == "AOSTRCAT":
             # Skip star catalog command because that has many (uninteresting) parameters
             # and increases the file size and load speed by an order of magnitude.
             pars_tup = ()
@@ -312,8 +339,18 @@ def get_idx_cmds(cmds, pars_dict):
             par_idx = len(pars_dict) + 65536
             pars_dict[pars_tup] = par_idx
 
-        idx_cmds.append((par_idx, cmd['date'], cmd['type'], cmd.get('tlmsid'),
-                         cmd['scs'], cmd['step'], cmd['timeline_id'], cmd['vcdu']))
+        idx_cmds.append(
+            (
+                par_idx,
+                cmd["date"],
+                cmd["type"],
+                cmd.get("tlmsid"),
+                cmd["scs"],
+                cmd["step"],
+                cmd["timeline_id"],
+                cmd["vcdu"],
+            )
+        )
 
     return idx_cmds
 
@@ -325,8 +362,9 @@ def add_h5_cmds(h5file, idx_cmds):
     """
     # Note: reading this file uncompressed is about 5 times faster, so sacrifice file size
     # for read speed and do not use compression.
-    h5 = retry_call(tables.open_file, [h5file], {'mode': 'a'},
-                    tries=4, delay=1, backoff=4)
+    h5 = retry_call(
+        tables.open_file, [h5file], {"mode": "a"}, tries=4, delay=1, backoff=4
+    )
 
     # Convert cmds (list of tuples) to numpy structured array.  This also works for an
     # existing structured array.
@@ -336,43 +374,49 @@ def add_h5_cmds(h5file, idx_cmds):
 
     try:
         h5d = h5.root.data
-        logger.info('Opened h5 cmds table {}'.format(h5file))
+        logger.info("Opened h5 cmds table {}".format(h5file))
     except tables.NoSuchNodeError:
-        h5.create_table(h5.root, 'data', cmds, "cmds", expectedrows=2e6)
-        logger.info('Created h5 cmds table {}'.format(h5file))
+        h5.create_table(h5.root, "data", cmds, "cmds", expectedrows=2e6)
+        logger.info("Created h5 cmds table {}".format(h5file))
     else:
         date0 = min(idx_cmd[1] for idx_cmd in idx_cmds)
         h5_date = h5d.cols.date[:]
         idx_recent = np.searchsorted(h5_date, date0)
-        logger.info('Selecting commands from h5d[{}:]'.format(idx_recent))
-        logger.info('  {}'.format(str(h5d[idx_recent])))
+        logger.info("Selecting commands from h5d[{}:]".format(idx_recent))
+        logger.info("  {}".format(str(h5d[idx_recent])))
         h5d_recent = h5d[idx_recent:]  # recent h5d entries
 
         # Define the column names that specify a complete and unique row
-        key_names = ('date', 'type', 'tlmsid', 'scs', 'step', 'timeline_id', 'vcdu')
+        key_names = ("date", "type", "tlmsid", "scs", "step", "timeline_id", "vcdu")
 
-        h5d_recent_vals = [tuple(
-            row[x].decode('ascii') if isinstance(row[x], bytes) else str(row[x])
-            for x in key_names)
-            for row in h5d_recent]
+        h5d_recent_vals = [
+            tuple(
+                row[x].decode("ascii") if isinstance(row[x], bytes) else str(row[x])
+                for x in key_names
+            )
+            for row in h5d_recent
+        ]
         idx_cmds_vals = [tuple(str(x) for x in row[1:]) for row in idx_cmds]
 
-        diff = difflib.SequenceMatcher(a=h5d_recent_vals, b=idx_cmds_vals, autojunk=False)
+        diff = difflib.SequenceMatcher(
+            a=h5d_recent_vals, b=idx_cmds_vals, autojunk=False
+        )
         blocks = diff.get_matching_blocks()
-        logger.info('Matching blocks for existing HDF5 and timeline commands')
+        logger.info("Matching blocks for existing HDF5 and timeline commands")
         for block in blocks:
-            logger.info('  {}'.format(block))
+            logger.info("  {}".format(block))
         opcodes = diff.get_opcodes()
-        logger.info('Diffs between existing HDF5 and timeline commands')
+        logger.info("Diffs between existing HDF5 and timeline commands")
         for opcode in opcodes:
-            logger.info('  {}'.format(opcode))
+            logger.info("  {}".format(opcode))
         # Find the first matching block that is sufficiently long
         for block in blocks:
             if block.size > MIN_MATCHING_BLOCK_SIZE:
                 break
         else:
-            raise ValueError('No matching blocks at least {} long'
-                             .format(MIN_MATCHING_BLOCK_SIZE))
+            raise ValueError(
+                "No matching blocks at least {} long".format(MIN_MATCHING_BLOCK_SIZE)
+            )
 
         # Index into idx_cmds at the end of the large matching block.  block.b is the
         # beginning of the match.
@@ -383,18 +427,23 @@ def add_h5_cmds(h5file, idx_cmds):
             h5d_idx = block.a + block.size + idx_recent
 
             if h5d_idx < len(h5d):
-                logger.debug('Deleted relative cmds indexes {} .. {}'.format(h5d_idx - idx_recent,
-                                                                             len(h5d) - idx_recent))
-                logger.debug('Deleted cmds indexes {} .. {}'.format(h5d_idx, len(h5d)))
+                logger.debug(
+                    "Deleted relative cmds indexes {} .. {}".format(
+                        h5d_idx - idx_recent, len(h5d) - idx_recent
+                    )
+                )
+                logger.debug("Deleted cmds indexes {} .. {}".format(h5d_idx, len(h5d)))
                 h5d.truncate(h5d_idx)
 
             h5d.append(cmds[idx_cmds_idx:])
-            logger.info('Added {} commands to HDF5 cmds table'.format(len(cmds[idx_cmds_idx:])))
+            logger.info(
+                "Added {} commands to HDF5 cmds table".format(len(cmds[idx_cmds_idx:]))
+            )
         else:
-            logger.info('No new timeline commands, HDF5 cmds table not updated')
+            logger.info("No new timeline commands, HDF5 cmds table not updated")
 
     h5.flush()
-    logger.info('Upated HDF5 cmds table {}'.format(h5file))
+    logger.info("Upated HDF5 cmds table {}".format(h5file))
     h5.close()
 
 
@@ -403,36 +452,44 @@ def main(args=None):
 
     opt = get_opt(args)
 
-    logger = pyyaks.logger.get_logger(name='kadi_update_cmds', level=opt.log_level,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name="kadi_update_cmds", level=opt.log_level, format="%(asctime)s %(message)s"
+    )
 
     log_run_info(logger.info, opt)
 
     # Set the global root data directory.  This gets used in ..paths to
     # construct file names.  The use of an env var is needed to allow
     # configurability of the root data directory within django.
-    os.environ['KADI'] = os.path.abspath(opt.data_root)
+    os.environ["KADI"] = os.path.abspath(opt.data_root)
     idx_cmds_path = IDX_CMDS_PATH()
     pars_dict_path = PARS_DICT_PATH()
 
     try:
-        with open(pars_dict_path, 'rb') as fh:
+        with open(pars_dict_path, "rb") as fh:
             pars_dict = pickle.load(fh)
-        logger.info('Read {} pars_dict values from {}'.format(len(pars_dict), pars_dict_path))
+        logger.info(
+            "Read {} pars_dict values from {}".format(len(pars_dict), pars_dict_path)
+        )
     except IOError:
-        logger.info('No pars_dict file {} found, starting from empty dict'
-                    .format(pars_dict_path))
+        logger.info(
+            "No pars_dict file {} found, starting from empty dict".format(
+                pars_dict_path
+            )
+        )
         pars_dict = {}
 
     if not opt.mp_dir:
-        for prefix in ('/', os.environ['SKA']):
-            pth = Path(prefix, 'data', 'mpcrit1', 'mplogs')
+        for prefix in ("/", os.environ["SKA"]):
+            pth = Path(prefix, "data", "mpcrit1", "mplogs")
             if pth.exists():
                 opt.mp_dir = str(pth)
                 break
         else:
-            raise FileNotFoundError('no mission planning directories found (need --mp-dir)')
-    logger.info(f'Using mission planning files at {opt.mp_dir}')
+            raise FileNotFoundError(
+                "no mission planning directories found (need --mp-dir)"
+            )
+    logger.info(f"Using mission planning files at {opt.mp_dir}")
 
     # Recast as dict subclass that remembers if any element was updated
     pars_dict = UpdatedDict(pars_dict)
@@ -445,15 +502,18 @@ def main(args=None):
     add_h5_cmds(idx_cmds_path, idx_cmds)
 
     if pars_dict.n_updated > 0:
-        with open(pars_dict_path, 'wb') as fh:
+        with open(pars_dict_path, "wb") as fh:
             # Dump as pickle, first converting pars_dict from UpdatedDict to
             # plain dict. The n_updated attribute is not used outside of
             # update_cmds.py. See historical note in NOTES.build for context.
             pickle.dump(dict(pars_dict), fh, protocol=2)
-            logger.info('Wrote {} pars_dict values ({} new) to {}'
-                        .format(len(pars_dict), pars_dict.n_updated, pars_dict_path))
+            logger.info(
+                "Wrote {} pars_dict values ({} new) to {}".format(
+                    len(pars_dict), pars_dict.n_updated, pars_dict_path
+                )
+            )
     else:
-        logger.info('pars_dict was unmodified, not writing')
+        logger.info("pars_dict was unmodified, not writing")
 
 
 def _coerce_type(val):
@@ -481,10 +541,10 @@ def parse_params(paramstr):
     :rtype: dict of key=val pairs
     """
     params = {}
-    for opt in paramstr.split(','):
+    for opt in paramstr.split(","):
         try:
-            key, val = opt.split('=')
-            params[key] = val if key == 'HEX' else _coerce_type(val)
+            key, val = opt.split("=")
+            params[key] = val if key == "HEX" else _coerce_type(val)
         except Exception:
             pass  # backstop has some quirks like blank or '??????' fields
 
@@ -504,20 +564,25 @@ def read_backstop(filename):
     """
     bs = []
     for bs_line in open(filename):
-        bs_line = bs_line.replace(' ', '')
-        date, vcdu, cmd_type, paramstr = [x for x in bs_line.split('|')]
-        vcdu = int(vcdu[:-1])  # Get rid of final '0' from '8023268 0' (where space was stripped)
+        bs_line = bs_line.replace(" ", "")
+        date, vcdu, cmd_type, paramstr = [x for x in bs_line.split("|")]
+        vcdu = int(
+            vcdu[:-1]
+        )  # Get rid of final '0' from '8023268 0' (where space was stripped)
         params = parse_params(paramstr)
-        bs.append({'date': date,
-                   'type': cmd_type,
-                   'params': params,
-                   'tlmsid': params.get('TLMSID'),
-                   'scs': params.get('SCS'),
-                   'step': params.get('STEP'),
-                   'vcdu': vcdu
-                   })
+        bs.append(
+            {
+                "date": date,
+                "type": cmd_type,
+                "params": params,
+                "tlmsid": params.get("TLMSID"),
+                "scs": params.get("SCS"),
+                "step": params.get("STEP"),
+                "vcdu": vcdu,
+            }
+        )
     return bs
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/kadi/scripts/update_cmds_v1.py
+++ b/kadi/scripts/update_cmds_v1.py
@@ -1,22 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 import argparse
 import difflib
+import os
 import pickle
 from pathlib import Path
 
 import numpy as np
-import tables
-
 import pyyaks.logger
 import Ska.DBI
 import Ska.File
+import tables
 from Chandra.Time import DateTime
-from ska_helpers.run_info import log_run_info
 from ska_helpers.retry import retry_call
+from ska_helpers.run_info import log_run_info
 
-from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 from kadi import __version__
+from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 
 MPLOGS_DIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs")
 

--- a/kadi/scripts/update_cmds_v2.py
+++ b/kadi/scripts/update_cmds_v2.py
@@ -11,23 +11,25 @@ def get_opt(args=None):
     """
     Get options for command line interface to update_
     """
-    parser = argparse.ArgumentParser(description='Update HDF5 cmds v2 table')
-    parser.add_argument("--lookback",
-                        type=int,
-                        help="Lookback (default=30 days)")
-    parser.add_argument("--stop",
-                        help="Stop date for update (default=Now+21 days)")
-    parser.add_argument("--log-level",
-                        type=int,
-                        default=10,
-                        help='Log level (10=debug, 20=info, 30=warnings)')
-    parser.add_argument("--scenario",
-                        help="Scenario for loads and command events outputs (default=None)")
-    parser.add_argument("--data-root",
-                        default='.',
-                        help="Data root (default='.')")
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s {version}'.format(version=__version__))
+    parser = argparse.ArgumentParser(description="Update HDF5 cmds v2 table")
+    parser.add_argument("--lookback", type=int, help="Lookback (default=30 days)")
+    parser.add_argument("--stop", help="Stop date for update (default=Now+21 days)")
+    parser.add_argument(
+        "--log-level",
+        type=int,
+        default=10,
+        help="Log level (10=debug, 20=info, 30=warnings)",
+    )
+    parser.add_argument(
+        "--scenario",
+        help="Scenario for loads and command events outputs (default=None)",
+    )
+    parser.add_argument("--data-root", default=".", help="Data root (default='.')")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s {version}".format(version=__version__),
+    )
 
     args = parser.parse_args(args)
     return args
@@ -40,12 +42,14 @@ def main(args=None):
     opt = get_opt(args)
     log_run_info(log_func=print, opt=opt)
 
-    update_cmds_archive(lookback=opt.lookback,
-                        stop=opt.stop,
-                        log_level=opt.log_level,
-                        scenario=opt.scenario,
-                        data_root=opt.data_root)
+    update_cmds_archive(
+        lookback=opt.lookback,
+        stop=opt.stop,
+        log_level=opt.log_level,
+        scenario=opt.scenario,
+        data_root=opt.data_root,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/kadi/scripts/update_events.py
+++ b/kadi/scripts/update_events.py
@@ -1,16 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Update the events database"""
 
+import argparse
 import os
 import re
-import argparse
 import time
 
 import numpy as np
-
 import pyyaks.logger
 from Chandra.Time import DateTime
 from ska_helpers.run_info import log_run_info
+
 from kadi import __version__  # noqa
 
 logger = None  # for pyflakes
@@ -115,6 +115,7 @@ def delete_from_date(EventModel, start, set_update_date=True):
 def update(EventModel, date_stop):
     import django.db
     from django.core.exceptions import ObjectDoesNotExist
+
     from kadi.events import models
 
     date_stop = DateTime(date_stop)

--- a/kadi/scripts/update_events.py
+++ b/kadi/scripts/update_events.py
@@ -17,32 +17,40 @@ logger = None  # for pyflakes
 
 
 def get_opt(args=None):
-    parser = argparse.ArgumentParser(description='Update the events database')
-    parser.add_argument("--stop",
-                        default=DateTime().date,
-                        help="Processing stop date (default=NOW)")
-    parser.add_argument("--start",
-                        default=None,
-                        help=("Processing start date (loops by --loop-days "
-                              "until --stop date if set)"))
-    parser.add_argument("--delete-from-start",
-                        action='store_true',
-                        help=("Delete events after --start and reset update time to --start"))
-    parser.add_argument("--loop-days",
-                        default=100,
-                        type=int,
-                        help=("Number of days in interval for looping (default=100)"))
-    parser.add_argument("--log-level",
-                        type=int,
-                        default=pyyaks.logger.INFO,
-                        help=("Logging level"))
-    parser.add_argument("--model",
-                        action='append',
-                        dest='models',
-                        help="Model class name to process [match regex] (default = all)")
-    parser.add_argument("--data-root",
-                        default=".",
-                        help="Root data directory (default='.')")
+    parser = argparse.ArgumentParser(description="Update the events database")
+    parser.add_argument(
+        "--stop", default=DateTime().date, help="Processing stop date (default=NOW)"
+    )
+    parser.add_argument(
+        "--start",
+        default=None,
+        help=(
+            "Processing start date (loops by --loop-days " "until --stop date if set)"
+        ),
+    )
+    parser.add_argument(
+        "--delete-from-start",
+        action="store_true",
+        help=("Delete events after --start and reset update time to --start"),
+    )
+    parser.add_argument(
+        "--loop-days",
+        default=100,
+        type=int,
+        help=("Number of days in interval for looping (default=100)"),
+    )
+    parser.add_argument(
+        "--log-level", type=int, default=pyyaks.logger.INFO, help=("Logging level")
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        dest="models",
+        help="Model class name to process [match regex] (default = all)",
+    )
+    parser.add_argument(
+        "--data-root", default=".", help="Root data directory (default='.')"
+    )
 
     args = parser.parse_args(args)
     return args
@@ -66,9 +74,11 @@ def try4times(func, *arg, **kwarg):
         try:
             func(*arg, **kwarg)
         except OperationalError as err:
-            if 'database is locked' in str(err):
+            if "database is locked" in str(err):
                 # Locked DB, issue informational warning
-                logger.info('Warning: locked database, waiting {} seconds'.format(delay))
+                logger.info(
+                    "Warning: locked database, waiting {} seconds".format(delay)
+                )
             else:
                 # Something else so just re-raise
                 raise
@@ -78,7 +88,7 @@ def try4times(func, *arg, **kwarg):
 
     else:
         # After 4 tries bail out with an exception
-        raise OperationalError('database is locked')
+        raise OperationalError("database is locked")
 
 
 def delete_from_date(EventModel, start, set_update_date=True):
@@ -89,12 +99,16 @@ def delete_from_date(EventModel, start, set_update_date=True):
 
     if set_update_date:
         update = models.Update.objects.get(name=cls_name)
-        logger.info('Updating {} date from {} to {}'.format(cls_name, update.date, date_start))
+        logger.info(
+            "Updating {} date from {} to {}".format(cls_name, update.date, date_start)
+        )
         update.date = date_start
         try4times(update.save)
 
     events = EventModel.objects.filter(start__gte=date_start)
-    logger.info('Deleting {} {} events after {}'.format(events.count(), cls_name, date_start))
+    logger.info(
+        "Deleting {} {} events after {}".format(events.count(), cls_name, date_start)
+    )
     try4times(events.delete)
 
 
@@ -109,7 +123,7 @@ def update(EventModel, date_stop):
     try:
         update = models.Update.objects.get(name=cls_name)
     except ObjectDoesNotExist:
-        logger.info('No previous update for {} found'.format(cls_name))
+        logger.info("No previous update for {} found".format(cls_name))
         duration = EventModel.lookback
         update = models.Update(name=cls_name, date=date_stop.date)
         date_start = date_stop - EventModel.lookback
@@ -121,24 +135,30 @@ def update(EventModel, date_stop):
         # Some events like LoadSegment or DsnComm might change in the database after
         # having been ingested.  Use lookback_delete (less than lookback) to
         # always remove events in that range and re-ingest.
-        if duration >= 0.5 and hasattr(EventModel, 'lookback_delete'):
+        if duration >= 0.5 and hasattr(EventModel, "lookback_delete"):
             delete_date = DateTime(update.date) - EventModel.lookback_delete
             delete_from_date(EventModel, delete_date, set_update_date=False)
 
     if duration < 0.5:
-        logger.info('Skipping {} events because update duration={:.1f} is < 0.5 day'
-                    .format(cls_name, duration))
+        logger.info(
+            "Skipping {} events because update duration={:.1f} is < 0.5 day".format(
+                cls_name, duration
+            )
+        )
         return
 
     # Some events like LoadSegment, DsnComm are defined into the future, so
     # modify date_stop accordingly.  Note that update.date is set to the
     # nominal date_stop (typically NOW), and this refers more to the last date
     # of processing rather than the actual last date in the archive.
-    if hasattr(EventModel, 'lookforward'):
+    if hasattr(EventModel, "lookforward"):
         date_stop = date_stop + EventModel.lookforward
 
-    logger.info('Updating {} events from {} to {}'
-                .format(cls_name, date_start.date[:-4], date_stop.date[:-4]))
+    logger.info(
+        "Updating {} events from {} to {}".format(
+            cls_name, date_start.date[:-4], date_stop.date[:-4]
+        )
+    )
 
     # Get events for this model from telemetry.  This is returned as a list
     # of dicts with key/val pairs corresponding to model fields.
@@ -146,7 +166,9 @@ def update(EventModel, date_stop):
 
     # Determine which of the events is not already in the database and
     # put them in a list for saving.
-    event_models, events = get_events_and_event_models(EventModel, cls_name, events_in_dates)
+    event_models, events = get_events_and_event_models(
+        EventModel, cls_name, events_in_dates
+    )
 
     # Save the new events in an atomic fashion
     with django.db.transaction.atomic():
@@ -160,9 +182,10 @@ def update(EventModel, date_stop):
                     save_event_to_database(cls_name, event, event_model, models)
             except django.db.utils.IntegrityError:
                 import traceback
-                logger.warn(f'WARNING: IntegrityError skipping {event_model}')
-                logger.warn(f'Event dict:\n{event}')
-                logger.warn(f'Traceback:\n{traceback.format_exc()}')
+
+                logger.warn(f"WARNING: IntegrityError skipping {event_model}")
+                logger.warn(f"Event dict:\n{event}")
+                logger.warn(f"Traceback:\n{traceback.format_exc()}")
                 continue
 
         # If processing got here with no exceptions then save the event update
@@ -172,12 +195,13 @@ def update(EventModel, date_stop):
 
 def save_event_to_database(cls_name, event, event_model, models):
     try4times(event_model.save)
-    logger.info('Added {} {}'.format(cls_name, event_model))
-    if 'dur' in event and event['dur'] < 0:
-        logger.info('WARNING: negative event duration for {} {}'
-                    .format(cls_name, event_model))
+    logger.info("Added {} {}".format(cls_name, event_model))
+    if "dur" in event and event["dur"] < 0:
+        logger.info(
+            "WARNING: negative event duration for {} {}".format(cls_name, event_model)
+        )
     # Add any foreign rows (many to one)
-    for foreign_cls_name, rows in event.get('foreign', {}).items():
+    for foreign_cls_name, rows in event.get("foreign", {}).items():
         ForeignModel = getattr(models, foreign_cls_name)
         if isinstance(rows, np.ndarray):
             rows = [{key: row[key].tolist() for key in row.dtype.names} for row in rows]
@@ -185,7 +209,7 @@ def save_event_to_database(cls_name, event, event_model, models):
             # Convert to a plain dict if row is structured array
             foreign_model = ForeignModel.from_dict(row, logger)
             setattr(foreign_model, event_model.model_name, event_model)
-            logger.verbose('Adding {}'.format(foreign_model))
+            logger.verbose("Adding {}".format(foreign_model))
             try4times(foreign_model.save)
 
 
@@ -202,8 +226,11 @@ def get_events_and_event_models(EventModel, cls_name, events_in_dates):
             events.append(event)
             event_models.append(event_model)
         else:
-            logger.verbose('Skipping {} at {}: already in database'
-                           .format(cls_name, event['start']))
+            logger.verbose(
+                "Skipping {} at {}: already in database".format(
+                    cls_name, event["start"]
+                )
+            )
     return event_models, events
 
 
@@ -212,17 +239,18 @@ def main():
 
     opt = get_opt()
 
-    logger = pyyaks.logger.get_logger(name='kadi_update_events', level=opt.log_level,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name="kadi_update_events", level=opt.log_level, format="%(asctime)s %(message)s"
+    )
     log_run_info(logger.info, opt)
 
     # Set the global root data directory.  This gets used in the django
     # setup to find the sqlite3 database file.
-    os.environ['KADI'] = os.path.abspath(opt.data_root)
+    os.environ["KADI"] = os.path.abspath(opt.data_root)
     from kadi.paths import EVENTS_DB_PATH
 
-    logger.info('Event database : {}'.format(EVENTS_DB_PATH()))
-    logger.info('')
+    logger.info("Event database : {}".format(EVENTS_DB_PATH()))
+    logger.info("")
 
     from kadi.events import models
 
@@ -232,24 +260,29 @@ def main():
     if opt.start is None:
         date_stops = [opt.stop]
     else:
-        t_starts = np.arange(DateTime(opt.start).secs,
-                             DateTime(opt.stop).secs,
-                             opt.loop_days * 86400.)
+        t_starts = np.arange(
+            DateTime(opt.start).secs, DateTime(opt.stop).secs, opt.loop_days * 86400.0
+        )
         date_stops = [DateTime(t).date for t in t_starts]
         date_stops.append(opt.stop)
 
     # Get the event classes in models module
-    EventModels = [Model for name, Model in vars(models).items()
-                   if (isinstance(Model, type)  # is a class
-                       and issubclass(Model, models.BaseEvent)  # is a BaseEvent subclass
-                       and 'Meta' not in Model.__dict__  # is not a base class
-                       and hasattr(Model, 'get_events')  # can get events
-                       )]
+    EventModels = [
+        Model
+        for name, Model in vars(models).items()
+        if (
+            isinstance(Model, type)  # is a class
+            and issubclass(Model, models.BaseEvent)  # is a BaseEvent subclass
+            and "Meta" not in Model.__dict__  # is not a base class
+            and hasattr(Model, "get_events")  # can get events
+        )
+    ]
 
     # Filter on ---model command line arg(s)
     if opt.models:
-        EventModels = [x for x in EventModels
-                       if any(re.match(y, x.__name__) for y in opt.models)]
+        EventModels = [
+            x for x in EventModels if any(re.match(y, x.__name__) for y in opt.models)
+        ]
 
     # Update priority (higher priority value means earlier in processing)
     EventModels = sorted(EventModels, key=lambda x: x.update_priority, reverse=True)
@@ -264,9 +297,10 @@ def main():
         except Exception:
             # Something went wrong, but press on with processing other EventModels
             import traceback
-            logger.error(f'ERROR in processing {EventModel}')
-            logger.error(f'Traceback:\n{traceback.format_exc()}')
+
+            logger.error(f"ERROR in processing {EventModel}")
+            logger.error(f"Traceback:\n{traceback.format_exc()}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -20,34 +20,38 @@ from kadi.paths import EVENTS_DB_PATH, DATA_DIR  # noqa
 # Make sure there is an events database
 if not os.path.exists(EVENTS_DB_PATH()):
     import warnings
-    message = ('\n\n'
-               '***************************************'
-               '\n\n'
-               'Events database file {} not found.  \n'
-               'Most likely this is not what you want since no events\n'
-               'will be found. If you are running in a test or standalone\n'
-               'Ska environment then you may need to set the KADI environment variable\n'
-               'to point to a directory like /proj/sot/ska/data/kadi that has an\n'
-               'events.db3 file.\n\n'
-               '***************************************'.format(EVENTS_DB_PATH()))
+
+    message = (
+        "\n\n"
+        "***************************************"
+        "\n\n"
+        "Events database file {} not found.  \n"
+        "Most likely this is not what you want since no events\n"
+        "will be found. If you are running in a test or standalone\n"
+        "Ska environment then you may need to set the KADI environment variable\n"
+        "to point to a directory like /proj/sot/ska/data/kadi that has an\n"
+        "events.db3 file.\n\n"
+        "***************************************".format(EVENTS_DB_PATH())
+    )
     warnings.warn(message)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
 
-_secret_file = join(DATA_DIR(), 'secret_key.txt')
+_secret_file = join(DATA_DIR(), "secret_key.txt")
 try:
     with open(_secret_file) as fh:
         SECRET_KEY = fh.read().strip()
 
 except IOError:
     import random
-    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-    SECRET_KEY = ''.join([random.SystemRandom().choice(chars) for i in range(50)])
+
+    chars = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)"
+    SECRET_KEY = "".join([random.SystemRandom().choice(chars) for i in range(50)])
     try:
-        with open(_secret_file, 'w') as fh:
+        with open(_secret_file, "w") as fh:
             fh.write(SECRET_KEY)
-        print('Created secret key file {}'.format(_secret_file))
+        print("Created secret key file {}".format(_secret_file))
 
     except IOError:
         pass  # Running as a non-production instance, don't worry about secret key
@@ -55,23 +59,23 @@ except IOError:
     else:
         try:
             import stat
+
             os.chmod(_secret_file, stat.S_IRUSR)
-            print('Changed file mode to owner read-only')
+            print("Changed file mode to owner read-only")
         except Exception:
             import warnings
-            warnings.warn('Unable to change file mode permission!')
+
+            warnings.warn("Unable to change file mode permission!")
 
 # Application definition
-INSTALLED_APPS = (
-    'kadi.events',
-)
+INSTALLED_APPS = ("kadi.events",)
 
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': EVENTS_DB_PATH(),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": EVENTS_DB_PATH(),
     }
 }

--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -10,12 +10,12 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 # Build paths inside the project like this: join(BASE_DIR, ...)
 import os
-from os.path import join, dirname, realpath
+from os.path import dirname, join, realpath
 
 BASE_DIR = dirname(dirname(realpath(__file__)))
 
 # Data paths for kadi project
-from kadi.paths import EVENTS_DB_PATH, DATA_DIR  # noqa
+from kadi.paths import DATA_DIR, EVENTS_DB_PATH  # noqa
 
 # Make sure there is an events database
 if not os.path.exists(EVENTS_DB_PATH()):

--- a/kadi/tests/test_events.py
+++ b/kadi/tests/test_events.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from copy import deepcopy
 import os
 import sys
+from copy import deepcopy
 
 import numpy as np
+from Chandra.Time import DateTime
 
 from .. import events
-from Chandra.Time import DateTime
 
 
 def test_xdg_config_home_env_var():

--- a/kadi/tests/test_events.py
+++ b/kadi/tests/test_events.py
@@ -18,42 +18,48 @@ def test_xdg_config_home_env_var():
     Test this both ways by setting PYTHONPATH=/proj/web-kadi, or not.  Use -v -s flags in
     pytest to confirm expect path.
     """
-    ska_data_config = os.path.join(os.environ['SKA'], 'data', 'config')
-    if any(pth.startswith('/proj/web-kadi') for pth in sys.path):
+    ska_data_config = os.path.join(os.environ["SKA"], "data", "config")
+    if any(pth.startswith("/proj/web-kadi") for pth in sys.path):
         # Apache WSGI config sets local PYTHONPATH to include /proj/web-kadi (regardless
         # of where kadi is actually getting imported).
-        print('Checking production web path')
-        assert os.environ['XDG_CONFIG_HOME'] == ska_data_config
-        assert os.environ['XDG_CACHE_HOME'] == os.environ['XDG_CONFIG_HOME']
+        print("Checking production web path")
+        assert os.environ["XDG_CONFIG_HOME"] == ska_data_config
+        assert os.environ["XDG_CACHE_HOME"] == os.environ["XDG_CONFIG_HOME"]
     else:
         # Normal import, not part of web server
-        print('Checking normal import path')
-        assert not os.environ.get('XDG_CONFIG_HOME', '').startswith(ska_data_config)
-        assert not os.environ.get('XDG_CACHE_HOME', '').startswith(ska_data_config)
+        print("Checking normal import path")
+        assert not os.environ.get("XDG_CONFIG_HOME", "").startswith(ska_data_config)
+        assert not os.environ.get("XDG_CACHE_HOME", "").startswith(ska_data_config)
 
 
 def test_overlapping_intervals():
     """
     Intervals that overlap due to interval_pad get merged.
     """
-    start = '2013:221:00:10:00.000'
-    stop = '2013:221:00:20:00.000'
+    start = "2013:221:00:10:00.000"
+    stop = "2013:221:00:20:00.000"
     fa_moves = deepcopy(events.fa_moves)
     fa_moves.interval_pad = 0.0
-    assert fa_moves.intervals(start, stop) == [('2013:221:00:11:33.100', '2013:221:00:12:05.900'),
-                                               ('2013:221:00:12:38.700', '2013:221:00:13:11.500')]
+    assert fa_moves.intervals(start, stop) == [
+        ("2013:221:00:11:33.100", "2013:221:00:12:05.900"),
+        ("2013:221:00:12:38.700", "2013:221:00:13:11.500"),
+    ]
     fa_moves.interval_pad = 300.0
-    assert fa_moves.intervals(start, stop) == [('2013:221:00:10:00.000', '2013:221:00:18:11.500')]
+    assert fa_moves.intervals(start, stop) == [
+        ("2013:221:00:10:00.000", "2013:221:00:18:11.500")
+    ]
 
 
 def test_interval_pads():
     """
     Intervals pads.
     """
-    start = '2013:221:00:10:00.000'
-    stop = '2013:221:00:20:00.000'
-    intervals = [('2013:221:00:11:33.100', '2013:221:00:12:05.900'),
-                 ('2013:221:00:12:38.700', '2013:221:00:13:11.500')]
+    start = "2013:221:00:10:00.000"
+    stop = "2013:221:00:20:00.000"
+    intervals = [
+        ("2013:221:00:11:33.100", "2013:221:00:12:05.900"),
+        ("2013:221:00:12:38.700", "2013:221:00:13:11.500"),
+    ]
 
     assert events.fa_moves.intervals(start, stop) == intervals
 
@@ -68,37 +74,45 @@ def test_interval_pads():
 
     # 5 seconds earlier and 10 seconds later
     fa_moves = events.fa_moves(pad=(5, 10))
-    assert fa_moves.intervals(start, stop) == [('2013:221:00:11:28.100', '2013:221:00:12:15.900'),
-                                               ('2013:221:00:12:33.700', '2013:221:00:13:21.500')]
+    assert fa_moves.intervals(start, stop) == [
+        ("2013:221:00:11:28.100", "2013:221:00:12:15.900"),
+        ("2013:221:00:12:33.700", "2013:221:00:13:21.500"),
+    ]
 
     fa_moves = events.fa_moves(pad=300)
-    assert fa_moves.intervals(start, stop) == [('2013:221:00:10:00.000', '2013:221:00:18:11.500')]
+    assert fa_moves.intervals(start, stop) == [
+        ("2013:221:00:10:00.000", "2013:221:00:18:11.500")
+    ]
 
 
 def test_query_event_intervals():
-    intervals = (events.manvrs & events.tsc_moves).intervals('2012:001:12:00:00',
-                                                             '2012:002:12:00:00')
-    assert intervals == [('2012:001:18:21:31.715', '2012:001:18:22:04.515'),
-                         ('2012:002:02:53:03.804', '2012:002:02:54:50.917')]
+    intervals = (events.manvrs & events.tsc_moves).intervals(
+        "2012:001:12:00:00", "2012:002:12:00:00"
+    )
+    assert intervals == [
+        ("2012:001:18:21:31.715", "2012:001:18:22:04.515"),
+        ("2012:002:02:53:03.804", "2012:002:02:54:50.917"),
+    ]
 
 
 def test_basic_query():
-    rad_zones = events.rad_zones.filter('2013:001:12:00:00', '2013:007:12:00:00')
+    rad_zones = events.rad_zones.filter("2013:001:12:00:00", "2013:007:12:00:00")
     assert str(rad_zones).splitlines() == [
-        '<RadZone: 1852 2013:003:16:19:36 2013:004:02:21:34 dur=36.1 ksec>',
-        '<RadZone: 1853 2013:006:08:22:22 2013:006:17:58:48 dur=34.6 ksec>']
+        "<RadZone: 1852 2013:003:16:19:36 2013:004:02:21:34 dur=36.1 ksec>",
+        "<RadZone: 1853 2013:006:08:22:22 2013:006:17:58:48 dur=34.6 ksec>",
+    ]
     rzt = rad_zones.table
-    rzt['tstart'].format = '.3f'
-    rzt['tstop'].format = '.3f'
-    rzt['dur'].format = '.3f'
+    rzt["tstart"].format = ".3f"
+    rzt["tstop"].format = ".3f"
+    rzt["dur"].format = ".3f"
     assert rzt.pformat(max_width=-1) == [
-        '        start                  stop             tstart        tstop        dur    orbit orbit_num        perigee       ',  # noqa
-        '--------------------- --------------------- ------------- ------------- --------- ----- --------- ---------------------',  # noqa
-        '2013:003:16:19:36.289 2013:004:02:21:34.289 473617243.473 473653361.473 36118.000  1852      1852 2013:003:22:29:59.302',  # noqa
-        '2013:006:08:22:22.982 2013:006:17:58:48.982 473847810.166 473882396.166 34586.000  1853      1853 2013:006:13:58:21.389'  # noqa
+        "        start                  stop             tstart        tstop        dur    orbit orbit_num        perigee       ",  # noqa
+        "--------------------- --------------------- ------------- ------------- --------- ----- --------- ---------------------",  # noqa
+        "2013:003:16:19:36.289 2013:004:02:21:34.289 473617243.473 473653361.473 36118.000  1852      1852 2013:003:22:29:59.302",  # noqa
+        "2013:006:08:22:22.982 2013:006:17:58:48.982 473847810.166 473882396.166 34586.000  1853      1853 2013:006:13:58:21.389",  # noqa
     ]
 
-    rad_zones = events.rad_zones.filter('2013:001:12:00:00', '2013:002:12:00:00')
+    rad_zones = events.rad_zones.filter("2013:001:12:00:00", "2013:002:12:00:00")
     assert len(rad_zones) == 0
     assert len(rad_zones.table) == 0
 
@@ -108,11 +122,11 @@ def test_short_query():
     Short duration queries that test that filter will return partially
     included intervals.
     """
-    dwells = events.dwells.filter('2012:002:00:00:00', '2012:002:00:00:01')
+    dwells = events.dwells.filter("2012:002:00:00:00", "2012:002:00:00:01")
     assert len(dwells) == 1
-    dwells = events.dwells.filter('2012:001:18:40:00', '2012:001:18:42:00')
+    dwells = events.dwells.filter("2012:001:18:40:00", "2012:001:18:42:00")
     assert len(dwells) == 1
-    dwells = events.dwells.filter('2012:002:02:49:00', '2012:002:02:50:00')
+    dwells = events.dwells.filter("2012:002:02:49:00", "2012:002:02:50:00")
     assert len(dwells) == 1
 
 
@@ -122,20 +136,22 @@ def test_get_obsid():
     """
     models = events.models.get_event_models()
     for model in models.values():
-        if model.__name__ == 'SafeSun':
+        if model.__name__ == "SafeSun":
             continue  # Doesn't work for SafeSun because of bad OBC telem
-        model_obj = model.objects.filter(start__gte='2002:010:12:00:00')[0]
+        model_obj = model.objects.filter(start__gte="2002:010:12:00:00")[0]
         obsid = model_obj.get_obsid()
         obsid_obj = events.obsids.filter(obsid__exact=obsid)[0]
-        model_obj_start = DateTime(getattr(model_obj, model_obj._get_obsid_start_attr)).date
+        model_obj_start = DateTime(
+            getattr(model_obj, model_obj._get_obsid_start_attr)
+        ).date
         assert obsid_obj.start <= model_obj_start
         assert obsid_obj.stop > model_obj_start
 
         # Now test that searching for objects with the same obsid gets
         # some matching objects and that they all have the same obsid.
-        if model_obj.model_name in ('major_event', 'safe_sun'):
+        if model_obj.model_name in ("major_event", "safe_sun"):
             continue  # Doesn't work for these
-        query = getattr(events, model_obj.model_name + 's')
+        query = getattr(events, model_obj.model_name + "s")
         query_events = query.filter(obsid=obsid)
         assert len(query_events) >= 1
         for query_event in query_events:
@@ -147,41 +163,49 @@ def test_intervals_filter():
     Test setting filter keywords in the EventQuery object itself.
     """
     ltt_bads = events.ltt_bads
-    start, stop = '2000:121:12:00:00', '2000:134:12:00:00'
+    start, stop = "2000:121:12:00:00", "2000:134:12:00:00"
 
     # 2000-04-30 00:00:00 | ELBI_LOW        | R
     # 2000-04-30 00:00:00 | EPOWER1         | R
     # 2000-05-01 00:00:00 | 3SDTSTSV        | Y
     # 2000-05-13 00:00:00 | 3SDP15V         | 1
 
-    lines = sorted(str(ltt_bads().filter('2000:121:12:00:00', '2000:134:12:00:00')).splitlines())
-    assert (lines
-            == ['<LttBad: start=2000:121:00:00:00.000 msid=ELBI_LOW flag=R>',
-                '<LttBad: start=2000:121:00:00:00.000 msid=EPOWER1 flag=R>',
-                '<LttBad: start=2000:122:00:00:00.000 msid=3SDTSTSV flag=Y>',
-                '<LttBad: start=2000:134:00:00:00.000 msid=3SDP15V flag=1>'])
+    lines = sorted(
+        str(ltt_bads().filter("2000:121:12:00:00", "2000:134:12:00:00")).splitlines()
+    )
+    assert lines == [
+        "<LttBad: start=2000:121:00:00:00.000 msid=ELBI_LOW flag=R>",
+        "<LttBad: start=2000:121:00:00:00.000 msid=EPOWER1 flag=R>",
+        "<LttBad: start=2000:122:00:00:00.000 msid=3SDTSTSV flag=Y>",
+        "<LttBad: start=2000:134:00:00:00.000 msid=3SDP15V flag=1>",
+    ]
 
     # No filter
-    assert (ltt_bads.intervals(start, stop)
-            == [('2000:121:12:00:00.000', '2000:123:00:00:00.000'),
-                ('2000:134:00:00:00.000', '2000:134:12:00:00.000')])
+    assert ltt_bads.intervals(start, stop) == [
+        ("2000:121:12:00:00.000", "2000:123:00:00:00.000"),
+        ("2000:134:00:00:00.000", "2000:134:12:00:00.000"),
+    ]
 
-    assert (ltt_bads(flag='Y').intervals(start, stop)
-            == [('2000:122:00:00:00.000', '2000:123:00:00:00.000')])
+    assert ltt_bads(flag="Y").intervals(start, stop) == [
+        ("2000:122:00:00:00.000", "2000:123:00:00:00.000")
+    ]
 
-    assert (ltt_bads(msid='ELBI_LOW', flag='R').intervals(start, stop)
-            == [('2000:121:12:00:00.000', '2000:122:00:00:00.000')])
+    assert ltt_bads(msid="ELBI_LOW", flag="R").intervals(start, stop) == [
+        ("2000:121:12:00:00.000", "2000:122:00:00:00.000")
+    ]
 
-    assert (ltt_bads(msid='ELBI_LOW', flag='1').intervals(start, stop) == [])
+    assert ltt_bads(msid="ELBI_LOW", flag="1").intervals(start, stop) == []
 
 
 def test_get_overlaps():
     """
     Unit test QuerySet._get_full_overlaps and QuerySet._get_partial_overlaps
     """
-    dates = [('2000:001:00:00:00', '2000:002:00:00:00'),
-             ('2000:003:00:00:00', '2000:004:00:00:00'),
-             ('2000:005:00:00:00', '2000:006:00:00:00')]
+    dates = [
+        ("2000:001:00:00:00", "2000:002:00:00:00"),
+        ("2000:003:00:00:00", "2000:004:00:00:00"),
+        ("2000:005:00:00:00", "2000:006:00:00:00"),
+    ]
     datestarts, datestops = zip(*dates)
     datestarts, datestops = np.array(datestarts), np.array(datestops)
 
@@ -189,22 +213,28 @@ def test_get_overlaps():
     overlap_starts, overlap_stops = zip(*overlaps)
     overlap_starts, overlap_stops = np.array(overlap_starts), np.array(overlap_stops)
 
-    x = events.manvrs.filter('2000:001:12:00:00', '2000:002:12:00:00')
+    x = events.manvrs.filter("2000:001:12:00:00", "2000:002:12:00:00")
     indices = x._get_full_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
     assert np.all(indices == [0, 1, 2])
 
-    indices = x._get_partial_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
+    indices = x._get_partial_overlaps(
+        overlap_starts, overlap_stops, datestarts, datestops
+    )
     assert np.all(indices == [0, 1, 2])
 
-    overlaps = [('2000:001:00:00:00', '2000:001:12:00:00'),
-                ('2000:001:13:00:00', '2000:002:00:00:00'),
-                ('2000:005:00:00:01', '2000:006:00:00:00')]
+    overlaps = [
+        ("2000:001:00:00:00", "2000:001:12:00:00"),
+        ("2000:001:13:00:00", "2000:002:00:00:00"),
+        ("2000:005:00:00:01", "2000:006:00:00:00"),
+    ]
     overlap_starts, overlap_stops = zip(*overlaps)
     overlap_starts, overlap_stops = np.array(overlap_starts), np.array(overlap_stops)
     indices = x._get_full_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
     assert len(indices) == 0
 
-    indices = x._get_partial_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
+    indices = x._get_partial_overlaps(
+        overlap_starts, overlap_stops, datestarts, datestops
+    )
     assert np.all(indices == [0, 2])
 
     overlap_starts, overlap_stops = [], []
@@ -213,7 +243,9 @@ def test_get_overlaps():
     indices = x._get_full_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
     assert len(indices) == 0
 
-    indices = x._get_partial_overlaps(overlap_starts, overlap_stops, datestarts, datestops)
+    indices = x._get_partial_overlaps(
+        overlap_starts, overlap_stops, datestarts, datestops
+    )
     assert len(indices) == 0
 
 
@@ -221,22 +253,25 @@ def test_select_overlapping():
     """
     Functional test of selecting overlapping events
     """
-    manvrs = events.manvrs.filter('2001:001:00:00:00', '2001:003:00:00:00')
+    manvrs = events.manvrs.filter("2001:001:00:00:00", "2001:003:00:00:00")
 
     manvrs_sel = manvrs.select_overlapping(~events.rad_zones)
     assert [repr(x) for x in manvrs_sel] == [
-        '<Manvr: start=2001:001:07:48:35.843 dur=2073 n_dwell=2 template=nman_dwell>',
-        '<Manvr: start=2001:002:20:50:34.523 dur=1185 n_dwell=1 template=normal>']
+        "<Manvr: start=2001:001:07:48:35.843 dur=2073 n_dwell=2 template=nman_dwell>",
+        "<Manvr: start=2001:002:20:50:34.523 dur=1185 n_dwell=1 template=normal>",
+    ]
 
     manvrs_sel = manvrs.select_overlapping(events.rad_zones)
     assert [repr(x) for x in manvrs_sel] == [
-        '<Manvr: start=2001:002:05:20:14.046 dur=1184 n_dwell=1 template=normal>',
-        '<Manvr: start=2001:002:08:53:23.997 dur=241 n_dwell=1 template=normal>',
-        '<Manvr: start=2001:002:14:55:24.773 dur=240 n_dwell=1 template=normal>']
+        "<Manvr: start=2001:002:05:20:14.046 dur=1184 n_dwell=1 template=normal>",
+        "<Manvr: start=2001:002:08:53:23.997 dur=241 n_dwell=1 template=normal>",
+        "<Manvr: start=2001:002:14:55:24.773 dur=240 n_dwell=1 template=normal>",
+    ]
 
     manvrs_sel = manvrs.select_overlapping(events.tsc_moves, allow_partial=False)
     assert [repr(x) for x in manvrs_sel] == []
 
     manvrs_sel = manvrs.select_overlapping(events.tsc_moves)
     assert [repr(x) for x in manvrs_sel] == [
-        '<Manvr: start=2001:002:20:50:34.523 dur=1185 n_dwell=1 template=normal>']
+        "<Manvr: start=2001:002:20:50:34.523 dur=1185 n_dwell=1 template=normal>"
+    ]

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -12,7 +12,7 @@ from kadi import occweb
 
 
 try:
-    Ska.ftp.parse_netrc()['lucky']['login']
+    Ska.ftp.parse_netrc()["lucky"]["login"]
     lucky = Ska.ftp.SFTP(occweb.LUCKY)
 except Exception:
     HAS_LUCKY = False
@@ -22,13 +22,13 @@ else:
 
 
 def _test_put_get(user):
-    filenames = ['test.dat', 'test2.dat']
+    filenames = ["test.dat", "test2.dat"]
 
     # Make a local temp dir and put files there
     local_tmpdir = Ska.File.TempDir()
     with Ska.File.chdir(local_tmpdir.name):
         for filename in filenames:
-            open(filename, 'w').write(filename)
+            open(filename, "w").write(filename)
         local_filenames = [os.path.abspath(x) for x in os.listdir(local_tmpdir.name)]
 
     remote_tmpdir = str(uuid.uuid4())  # random remote dir name
@@ -43,7 +43,7 @@ def _test_put_get(user):
     lucky = Ska.ftp.SFTP(occweb.LUCKY)
     if user is None:
         user = lucky.ftp.get_channel().transport.get_username()
-    lucky.rmdir('/home/{}/{}'.format(user, remote_tmpdir))
+    lucky.rmdir("/home/{}/{}".format(user, remote_tmpdir))
     lucky.close()
 
     # Make sure round-tripped files are the same
@@ -52,7 +52,7 @@ def _test_put_get(user):
             assert open(filename).read() == filename
 
 
-@pytest.mark.skipif(not HAS_LUCKY, reason='No access to lucky FTP server')
+@pytest.mark.skipif(not HAS_LUCKY, reason="No access to lucky FTP server")
 def test_put_get_user_none():
     # Test the user=None code branch (gets username back from SFTP object, which
     # had previously gotten it from the netrc file).
@@ -70,83 +70,87 @@ user, passwd = occweb.get_auth()
 HAS_OCCWEB = True if user is not None else False
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 def test_ifot_fetch():
-    events = occweb.get_ifot('LOADSEG', start='2008:001:12:00:00', stop='2008:003:12:00:00')
+    events = occweb.get_ifot(
+        "LOADSEG", start="2008:001:12:00:00", stop="2008:003:12:00:00"
+    )
     assert len(events) == 1
-    assert events[0]['tstart'] == '2008:002:21:00:00.000'
+    assert events[0]["tstart"] == "2008:002:21:00:00.000"
 
 
 # Looks like there isn't a way to check status (HTTP codes), but these
 # items should stay on these event pages
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 def test_get_fdb_major_events():
-    page = occweb.get_url('fdb_major_events')
-    assert 'Aspect Camera First Star Solution' in page
+    page = occweb.get_url("fdb_major_events")
+    assert "Aspect Camera First Star Solution" in page
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 def test_get_fot_major_events():
-    page = occweb.get_url('fot_major_events')
-    assert 'ACA Dark Current Calibration' in page
+    page = occweb.get_url("fot_major_events")
+    assert "ACA Dark Current Calibration" in page
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
-@pytest.mark.parametrize('str_or_Path', [str, Path])
-@pytest.mark.parametrize('cache', [False, 'update', True])
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
+@pytest.mark.parametrize("str_or_Path", [str, Path])
+@pytest.mark.parametrize("cache", [False, "update", True])
 def test_get_occweb_dir(str_or_Path, cache):
     """Test get_occweb_dir and get_occweb_page (which is called in the process)"""
-    path = str_or_Path('FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR/')
-    url = f'https://occweb.cfa.harvard.edu/occweb/{path}'
+    path = str_or_Path("FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR/")
+    url = f"https://occweb.cfa.harvard.edu/occweb/{path}"
     files_path = occweb.get_occweb_dir(path, cache=cache)
     files_url = occweb.get_occweb_dir(url, cache=cache)
     exp = [
-        '      Name        Last modified   Size',
-        '---------------- ---------------- ----',
-        'Parent Directory               --    -',
-        '       MAR0500D/ 2002-04-30 13:38    -',
-        '       MAR1200D/ 2002-04-30 13:38    -',
-        '       MAR1900E/ 2004-03-18 13:44    -',
-        '       MAR2600C/ 2002-04-30 13:38    -']
+        "      Name        Last modified   Size",
+        "---------------- ---------------- ----",
+        "Parent Directory               --    -",
+        "       MAR0500D/ 2002-04-30 13:38    -",
+        "       MAR1200D/ 2002-04-30 13:38    -",
+        "       MAR1900E/ 2004-03-18 13:44    -",
+        "       MAR2600C/ 2002-04-30 13:38    -",
+    ]
     assert files_path.pformat_all() == exp
     assert files_url.pformat_all() == exp
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
-@pytest.mark.parametrize('backslash', [True, False])
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
+@pytest.mark.parametrize("backslash", [True, False])
 def test_get_occweb_noodle(backslash):
     """Test get_occweb_dir and get_occweb_page (which is called in the process)
     for a noodle directory"""
-    path = '//noodle/FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR'
+    path = "//noodle/FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR"
     if backslash:
-        path = path.replace('/', '\\')
+        path = path.replace("/", "\\")
     files_path = occweb.get_occweb_dir(path)
     exp = [
-        '      Name        Last modified   Size',
-        '---------------- ---------------- ----',
-        'Parent Directory               --    -',
-        '       MAR0500D/ 2002-04-30 13:38    -',
-        '       MAR1200D/ 2002-04-30 13:38    -',
-        '       MAR1900E/ 2004-03-18 13:44    -',
-        '       MAR2600C/ 2002-04-30 13:38    -']
+        "      Name        Last modified   Size",
+        "---------------- ---------------- ----",
+        "Parent Directory               --    -",
+        "       MAR0500D/ 2002-04-30 13:38    -",
+        "       MAR1200D/ 2002-04-30 13:38    -",
+        "       MAR1900E/ 2004-03-18 13:44    -",
+        "       MAR2600C/ 2002-04-30 13:38    -",
+    ]
     assert files_path.pformat_all() == exp
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
-@pytest.mark.parametrize('cache', [False, True])
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
+@pytest.mark.parametrize("cache", [False, True])
 def test_get_occweb_dir_fail(cache):
     """Test get_occweb_dir and get_occweb_page (which is called in the process)"""
-    path = Path('FOT/mission_planning/PRODUCTS/APPR_LOADS/FAIL-NOT-THERE')
+    path = Path("FOT/mission_planning/PRODUCTS/APPR_LOADS/FAIL-NOT-THERE")
     with pytest.raises(requests.exceptions.HTTPError):
         occweb.get_occweb_dir(path, cache=cache)
 
 
-@pytest.mark.skipif(not HAS_OCCWEB, reason='No access to OCCweb')
-@pytest.mark.parametrize('cache', [False, 'update', True])
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
+@pytest.mark.parametrize("cache", [False, "update", True])
 def test_get_occweb_page_binary(cache):
     """Test get_occweb_page binary"""
-    path = 'FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR/'
+    path = "FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR/"
     content_bytes = occweb.get_occweb_page(path, binary=True, cache=cache)
     content_str = occweb.get_occweb_page(path, binary=False, cache=cache)
 
-    assert content_bytes.decode('utf-8') == content_str
+    assert content_bytes.decode("utf-8") == content_str

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -1,15 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from pathlib import Path
 import os
 import uuid
-import requests
+from pathlib import Path
 
-import Ska.ftp
-import Ska.File
 import pytest
+import requests
+import Ska.File
+import Ska.ftp
 
 from kadi import occweb
-
 
 try:
     Ska.ftp.parse_netrc()["lucky"]["login"]


### PR DESCRIPTION
## Description

This applies the `black`(version 22.5) and `isort` autoformatters to the kadi code base.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
