### PR TITLE
Suppress v1 FutureWarning for testing

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 
 import astropy.units as u
@@ -12,6 +13,12 @@ from astropy.table import Table, vstack
 from Chandra.Time import secs2date
 from cxotime import CxoTime
 from testr.test_helper import has_internet
+
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    message="kadi commands v1 is deprecated, use v2 instead",
+)
 
 from kadi import commands
 from kadi.commands import (

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -2,6 +2,7 @@ import functools
 import gzip
 import hashlib
 import os
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -11,6 +12,12 @@ from astropy.table import Table
 from Chandra.Time import DateTime
 from Ska.engarchive import fetch
 from testr.test_helper import has_internet
+
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    message="kadi commands v1 is deprecated, use v2 instead",
+)
 
 from kadi import commands
 from kadi.commands import states

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,3 @@ filterwarnings =
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore:'soft_unicode' has been renamed to 'soft_str'
     ignore:`np.object` is a deprecated alias for the builtin `object`
-    ignore:kadi commands v1 is deprecated, use v2 instead:FutureWarning


### PR DESCRIPTION
## Description

For testing it is still allowed to import and use commands v1.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Using this branch with v7.0 version of the cmds2.* files passes `pytest` unit tests and does not issue any warning messages at the end.

If I change the `message=...` to something that does not match then I confirm the warnings are flagged by pytest.
