### PR TITLE
Make commands v2 the default

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -15,14 +15,14 @@ replans, and certain non-load commands like ACIS CTI runs or Normal Sun Mode tra
 
 As of this release there are two versions of the commands archive:
 
-- `Commands archive v1`_ (flight): this is the current default version and
+- `Commands archive v2`_ (flight): this provides improved timeliness during
+  anomalies and better team-wide communication of non-load spacecraft
+  commanding. This relies on the `Chandra Command Events`_ sheet and OCCweb FOT
+  mission planning approved load products to maintain the commands database.
+- `Commands archive v1`_ (legacy): this is the legacy version and
   relies on iFOT load segments and the Chandra.cmd_states timelines database to
-  maintain the commands database.
-- `Commands archive v2`_ (beta): this provides improved timeliness during
-  anomalies and better team-wide communication of non-load spacecraft commanding.
-  This relies on the `Chandra Command Events`_ sheet and OCCweb FOT mission planning approved load products to
-  maintain the commands database. V2 is planned to be promoted to the default
-  and the legacy will be deprecated and then retired.
+  maintain the commands database. It is currently deprecated and will be
+  removed in a future release.
 
 **States and continuity**
 
@@ -44,163 +44,12 @@ installed code.  Note that a key design feature is that is it straightforward fo
 to implement their own states, often with just a few lines of code.  See the `User-defined states`_
 section for details.
 
-Commands archive v1
--------------------
-
-The basic way to select commands is with the |get_cmds| method.  For example you can find
-load commands from early in 2013 with::
-
-  >>> from kadi import commands
-  >>> cmds = commands.get_cmds('2013:001:00:00:00', '2013:001:00:56:10')
-  >>> print(cmds)
-          date            type      tlmsid   scs step      time     timeline_id   vcdu  params
-  --------------------- ---------- ---------- --- ---- ------------- ----------- ------- ------
-  2013:001:00:37:37.653   ORBPOINT       None   0    0 473387924.837   426098988 5533112    N/A
-  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524 473388854.365   426098990 5584176    N/A
-  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526 473388914.365   426098990 5584410    N/A
-  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528 473388974.365   426098990 5584644    N/A
-  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530 473389034.365   426098990 5584878    N/A
-  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620 473389034.365   426098991 5584878    N/A
-  2013:001:00:56:07.181   SIMTRANS       None 132 1623 473389034.365   426098991 5584878    N/A
-  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532 473389034.622   426098990 5584879    N/A
-
-
-In the |get_cmds| method, commands are selected with ``start <= date < stop``, where each
-of these are evaluated as a date string with millisec precision.  In order to get commands
-at exactly a certain date you need to select with the ``date`` argument::
-
-  >>> print(commands.get_cmds(date='2013:001:00:56:07.181'))
-           date            type      tlmsid   scs step timeline_id params
-  --------------------- ---------- ---------- --- ---- ----------- ------
-  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990    N/A
-  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991    N/A
-  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991    N/A
-
-The output ``cmds`` is based on the astropy `Table
-<http://docs.astropy.org/en/stable/table/index.html>`_ object with many powerful and handy
-features built in.  For instance you could sort by ``type``, ``tlmsid`` and ``date``::
-
-  >>> cmds_type = cmds.copy()
-  >>> cmds_type.sort(['type', 'tlmsid', 'date'])
-  >>> print(cmds_type)
-           date            type      tlmsid   scs step timeline_id params
-  --------------------- ---------- ---------- --- ---- ----------- ------
-  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991    N/A
-  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990    N/A
-  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990    N/A
-  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990    N/A
-  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990    N/A
-  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990    N/A
-  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988    N/A
-  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991    N/A
-
-You can print a single command and get all the information about it::
-
-  >>> print(cmds[5])
-  2013:001:00:56:07.181 ACISPKT tlmsid=AA00000000 scs=132 step=1620 timeline_id=426098991 cmds=3 packet(40)=D80000300030603001300 words=3
-
-This command has a number of attributes like ``date`` or ``tlmsid`` (shown in the original table) as well as command *parameters*: ``cmds``, ``packet(40)``, and ``words``.  You can access any of the attributes or parameters like a dictionary::
-
-  >>> print(cmds[5]['packet(40)'])
-  D80000300030603001300
-
-You probably noticed the first time we printed ``cmds`` that the command parameters
-``params`` were all listed as ``N/A`` (Not Available).  What happens if we print the
-table again:
-
-  >>> print(cmds)
-           date            type      tlmsid   scs step timeline_id                      params
-  --------------------- ---------- ---------- --- ---- ----------- -----------------------------------------------
-  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988                                             N/A
-  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990                                             N/A
-  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990                                             N/A
-  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990                                             N/A
-  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990                                             N/A
-  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991 cmds=3 packet(40)=D80000300030603001300 words=3
-  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991                                             N/A
-  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990                                             N/A
-
-So what happened?  The answer is that for performance reasons the |CommandTable| class is
-lazy about loading the command parameters, and only does so when you directly request the
-parameter value (as we did with ``packet(40)``).  If you want to just fetch them all
-at once you can do so with the ``fetch_params()`` method::
-
-  >>> cmds.fetch_params()
-  >>> print(cmds)
-           date            type      tlmsid   scs step timeline_id                      params
-  --------------------- ---------- ---------- --- ---- ----------- -----------------------------------------------
-  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988                              event_type=EQF013M
-  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990                       hex=8032000 msid=AOACRSTD
-  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990           aopcadsd=21 hex=8030215 msid=AOFUNCDS
-  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990           aopcadsd=32 hex=8030220 msid=AOFUNCDS
-  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990                       hex=8030402 msid=AONMMODE
-  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991 cmds=3 packet(40)=D80000300030603001300 words=3
-  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991                                      pos=-99616
-  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990                       hex=8030601 msid=AONM2NPE
-
-Finally, note that you can request the value of an attribute or parameter for the entire
-command table.  Note that command rows without that parameter will have a ``None`` object::
-
-  >>> print(cmds['msid'])
-    msid
-  --------
-      None
-  AOACRSTD
-  AOFUNCDS
-  AOFUNCDS
-  AONMMODE
-      None
-      None
-  AONM2NPE
-
-Notes and caveats
-^^^^^^^^^^^^^^^^^^
-
-* The exact set of load commands relies on the `Chandra commanded states database
-  <http://cxc.harvard.edu/mta/ASPECT/tool_doc/cmd_states>`_ to determine which command
-  loads ran on-board and for what duration.  This information comes from a combination of
-  the iFOT load segments database and SOT update procedures for load interrupts.  It has
-  been used operationally since 2009 and has frequent validation checking in the course of
-  thermal load review.  Nevertheless there are likely a few missing commands here and
-  there, particularly associated with load stoppages and replans.
-
-* The kadi commands archive includes all commands for approved loads.  Once loads have
-  been ingested into the database and iFOT has been updated accordingly, then the kadi
-  commands will reflect this update (within an hour).
-
-* Conversely if there is a load interrupt (SCS-107 or anomaly) then this will be reflected
-  in the commands archive within an hour after an on-call person runs a script to update
-  the `Chandra commanded states database
-  <http://cxc.harvard.edu/mta/ASPECT/tool_doc/cmd_states>`_.
-
-* Each load command has an identifier that can be used to retrieve the exact set of mission
-  planning products in which the command was generated.  This is valid even in the case
-  of a re-open replan in which a command load effectively has two source directories.
-
-* The archive includes a select set of non-load commands which result from either
-  autonomous on-board commanding (e.g. SCS-107) or real-time ground commanding
-  (e.g. anomaly recovery).  This list is not comprehensive but includes those
-  commands which typically affect mission planning continuity and thermal modeling.
-
-* The parameters for the ACA star catalog command ``AOSTRCAT`` are not included since this
-  alone would dramatically increase the database file size.  However, the commands are
-  included.
-
-* The command archive is stored in a highly performant HDF5 file backed by a
-  dictionary-based index file of unique command parameters.  As of 2018-Jan, the commands
-  archive is stored in two files with a total size about 52 Mb.
-
-.. note:: Would a command-line interface be useful?
-
 Commands archive v2
 -------------------
 
-Version 2 of the commands archive is currently provided as an experimental
-release to allow getting experience with the new interface.
-
-For details of the commands v2 archive, including important information about
-network access, the timeliness of commands, configuration and process details,
-please see:
+For more details of the commands v2 archive, including important information
+about network access, the timeliness of commands, configuration and process
+details, please see:
 
 .. toctree::
    :maxdepth: 2
@@ -223,23 +72,11 @@ If you have other authentication entries in the same file (e.g. for ``lucky``)
 then there needs to be a blank line between entries.
 
 .. Important::
-   If you are on a machine with other users make sure the file is readable only
-   by you. On linux this is done with ``chmod og-rwx ~/.netrc``.
+   Make sure the file is readable only by you. On linux this is done with
+   ``chmod og-rwx ~/.netrc``.
 
 Getting commands
 ^^^^^^^^^^^^^^^^
-
-In order to use the v2 version do the following::
-
-  >>> from kadi import commands
-  >>> commands.conf.commands_version = "2"  # must be the string "2" not int 2
-
-An alternative is to set the ``KADI_COMMANDS_VERSION`` environment variable to
-``2``. This will globally apply to all subsequent Python sessions that inherit
-this environment. For example from a linux/Mac bash command shell you can
-enter::
-
-  $ export KADI_COMMANDS_VERSION=2
 
 The basic way to select commands is with the |get_cmds| method.  For example you can find
 load commands from early in 2013 with::
@@ -504,6 +341,21 @@ permanently disable caching you can edit your configuration file (see
     >>> from kadi.commands import get_starcats, conf
     >>> with conf.set_temp('cache_starcats', False):
     ...    starcats = get_starcats('2022:001', '2022:002')
+
+Commands archive v1
+-------------------
+
+Version 1 of the commands archive is provided for legacy support but it will be
+removed in a future release.
+
+For details of the commands v1 archive please see:
+please see:
+
+.. toctree::
+   :maxdepth: 2
+
+   commands_v1.rst
+
 
 Chandra states and continuity
 ------------------------------

--- a/docs/commands_v1.rst
+++ b/docs/commands_v1.rst
@@ -1,0 +1,156 @@
+Commands archive v1
+-------------------
+In order to use the v1 version do the following::
+
+  >>> from kadi import commands
+  >>> commands.conf.commands_version = "1"  # must be the string "1" not int 1
+
+An alternative is to set the ``KADI_COMMANDS_VERSION`` environment variable to
+``1``. This will globally apply to all subsequent Python sessions that inherit
+this environment. For example from a linux/Mac bash command shell you can
+enter::
+
+  $ export KADI_COMMANDS_VERSION=1
+
+The basic way to select commands is with the |get_cmds| method.  For example you can find
+load commands from early in 2013 with::
+
+  >>> from kadi import commands
+  >>> cmds = commands.get_cmds('2013:001:00:00:00', '2013:001:00:56:10')
+  >>> print(cmds)
+          date            type      tlmsid   scs step      time     timeline_id   vcdu  params
+  --------------------- ---------- ---------- --- ---- ------------- ----------- ------- ------
+  2013:001:00:37:37.653   ORBPOINT       None   0    0 473387924.837   426098988 5533112    N/A
+  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524 473388854.365   426098990 5584176    N/A
+  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526 473388914.365   426098990 5584410    N/A
+  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528 473388974.365   426098990 5584644    N/A
+  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530 473389034.365   426098990 5584878    N/A
+  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620 473389034.365   426098991 5584878    N/A
+  2013:001:00:56:07.181   SIMTRANS       None 132 1623 473389034.365   426098991 5584878    N/A
+  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532 473389034.622   426098990 5584879    N/A
+
+
+In the |get_cmds| method, commands are selected with ``start <= date < stop``, where each
+of these are evaluated as a date string with millisec precision.  In order to get commands
+at exactly a certain date you need to select with the ``date`` argument::
+
+  >>> print(commands.get_cmds(date='2013:001:00:56:07.181'))
+           date            type      tlmsid   scs step timeline_id params
+  --------------------- ---------- ---------- --- ---- ----------- ------
+  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990    N/A
+  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991    N/A
+  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991    N/A
+
+The output ``cmds`` is based on the astropy `Table
+<http://docs.astropy.org/en/stable/table/index.html>`_ object with many powerful and handy
+features built in.  For instance you could sort by ``type``, ``tlmsid`` and ``date``::
+
+  >>> cmds_type = cmds.copy()
+  >>> cmds_type.sort(['type', 'tlmsid', 'date'])
+  >>> print(cmds_type)
+           date            type      tlmsid   scs step timeline_id params
+  --------------------- ---------- ---------- --- ---- ----------- ------
+  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991    N/A
+  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990    N/A
+  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990    N/A
+  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990    N/A
+  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990    N/A
+  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990    N/A
+  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988    N/A
+  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991    N/A
+
+You can print a single command and get all the information about it::
+
+  >>> print(cmds[5])
+  2013:001:00:56:07.181 ACISPKT tlmsid=AA00000000 scs=132 step=1620 timeline_id=426098991 cmds=3 packet(40)=D80000300030603001300 words=3
+
+This command has a number of attributes like ``date`` or ``tlmsid`` (shown in the original table) as well as command *parameters*: ``cmds``, ``packet(40)``, and ``words``.  You can access any of the attributes or parameters like a dictionary::
+
+  >>> print(cmds[5]['packet(40)'])
+  D80000300030603001300
+
+You probably noticed the first time we printed ``cmds`` that the command parameters
+``params`` were all listed as ``N/A`` (Not Available).  What happens if we print the
+table again:
+
+  >>> print(cmds)
+           date            type      tlmsid   scs step timeline_id                      params
+  --------------------- ---------- ---------- --- ---- ----------- -----------------------------------------------
+  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988                                             N/A
+  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990                                             N/A
+  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990                                             N/A
+  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990                                             N/A
+  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990                                             N/A
+  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991 cmds=3 packet(40)=D80000300030603001300 words=3
+  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991                                             N/A
+  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990                                             N/A
+
+So what happened?  The answer is that for performance reasons the |CommandTable| class is
+lazy about loading the command parameters, and only does so when you directly request the
+parameter value (as we did with ``packet(40)``).  If you want to just fetch them all
+at once you can do so with the ``fetch_params()`` method::
+
+  >>> cmds.fetch_params()
+  >>> print(cmds)
+           date            type      tlmsid   scs step timeline_id                      params
+  --------------------- ---------- ---------- --- ---- ----------- -----------------------------------------------
+  2013:001:00:37:37.653   ORBPOINT       None   0    0   426098988                              event_type=EQF013M
+  2013:001:00:53:07.181 COMMAND_SW   AOACRSTD 129 1524   426098990                       hex=8032000 msid=AOACRSTD
+  2013:001:00:54:07.181 COMMAND_SW   AOFUNCDS 129 1526   426098990           aopcadsd=21 hex=8030215 msid=AOFUNCDS
+  2013:001:00:55:07.181 COMMAND_SW   AOFUNCDS 129 1528   426098990           aopcadsd=32 hex=8030220 msid=AOFUNCDS
+  2013:001:00:56:07.181 COMMAND_SW   AONMMODE 129 1530   426098990                       hex=8030402 msid=AONMMODE
+  2013:001:00:56:07.181    ACISPKT AA00000000 132 1620   426098991 cmds=3 packet(40)=D80000300030603001300 words=3
+  2013:001:00:56:07.181   SIMTRANS       None 132 1623   426098991                                      pos=-99616
+  2013:001:00:56:07.438 COMMAND_SW   AONM2NPE 129 1532   426098990                       hex=8030601 msid=AONM2NPE
+
+Finally, note that you can request the value of an attribute or parameter for the entire
+command table.  Note that command rows without that parameter will have a ``None`` object::
+
+  >>> print(cmds['msid'])
+    msid
+  --------
+      None
+  AOACRSTD
+  AOFUNCDS
+  AOFUNCDS
+  AONMMODE
+      None
+      None
+  AONM2NPE
+
+Notes and caveats
+^^^^^^^^^^^^^^^^^^
+
+* The exact set of load commands relies on the `Chandra commanded states database
+  <http://cxc.harvard.edu/mta/ASPECT/tool_doc/cmd_states>`_ to determine which command
+  loads ran on-board and for what duration.  This information comes from a combination of
+  the iFOT load segments database and SOT update procedures for load interrupts.  It has
+  been used operationally since 2009 and has frequent validation checking in the course of
+  thermal load review.  Nevertheless there are likely a few missing commands here and
+  there, particularly associated with load stoppages and replans.
+
+* The kadi commands archive includes all commands for approved loads.  Once loads have
+  been ingested into the database and iFOT has been updated accordingly, then the kadi
+  commands will reflect this update (within an hour).
+
+* Conversely if there is a load interrupt (SCS-107 or anomaly) then this will be reflected
+  in the commands archive within an hour after an on-call person runs a script to update
+  the `Chandra commanded states database
+  <http://cxc.harvard.edu/mta/ASPECT/tool_doc/cmd_states>`_.
+
+* Each load command has an identifier that can be used to retrieve the exact set of mission
+  planning products in which the command was generated.  This is valid even in the case
+  of a re-open replan in which a command load effectively has two source directories.
+
+* The archive includes a select set of non-load commands which result from either
+  autonomous on-board commanding (e.g. SCS-107) or real-time ground commanding
+  (e.g. anomaly recovery).  This list is not comprehensive but includes those
+  commands which typically affect mission planning continuity and thermal modeling.
+
+* The parameters for the ACA star catalog command ``AOSTRCAT`` are not included since this
+  alone would dramatically increase the database file size.  However, the commands are
+  included.
+
+* The command archive is stored in a highly performant HDF5 file backed by a
+  dictionary-based index file of unique command parameters.  As of 2018-Jan, the commands
+  archive is stored in two files with a total size about 52 Mb.

--- a/docs/commands_v2.rst
+++ b/docs/commands_v2.rst
@@ -83,8 +83,8 @@ network these files are brought up to date each 10 minutes by a cron jobs, so
 using ``"flight"`` in this case is a reliable way to eliminate dependence on the
 kadi external web resources.
 
-Using the ``"flight"`` scenario is also recommended for use on GRETA
-workstations since they cannot access the Chandra Command Events Google sheet.
+Using the ``"flight"`` scenario is also recommended for use on some GRETA
+workstations if they cannot access the Chandra Command Events Google sheet.
 
 Custom scenario example
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -141,7 +141,6 @@ of the 2021:296 NSM recovery::
 Then from the bash command line::
 
     $ export KADI_SCENARIO=nsm-cti
-    $ export PYTHONPATH=$HOME/git/kadi:$HOME/git/parse_cm  # for Ska3 2022.2
     $ dpa_check \
         --outdir=out-cti \
         --oflsdir=DAWG-demo/OCT2521/oflsb \
@@ -177,7 +176,7 @@ The available options with the default settings are as follows::
 
     ## Default version of kadi commands ("1" or "2").  Overridden by
     ## KADI_COMMANDS_VERSION environment variable.
-    commands_version = 1
+    commands_version = 2
 
     ## Google Sheet ID for command events (flight scenario).
     cmd_events_flight_id = 19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ
@@ -206,8 +205,8 @@ You can also temporarily change an option within a context manager::
     >>> cmds1 = get_cmds('2022:001', '2022:002')  # Use commands v1
 
 For an even-more permanent solution you can write out the configuration file
-to disk and then edit it. This could be a good option if you want to always
-use commands version v2 for testing purposes.
+to disk and then edit it. Be wary of "temporarily" changing an option and  then
+forgetting to revert it later.
 
     >>> import kadi
     >>> status = kadi.create_config_file()

--- a/kadi/commands/__init__.py
+++ b/kadi/commands/__init__.py
@@ -39,7 +39,7 @@ class Conf(ConfigNamespace):
         "downloading from Google Sheets and OCCweb.",
     )
     commands_version = ConfigItem(
-        "1",
+        "2",
         'Default version of kadi commands ("1" or "2").  Overridden by '
         "KADI_COMMANDS_VERSION environment variable.",
     )

--- a/kadi/commands/commands_v1.py
+++ b/kadi/commands/commands_v1.py
@@ -1,9 +1,14 @@
+import warnings
 import weakref
 
 from astropy.table import Column
 from cxotime import CxoTime
 
 from kadi.commands.core import LazyVal, _find, load_idx_cmds, load_pars_dict
+
+# Warn about deprecation but use FutureWarning so it actually shows up (since
+# DeprecationWarning is ignored by default)
+warnings.warn("kadi commands v1 is deprecated, use v2 instead", FutureWarning)
 
 # Globals that contain the entire commands table and the parameters index
 # dictionary.

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ filterwarnings =
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore:'soft_unicode' has been renamed to 'soft_str'
     ignore:`np.object` is a deprecated alias for the builtin `object`
-
+    ignore:kadi commands v1 is deprecated, use v2 instead:FutureWarning


### PR DESCRIPTION
## Description

This makes commands v2 the default and thus v1 is now the backup.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
There are API changes that have been widely discussed in informational forums. In particular getting commands may try using network resources by default.

The new version of commands archive files generated with PR #248 should be installed into `$SKA/data/kadi` on HEAD when kadi commands v2 is promoted via a new ska3-flight release. Those files are in `/home/aldcroft/tmp/kadi` on HEAD.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
