### PR TITLE
Fix problem where starcat_date can be uninitialized

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -679,12 +679,13 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     :returns: CommandTable of OBS commands with all parameters filled in.
     """
     # Initialize state variables. Note that the first OBS command may end up
-    # with None values for some of these, but this is OK because of the command
+    # with bogus values for some of these, but this is OK because of the command
     # merging with the archive commands which are always correct. Nevertheless
     # use values that are not None to avoid errors. For `sim_pos`, if the SIM
     # has not been commanded in a long time then it will be at -99616.
     obsid = -1
     starcat_idx = -1
+    starcat_date = "1999:001:00:00:00.000"
     sim_pos = -99616
     obs_params = None
     cmd_obs_extras = []


### PR DESCRIPTION
## Description

Fixes this problem, which likely won't be reproducible in the future because it depends on running about 20-30 days after day 2022:232.
```
from kadi.commands import states
tstart = '2022:140'
tstop = '2022:245'
keys = ['pitch', 'off_nom_roll', 'ccd_count', 'fep_count', 'clocking', 'vid_board', 'pcad_mode', 'simpos'] 
state_data = states.get_states(tstart, tstop, state_keys=keys, merge_identical=True)
```
Output:
```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
/var/folders/dy/fgd_00hx3t74rh7tfkw5btqw0000gn/T/ipykernel_7931/4291996280.py in <module>
      4 tstop = '2022:245'
      5 keys = ['pitch', 'off_nom_roll', 'ccd_count', 'fep_count', 'clocking', 'vid_board', 'pcad_mode', 'simpos']
----> 6 state_data = states.get_states(tstart, tstop, state_keys=keys, merge_identical=True)

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/states.py in get_states(start, stop, state_keys, cmds, continuity, reduce, merge_identical, scenario)
   1320         if start is None:
   1321             raise ValueError("must supply either 'cmds' argument or 'start' argument")
-> 1322         cmds = commands.get_cmds(start, stop, scenario=scenario)
   1323         start = DateTime(start).date
   1324         stop = DateTime(stop or cmds[-1]['date']).date  # User-supplied stop or last command

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/commands.py in get_cmds(start, stop, inclusive_stop, scenario, **kwargs)
     52         from kadi.commands.commands_v1 import get_cmds as get_cmds_
     53 
---> 54     cmds = get_cmds_(start=start, stop=stop,
     55                      inclusive_stop=inclusive_stop,
     56                      **kwargs)

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/commands_v2.py in get_cmds(start, stop, inclusive_stop, scenario, **kwargs)
    215     else:
    216         if scenario not in CMDS_RECENT:
--> 217             cmds_recent = update_archive_and_get_cmds_recent(
    218                 scenario, cache=True,
    219                 pars_dict=PARS_DICT, rev_pars_dict=REV_PARS_DICT)

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/commands_v2.py in update_archive_and_get_cmds_recent(scenario, lookback, stop, cache, pars_dict, rev_pars_dict)
    371     cmds_recent.deduplicate_orbit_cmds()
    372     cmds_recent.remove_not_run_cmds()
--> 373     cmds_recent = add_obs_cmds(cmds_recent, pars_dict, rev_pars_dict)
    374 
    375     if cache:

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/commands_v2.py in add_obs_cmds(cmds, pars_dict, rev_pars_dict, prev_att)
    419     # `pars_dict` and `rev_pars_dict` in place.
    420     cmds_state_obs = cmds_state.add_cmds(cmds_obs)
--> 421     cmds_obs = get_cmds_obs_final(cmds_state_obs, pars_dict, rev_pars_dict,
    422                                   schedule_stop_time)
    423 

~/opt/miniconda3/envs/ska3/lib/python3.8/site-packages/kadi/commands/commands_v2.py in get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time)
    677             if obs_params['npnt_enab']:
    678                 obs_params['starcat_idx'] = starcat_idx
--> 679                 obs_params['starcat_date'] = starcat_date
    680 
    681         elif (tlmsid in ('AONMMODE', 'AONSMSAF')

UnboundLocalError: local variable 'starcat_date' referenced before assignment
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The original exception is no longer seen with this fix. Without the fix on master I can reproduce the issue.
