### PR TITLE
Better star catalog handling

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -684,8 +684,8 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     # use values that are not None to avoid errors. For `sim_pos`, if the SIM
     # has not been commanded in a long time then it will be at -99616.
     obsid = -1
-    starcat_idx = -1
-    starcat_date = "1999:001:00:00:00.000"
+    starcat_idx = None
+    starcat_date = None
     sim_pos = -99616
     obs_params = None
     cmd_obs_extras = []
@@ -734,8 +734,14 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
             obs_params["simpos"] = sim_pos  # matches states 'simpos'
             obs_params["obs_start"] = cmd["date"]
             if obs_params["npnt_enab"]:
-                obs_params["starcat_idx"] = starcat_idx
-                obs_params["starcat_date"] = starcat_date
+                if starcat_idx is not None and starcat_date is not None:
+                    obs_params["starcat_idx"] = starcat_idx
+                    obs_params["starcat_date"] = starcat_date
+                else:
+                    logger.warning(
+                        f"WARNING: no starcat for obsid {obsid} at {cmd['date']} "
+                        "even though npnt_enab is True"
+                    )
 
         elif tlmsid in ("AONMMODE", "AONSMSAF") or (
             tlmsid == "AONM2NPE" and cmd["vcdu"] == -1
@@ -748,8 +754,13 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
             # obs_params will be None at that point.
             if obs_params is not None:
                 obs_params["obs_stop"] = cmd["date"]
-            # This closes out the observation
+            # This closes out the observation. Reset the star catalog state
+            # variables since a valid star catalog is always uniquely associated
+            # with an pointing observation.
             obs_params = None
+            starcat_idx = None
+            starcat_date = None
+
         elif cmd["type"] == "SIMTRANS":
             sim_pos = cmd["params"]["pos"]
 

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -738,7 +738,7 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
                     obs_params["starcat_idx"] = starcat_idx
                     obs_params["starcat_date"] = starcat_date
                 else:
-                    logger.warning(
+                    logger.info(
                         f"WARNING: no starcat for obsid {obsid} at {cmd['date']} "
                         "even though npnt_enab is True"
                     )

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -386,7 +386,7 @@ def get_starcats(
             )
             if db_key in starcats_db:
                 # From the cache
-                starcat_dict = starcats_db[db_key]
+                starcat_dict = starcats_db[db_key].copy()
                 if as_dict:
                     starcat = starcat_dict
                 else:

--- a/kadi/paths.py
+++ b/kadi/paths.py
@@ -73,4 +73,4 @@ def CMD_EVENTS_PATH(scenario=None):
 def STARCATS_CACHE_PATH():
     from kadi.commands import conf
 
-    return Path(conf.commands_dir).expanduser() / "starcats"
+    return Path(conf.commands_dir).expanduser() / "starcats_cache"


### PR DESCRIPTION
## Description

This makes a few improvements to the way star catalogs are handled in kadi commands:

#### Reset the star catalog after each observation
Previously the last commanded star catalog was kept as "continuity" for subsequent observation. This is actually how the spacecraft works which was the original motivation, but in practice the way loads are built there is always a unique new catalog associated with the end of each maneuver (when auto-transition to NPNT is enabled).

What was happening in kadi was that a stale catalog was being assigned to maneuvers during anomaly recovery. The new behavior is that such an observation gets no catalog but logs a warning that no catalog was found when one was expected.

#### Copy the cached starcat dict in case a key gets re-used
With the current flight version of `cmds2.h5` there were cases of multiple observations sharing the same star catalog. This no longer happens, but just the same this commit fixes a problem that came up getting star catalogs when caching to file was disabled.

#### Correct for MATLAB proper motion but in star identification
The comment in e4b5bda describes this in detail.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None as far as I know. Undercover observations are still the same.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac except for expected failure in test_commands_create_archive_regress for v2
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [X] Linux - tests pass except for test_commands_create_archive_regress

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### Correct for MATLAB proper motion but in star identification
With the debug code in this commit uncommented and the MATLAB PM correction **disabled** I got the output below. This shows many cases of high PM stars (mostly at higher Dec values) which have large offsets between the predicted yag/zag and the commanded catalog yag/zag.
```
In [1]: from kadi.commands import get_starcats

^PIn [2]: scs = get_starcats(start='2018:001', stop='2019:001', scenario='flight')
# date, agasc_id, obsid, dy, dz, PM_RA, PM_DEC, RA, DEC
2018:002:10:05:43.057, 499389184, 49534, 0.37, 0.52, -88, -44, 145.40025376, 57.49627126
2018:006:07:29:17.849, 324669672, 20510, 0.56, 0.64, 216, -240, 122.54782543, 35.45498248
2018:011:02:09:39.932, 376054296, 20526, 0.06, 0.81, 186, -155, 51.30444354, 42.12313055
2018:014:16:45:47.138, 1141382448, 20294, 0.19, 0.67, 60, -46, 234.50127751, -59.40689683
2018:018:18:02:05.473, 1239680712, 49476, 1.13, 0.22, -93, -128, 287.68562644, -76.40468156
2018:018:18:02:05.473, 1239681544, 49476, 0.55, 0.26, 30, -48, 285.54434051, -76.59478494
2018:019:10:03:07.000, 394533848, 19444, 0.17, 1.21, -336, 62, 166.38290562, 38.27600693
2018:020:05:33:47.476, 394533848, 20942, 0.17, 1.20, -336, 62, 166.38290562, 38.27600693
2018:021:18:12:04.101, 394533848, 20943, 0.17, 1.20, -336, 62, 166.38290562, 38.27600693
2018:022:07:58:06.045, 394533848, 20944, 0.17, 1.20, -336, 62, 166.38290562, 38.27600693
2018:025:09:22:30.079, 1051204328, 20797, 0.32, 0.59, 142, 34, 355.95816321, -43.24558054
2018:025:09:22:30.079, 1051197856, 20797, 0.13, 0.94, -194, -323, 355.46154191, -42.74886491
2018:027:04:19:45.099, 501483392, 20528, 0.90, 0.89, -169, -75, 163.11949078, 56.16555028
2018:028:08:29:02.617, 501483392, 20941, 0.91, 0.89, -169, -75, 163.11949078, 56.16555028
2018:030:20:50:14.778, 500309776, 19307, 1.14, 0.50, -174, -447, 150.40923813, 55.58508735
2018:031:16:18:57.952, 392176472, 49448, 0.68, 0.39, -219, -8, 146.52092207, 39.87094553
2018:032:02:56:55.900, 500309776, 20947, 1.13, 0.49, -174, -447, 150.40923813, 55.58508735
2018:036:01:07:00.765, 452070096, 20352, 0.53, 0.52, -130, -62, 163.2995289, 51.01456212
2018:038:20:26:27.791, 1197885328, 20641, 0.78, 0.99, 104, 48, 16.28308987, -71.73394326
2018:038:20:26:27.791, 1197885104, 20641, 0.18, 0.54, -37, -65, 17.84506653, -72.18936821
2018:042:09:59:01.055, 918685352, 49427, 0.12, 0.58, 195, 49, 33.58575677, -37.10771245
2018:042:09:59:01.055, 918699472, 49427, 0.09, 0.70, 210, 8, 32.55546815, -36.77113641
2018:044:12:12:10.974, 1197885328, 20640, 0.81, 0.97, 104, 48, 16.28308987, -71.73394326
2018:044:12:12:10.974, 1197885104, 20640, 0.19, 0.54, -37, -65, 17.84506653, -72.18936821
2018:048:12:14:10.776, 574886288, 19305, 0.58, 0.01, 46, -59, 149.95271848, 70.13962657
2022-09-14 15:09:59,654 set_star_ids: WARNING: star idx 12 not found in obsid 20282 at 2018:049:20:01:30.248
2018:050:01:42:44.654, 1098912864, 49414, 0.72, 1.11, -230, -88, 291.48413636, -49.84288513
2018:051:22:07:05.475, 1157236080, 20381, 0.83, 0.02, 87, -11, 338.97054336, -57.88375362
2018:052:10:50:12.613, 394533848, 20982, 1.14, 0.41, -336, 62, 166.38290562, 38.27600693
2018:054:09:15:46.492, 328738624, 20981, 0.92, 0.17, 263, -152, 148.16052842, 35.11164953
2018:054:16:27:46.363, 328738624, 20564, 0.92, 0.17, 263, -152, 148.16052842, 35.11164953
2018:054:21:42:33.411, 453524624, 19296, 0.47, 0.74, -175, -15, 198.19320598, 47.31328763
2018:054:21:42:33.411, 453526584, 19296, 0.51, 0.65, -169, -14, 198.30884426, 46.49395113
2018:055:20:04:17.073, 474484064, 49403, 1.07, 0.13, -175, 38, 337.77385949, 45.14510279
2018:056:06:08:19.808, 394533848, 20719, 1.13, 0.42, -336, 62, 166.38290562, 38.27600693
2018:056:22:29:37.499, 394533848, 20983, 1.13, 0.42, -336, 62, 166.38290562, 38.27600693
2018:057:05:29:28.386, 453524624, 20977, 0.47, 0.74, -175, -15, 198.19320598, 47.31328763
2018:057:05:29:28.386, 453526584, 20977, 0.51, 0.64, -169, -14, 198.30884426, 46.49395113
2018:057:15:48:31.808, 394533848, 20720, 1.19, 0.26, -336, 62, 166.38290562, 38.27600693
2022-09-14 15:10:00,076 set_star_ids: WARNING: star idx 8 not found in obsid 20994 at 2018:058:13:12:37.242
2018:058:22:51:03.214, 394533848, 20721, 1.22, 0.10, -336, 62, 166.38290562, 38.27600693
2018:059:19:47:17.985, 394533848, 20984, 1.19, 0.26, -336, 62, 166.38290562, 38.27600693
2022-09-14 15:10:00,129 set_star_ids: WARNING: star idx 8 not found in obsid 20995 at 2018:060:04:10:07.380
2018:061:04:50:45.148, 1157634096, 19756, 0.91, 0.05, 107, -51, 352.9344266, -53.76994821
2018:061:04:50:45.148, 1157635936, 19756, 0.93, 0.07, 115, -71, 353.41729947, -53.65813323
2018:061:14:51:26.992, 394533848, 20985, 1.22, 0.10, -336, 62, 166.38290562, 38.27600693
2018:064:11:05:58.678, 503191936, 19362, 1.00, 0.25, -134, -25, 178.37730689, 58.76228836
2018:065:08:56:07.017, 1157759040, 19757, 0.52, 0.05, 71, -9, 359.88390876, -52.84353665
2018:065:08:56:07.017, 1157760016, 19757, 1.11, 0.23, 145, 20, 358.35334114, -52.69979037
2018:065:08:56:07.017, 1157760048, 19757, 0.65, 0.09, 71, -23, 357.73084681, -52.74969549
2018:067:09:11:51.245, 1158024208, 19759, 0.60, 0.10, 64, -15, 352.19270653, -55.85027739
2018:067:09:11:51.245, 1158025144, 19759, 0.67, 0.04, 71, -54, 351.8416199, -55.32263527
2018:068:08:39:07.038, 1156326496, 20380, 0.67, 0.32, 84, -15, 336.6158935, -52.52540163
2018:069:11:03:13.404, 452868256, 19351, 1.41, 0.15, -284, -46, 184.39704831, 45.1686267
2018:071:16:15:10.104, 1052254272, 49378, 0.86, 0.04, 114, 38, 1.90771587, -51.95484536
2018:071:16:15:10.104, 1052256512, 49378, 0.64, 0.30, -111, -131, 1.28122483, -52.15174124
2018:071:18:22:31.452, 1197885328, 20639, 1.25, 0.48, 104, 48, 16.28308987, -71.73394326
2018:071:22:51:51.192, 1197885328, 20638, 1.25, 0.48, 104, 48, 16.28308987, -71.73394326
2018:076:15:55:38.854, 456790096, 49372, 0.30, 0.53, 85, -89, 230.80262715, 48.66066291
2018:079:16:41:57.686, 545395528, 19578, 1.32, 0.27, 115, -90, 186.90526056, 65.25401562
2018:081:07:39:52.608, 504105784, 20760, 0.60, 0.11, -94, -30, 197.07841921, 55.65341612
2018:081:07:39:52.608, 504106680, 20760, 0.52, 0.07, -89, 47, 196.04587101, 55.72372739
2018:082:02:48:51.192, 989201840, 49362, 0.86, 0.25, 161, 61, 20.05790137, -43.91592871
2018:082:02:48:51.192, 989209464, 49362, 0.62, 0.18, 123, 36, 20.60122751, -43.60255698
2018:085:19:40:50.470, 331354344, 21005, 0.85, 0.00, -356, -239, 186.32710732, 31.86425139
2018:087:08:50:12.190, 987896456, 49354, 0.62, 0.16, 133, -64, 19.47618699, -41.58821758
2022-09-14 15:10:01,287 set_star_ids: WARNING: star idx 6 not found in obsid 49348 at 2018:092:20:15:54.223
2018:094:23:19:08.344, 433077392, 49347, 0.65, 0.54, 145, -52, 41.43159431, 50.60731815
2018:096:16:20:06.436, 391389880, 20430, 0.06, 0.60, -115, -183, 136.11677574, 40.59736925
2018:099:05:49:11.103, 452342656, 20759, 0.46, 0.52, -122, -218, 169.61024753, 45.86607159
2018:099:17:04:16.436, 502669496, 19357, 0.99, 0.55, -145, -78, 174.70051164, 55.11352941
2018:100:12:32:52.369, 439878160, 49328, 0.22, 0.51, 101, -133, 74.48400108, 52.11216685
2018:100:12:32:52.369, 439881832, 49328, 0.27, 0.51, -64, -18, 74.05499793, 51.75215781
2018:100:19:39:05.770, 528506400, 49314, 0.73, 0.10, 84, -63, 28.40743714, 60.98999306
2018:104:06:56:52.816, 544874592, 19383, 0.83, 0.38, -94, 11, 181.16367215, 62.97293223
2018:104:06:56:52.816, 544474032, 19383, 0.75, 0.47, -98, -11, 180.0402825, 61.96594966
2018:104:16:59:32.817, 503057448, 19342, 0.65, 0.48, -93, -47, 176.83487619, 57.93384136
2018:104:16:59:32.817, 503058768, 19342, 1.19, 0.76, -165, -14, 176.47069405, 58.02746736
2022-09-14 15:10:02,003 set_star_ids: WARNING: star idx 7 not found in obsid 49306 at 2018:105:14:18:08.562
2018:105:23:52:40.041, 482086552, 49301, 0.83, 0.16, 112, -99, 21.11296366, 57.85170541
2018:105:23:52:40.041, 481963448, 49301, 0.65, 0.11, 85, -9999, 19.87049098, 57.34593471
2018:105:23:52:40.041, 481959824, 49301, 0.52, 0.14, 67, -29, 19.55523217, 57.70084835
2018:109:07:56:44.579, 393610288, 19637, 0.15, 0.51, -102, -15, 151.53889936, 41.0904039
2018:118:09:46:52.686, 986453000, 20136, 0.71, 0.52, 183, 6, 1.85587193, -40.47957216
2018:119:21:45:21.185, 452466880, 20354, 0.51, 0.60, -126, -9999, 179.64168893, 46.44144286
2018:120:14:16:39.953, 522200440, 20586, 0.00, 0.59, 62, -45, 340.18336433, 53.91734466
2018:121:03:08:47.808, 522200440, 21086, 0.01, 0.58, 62, -45, 340.18336433, 53.91734466
2018:121:23:44:12.160, 565190480, 49272, 1.28, 0.10, 125, -91, 39.87687236, 67.67509112
2018:122:09:01:50.392, 522200440, 21087, 0.00, 0.59, 62, -45, 340.18336433, 53.91734466
2018:122:23:10:07.634, 522200440, 21088, 0.00, 0.59, 62, -45, 340.18336433, 53.91734466
2018:124:13:53:04.470, 564790288, 49267, 0.59, 0.42, 56, -14, 19.61337841, 74.99920615
2022-09-14 15:10:02,803 set_star_ids: WARNING: star idx 1 not found in obsid 49266 at 2018:126:17:02:56.547
2018:126:17:02:56.547, 588776832, 49266, 0.52, 0.64, 56, -13, 5.64258451, 75.06650358
2018:126:17:02:56.547, 588776808, 49266, 0.50, 0.66, 55, -9999, 4.84761408, 75.23692103
2018:127:07:10:19.182, 522200440, 21089, 0.00, 0.59, 62, -45, 340.18336433, 53.91734466
2018:128:22:43:21.590, 506208544, 19376, 0.87, 0.26, -113, -11, 217.71296556, 56.24943176
2018:132:06:29:56.058, 1152264272, 49256, 0.18, 0.66, 74, -213, 310.11698468, -54.02009116
2018:132:06:29:56.058, 1152265168, 49256, 0.17, 0.84, 101, -43, 310.63345251, -54.22842747
2018:132:06:29:56.058, 1152649896, 49256, 0.10, 0.72, 77, -24, 309.86624886, -54.74459595
2018:132:14:03:28.665, 1032462424, 20309, 0.72, 0.69, -199, -320, 257.03041836, -41.72397413
2018:135:15:52:08.898, 525732232, 19605, 0.22, 1.17, 132, -110, 351.66954967, 58.75701183
2018:136:07:57:25.596, 1032462424, 20308, 0.73, 0.69, -199, -320, 257.03041836, -41.72397413
2018:138:06:55:05.960, 1032462424, 21093, 0.73, 0.69, -199, -320, 257.03041836, -41.72397413
2018:139:03:09:30.359, 1153182688, 20373, 0.15, 0.53, -75, -110, 306.97563095, -57.64481388
2022-09-14 15:10:03,332 set_star_ids: WARNING: star idx 12 not found in obsid 20373 at 2018:139:03:09:30.359
2018:139:06:30:13.659, 1032462424, 21094, 0.73, 0.69, -199, -320, 257.03041836, -41.72397413
2018:140:12:31:34.863, 1032462424, 21095, 0.73, 0.69, -199, -320, 257.03041836, -41.72397413
```
With the proper motion correction enabled then the same command results in no output, meaning no stars had a residual of over 0.5 arcsec in the identification process.

#### Reset star catalog after each observation
Here is a test script asking for the observation and star catalog for the ground-commanded maneuver after the 2022:223 BSH:
```
import os
import pprint

import kadi
from kadi.commands import commands_v2, conf, get_observations, get_starcats
print(kadi.__version__)

os.environ["KADI_COMMANDS_DEFAULT_STOP"] = "2022:225"

obss = get_observations(start="2022:224", stop="2022:225")
starcats = get_starcats(start="2022:224", stop="2022:225")

pprint.pprint(obss[0])
if len(starcats) > 0:
    print(starcats[0])
else:
    print("No starcats")
```
**New version** (correct behavior, no catalog since the ground FOT request for the star catalog is not in the archive)
```
6.0.2.dev37+ge4b5bda
2022-09-14 15:57:30,847 get_cmds_obs_final: WARNING: no starcat for obsid 45339 at 2022:224:02:40:48.033 even though npnt_enab is True
2022-09-14 15:57:30,853 get_cmds_obs_final: WARNING: no starcat for obsid 62624 at 2022:232:20:32:28.838 even though npnt_enab is True
{'manvr_start': '2022:224:02:25:10.250',
 'npnt_enab': True,
 'obs_start': '2022:224:02:40:48.033',
 'obs_stop': '2022:225:11:40:00.000',
 'obsid': 45339,
 'prev_att': (-0.12752005, 0.556391476, -0.351473717, 0.742046756),
 'simpos': -99616,
 'source': 'CMD_EVT',
 'targ_att': (-0.24849372, 0.40954561, -0.31440262, 0.81955735)}
No starcats
```
**Flight** (previously catalog erroneously assigned)
```
6.0.1
{'manvr_start': '2022:224:02:25:10.250',
 'npnt_enab': True,
 'obs_start': '2022:224:02:40:48.033',
 'obs_stop': '2022:226:19:15:48.867',
 'obsid': 45339,
 'prev_att': (-0.12752005, 0.556391476, -0.351473717, 0.742046756),
 'simpos': -99616,
 'source': 'CMD_EVT',
 'starcat_date': '2022:223:12:40:40.435',
 'starcat_idx': 210963,
 'targ_att': (-0.24849372, 0.40954561, -0.31440262, 0.81955735)}
slot idx  id  type  sz   mag   maxmag   yang     zang   dim res halfw
---- --- ---- ---- --- ------- ------ -------- -------- --- --- -----
   0   1 -999  BOT 8x8 -999.00   9.59  1212.41 -1350.77  28   1   160
   1   2 -999  BOT 8x8 -999.00   9.62  2168.73  1279.76  28   1   160
   2   3 -999  BOT 8x8 -999.00   9.78  1536.77  1539.88  28   1   160
   3   4 -999  BOT 8x8 -999.00   9.80   598.36  -367.62  28   1   160
   4   5 -999  BOT 8x8 -999.00  10.14 -1781.69 -1097.56  28   1   160
   5   6 -999  BOT 8x8 -999.00  10.41 -1903.52  -388.59  28   1   160
   6   7 -999  GUI 8x8 -999.00  10.59   -54.92 -1994.45   1   1    25
   7   8 -999  GUI 8x8 -999.00  10.61 -2046.92 -1376.66   1   1    25
   6   9 -999  ACQ 8x8 -999.00  10.00 -1393.27  -659.29  28   1   160
   7  10 -999  ACQ 8x8 -999.00  10.27 -1755.56 -2008.82  28   1   160
```
#### Copy the cached starcat dict in case a key gets re-used

I don't remember how to reproduce this, but at some point it came up (`KeyError` trying to do `starcat_dict.pop("meta")`) and this changed fixed it.