### PR TITLE
Remove dither disable from bright star hold command set

### DIFF
--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -94,7 +94,7 @@ def cmd_set_dither(state, date=None):
 
 
 def cmd_set_bright_star_hold(date=None):
-    out = cmd_set_scs107(date=date) + cmd_set_dither("OFF", date=date)
+    out = cmd_set_scs107(date=date)
     return out
 
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -514,8 +514,6 @@ def test_command_set_bsh():
         "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
         "2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | "
         "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
-        "2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
-        "event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0",
     ]
 
     assert cmds.pformat_like_backstop() == exp
@@ -593,8 +591,6 @@ Definitive,2020:337:00:00:00,Bright star hold,,Tom Aldcroft,
         "2020:337:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | "
         "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
         "2020:337:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | "
-        "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
-        "2020:337:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | "
         "event=Bright_star_hold, event_date=2020:337:00:00:00, scs=0",
         # Only ORBPOINT from here on
         "2020:337:02:07:03.790 | ORBPOINT         | None       | NOV3020A | "
@@ -939,7 +935,6 @@ cmd_events_all_exps = [
         "2020:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
         "2020:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
         "2020:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
-        "2020:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Bright_star_hold, event_date=2020:001:00:00:00, scs=0",  # noqa
     ],  # noqa
     [
         "2020:001:00:00:00.000 | COMMAND_SW       | AOENDITH   | CMD_EVT  | event=Dither, event_date=2020:001:00:00:00, scs=0"  # noqa


### PR DESCRIPTION
## Description

The Bright Star Hold command set mistakenly contained the command to disable dither. This command does not actually happen in BSH so this PR removes the command.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I confirmed using visual inspection with aca_view that dither is still enabled for the 2017:090 and 2022:223 BSH events.