### PR TITLE
Fix unit test failure for final v2 cmds

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -727,7 +727,6 @@ def test_get_observations_by_obsid_multi():
                 -0.4661410647781301,
                 0.47332803366853643,
             ),
-            "starcat_date": "2019:248:14:52:31.156",
             "source": "CMD_EVT",
         },
     ]


### PR DESCRIPTION
## Description

The cmds v2 archive was regenerated using version 7.0.0 with `migrate_cmds_to_cmds2.py`. Using this new file the unit tests pass (in particular the `create_archive` one for v2), except for the test that is fixed here.

This change is expected/desired because the observation in question previously had the *wrong* `starcat_date` associated with it. This obs was really a ground-commanded maneuver with a custom starcat that is not captured by the commands archive. Leaving the starcat as undefined is the right thing in this case.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

Make a directory to store kadi archive files. From within that directory:
```
ln -s /proj/sot/ska/data/kadi/cmds-v7.0.x/cmds2.* ./
ln -s /proj/sot/ska/data/kadi/cmds.* ./
ln -s /proj/sot/ska/data/kadi/events3.db3 ./

export KADI=$PWD
```
Then run unit tests.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [X] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
