### PR TITLE
Add HRC states: 15v on, HRC-I on, HRC-S on

### DIFF
--- a/docs/commands_states.rst
+++ b/docs/commands_states.rst
@@ -715,6 +715,26 @@ classes which affect the keys.
 ``ephem_update``
   - :class:`~kadi.commands.states.EphemerisUpdateTransition`
 
+``format``
+  - :class:`~kadi.commands.states.Format1_Transition`
+  - :class:`~kadi.commands.states.Format2_Transition`
+  - :class:`~kadi.commands.states.Format3_Transition`
+  - :class:`~kadi.commands.states.Format4_Transition`
+  - :class:`~kadi.commands.states.Format5_Transition`
+  - :class:`~kadi.commands.states.Format6_Transition`
+
+``hrc_15v``
+  - :class:`~kadi.commands.states.Hrc15vOff_Transition`
+  - :class:`~kadi.commands.states.Hrc15vOn_Transition`
+
+``hrc_i``
+  - :class:`~kadi.commands.states.HrcIOff_Transition`
+  - :class:`~kadi.commands.states.HrcIOn_Transition`
+
+``hrc_s``
+  - :class:`~kadi.commands.states.HrcSOff_Transition`
+  - :class:`~kadi.commands.states.HrcSOn_Transition`
+
 ``letg``, ``hetg``, ``grating``
   - :class:`~kadi.commands.states.HETG_INSR_Transition`
   - :class:`~kadi.commands.states.HETG_RETR_Transition`
@@ -754,6 +774,12 @@ classes which affect the keys.
 
 ``simpos``
   - :class:`~kadi.commands.states.SimTscTransition`
+
+``subformat``
+  - :class:`~kadi.commands.states.SubFormatEPS_Transition`
+  - :class:`~kadi.commands.states.SubFormatNRM_Transition`
+  - :class:`~kadi.commands.states.SubFormatPDG_Transition`
+  - :class:`~kadi.commands.states.SubFormatSSR_Transition`
 
 ``sun_pos_mon``
   - :class:`~kadi.commands.states.SPMDisableTransition`

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -554,6 +554,69 @@ class SimFocusTransition(ParamTransition):
 
 
 ###################################################################
+# HRC transitions
+###################################################################
+
+
+class Hrc15vOn_Transition(FixedTransition):
+    """HRC 15V ON"""
+
+    command_attributes = {"tlmsid": "215PCAON"}
+    state_keys = ["hrc_15v"]
+    transition_key = "hrc_15v"
+    transition_val = "ON"
+
+
+class Hrc15vOff_Transition(FixedTransition):
+    """HRC 15V OFF"""
+
+    command_attributes = {"tlmsid": "215PCAOF"}
+    state_keys = ["hrc_15v"]
+    transition_key = "hrc_15v"
+    transition_val = "OFF"
+
+
+class HrcIOn_Transition(FixedTransition):
+    """HRC-I ON"""
+
+    command_attributes = {"tlmsid": "COENASX", "coenas1": 89}
+    state_keys = ["hrc_i"]
+    transition_key = "hrc_i"
+    transition_val = "ON"
+
+
+class HrcIOff_Transition(FixedTransition):
+    """HRC-I OFF"""
+
+    command_attributes = {
+        "tlmsid": "215PCAOF",
+    }
+    state_keys = ["hrc_i"]
+    transition_key = "hrc_i"
+    transition_val = "OFF"
+
+
+class HrcSOn_Transition(FixedTransition):
+    """HRC-S ON"""
+
+    command_attributes = {"tlmsid": "COENASX", "coenas1": 90}
+    state_keys = ["hrc_s"]
+    transition_key = "hrc_s"
+    transition_val = "ON"
+
+
+class HrcSOff_Transition(FixedTransition):
+    """HRC-S OFF"""
+
+    command_attributes = {
+        "tlmsid": "215PCAOF",
+    }
+    state_keys = ["hrc_s"]
+    transition_key = "hrc_s"
+    transition_val = "OFF"
+
+
+###################################################################
 # OBC etc transitions
 ###################################################################
 

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -896,9 +896,9 @@ class SunVectorTransition(BaseTransition):
 
         :returns: None
         """
-        # np.ceil is used here to get 'times' between start/stop at even increments of
-        # "sample_time" so that the commands will be at the same times in an interval even if
-        # a different time range is being updated.
+        # np.ceil is used here to get 'times' between start/stop at even
+        # increments of "sample_time" so that the commands will be at the same
+        # times in an interval even if a different time range is being updated.
         sample_time = 10000
         tstart = np.ceil(DateTime(start).secs / sample_time) * sample_time
         tstop = DateTime(stop).secs
@@ -1296,7 +1296,8 @@ class ACISTransition(BaseTransition):
             elif tlmsid.startswith("WC"):
                 transitions[date].update(si_mode="CC_" + tlmsid[2:7])
 
-            # Two special-case raw-mode SI modes (https://github.com/sot/cmd_states/issues/23)
+            # Two special-case raw-mode SI modes
+            # (https://github.com/sot/cmd_states/issues/23)
             elif tlmsid == "WT000B5024":
                 transitions[date].update(si_mode="TN_000B4")
 
@@ -1772,9 +1773,10 @@ def get_continuity(
             # continuity as possible from last state (corresponding to the state after the
             # last command in cmds).
             try:
-                # Note that we need to specify start and stop to ensure that the states span
-                # the required time range. Without this the time range of cmds is used which
-                # can give unexpected outputs if ``date``` is within a maneuver.
+                # Note that we need to specify start and stop to ensure that the
+                # states span the required time range. Without this the time
+                # range of cmds is used which can give unexpected outputs if
+                # ``date``` is within a maneuver.
                 states = get_states(
                     state_keys=state_key,
                     cmds=cmds,
@@ -1788,8 +1790,8 @@ def get_continuity(
                 # No transitions within `cmds` for state_key, continue with other keys
                 continue
             else:
-                # get_states() sets this meta value with a list of transitions that were beyond
-                # the stop time and did not get processed.
+                # get_states() sets this meta value with a list of transitions
+                # that were beyond the stop time and did not get processed.
                 continuity_transitions.extend(states.meta["continuity_transitions"])
 
             colnames = set(states.colnames) - set(
@@ -1822,9 +1824,8 @@ def get_continuity(
         if missing_keys:
             raise ValueError(
                 "did not find transitions for state key(s)"
-                " {} within {} days of {}.  Maybe adjust the `lookbacks` argument?".format(
-                    missing_keys, lookbacks[-1], stop.date
-                )
+                " {} within {} days of {}.  Maybe adjust the "
+                "`lookbacks` argument?".format(missing_keys, lookbacks[-1], stop.date)
             )
 
     # Finally reduce down to the state_keys the user requested

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -365,6 +365,7 @@ def stop_date_fixture_factory(stop_date):
         cmds_dir = Path(conf.commands_dir) / stop_date
         with commands_v2.conf.set_temp("commands_dir", str(cmds_dir)):
             yield
+        commands_v2.clear_caches()
 
     return stop_date_fixture
 

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -492,7 +492,8 @@ def test_get_continuity_regress():
             assert np.isclose(continuity[key], val, rtol=0, atol=1e-7)
         assert continuity["__dates__"][key] == dates[key]
         assert continuity["__dates__"][key] < "2018:001:12:00:00.000"
-        # Transitions with no spacecraft command (instead from injected maneuver state breaks)
+        # Transitions with no spacecraft command (instead from injected maneuver
+        # state breaks)
         manvr_keys = (
             "pitch",
             "off_nom_roll",
@@ -996,7 +997,7 @@ def test_backstop_sun_pos_mon_lunar():
     2017:087:08:10:35.838 ORBPOINT    scs=0 step=0 timeline_id=426102503 event_type=LSPEXIT
 
     We expect SPM enable at the LSPEXIT time + 11 minutes = 2017:087:08:21:35.838
-    """
+    """  # noqa
     history = """
       datestart              datestop       sun_pos_mon
 2017:087:03:04:02.242 2017:087:07:21:40.189        DISA
@@ -1622,17 +1623,17 @@ def test_grating_motion_states():
     del sts["tstart"]
     del sts["tstop"]
     exp = [
-        "      datestart              datestop          letg      hetg   grating  trans_keys ",
-        "--------------------- --------------------- --------- --------- ------- ------------",
-        "2021:227:12:00:00.000 2021:227:23:06:03.276      RETR      RETR    NONE             ",
-        "2021:227:23:06:03.276 2021:227:23:08:40.276      RETR INSR_MOVE    HETG grating,hetg",
-        "2021:227:23:08:40.276 2021:228:08:15:00.722      RETR      INSR    HETG         hetg",
-        "2021:228:08:15:00.722 2021:228:08:17:33.722      RETR RETR_MOVE    NONE grating,hetg",
-        "2021:228:08:17:33.722 2021:229:17:41:45.525      RETR      RETR    NONE         hetg",
-        "2021:229:17:41:45.525 2021:229:17:45:08.525 INSR_MOVE      RETR    LETG grating,letg",
-        "2021:229:17:45:08.525 2021:230:00:37:56.002      INSR      RETR    LETG         letg",
-        "2021:230:00:37:56.002 2021:230:00:41:19.002 RETR_MOVE      RETR    NONE grating,letg",
-        "2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg",
+        "      datestart              datestop          letg      hetg   grating  trans_keys ",  # noqa
+        "--------------------- --------------------- --------- --------- ------- ------------",  # noqa
+        "2021:227:12:00:00.000 2021:227:23:06:03.276      RETR      RETR    NONE             ",  # noqa
+        "2021:227:23:06:03.276 2021:227:23:08:40.276      RETR INSR_MOVE    HETG grating,hetg",  # noqa
+        "2021:227:23:08:40.276 2021:228:08:15:00.722      RETR      INSR    HETG         hetg",  # noqa
+        "2021:228:08:15:00.722 2021:228:08:17:33.722      RETR RETR_MOVE    NONE grating,hetg",  # noqa
+        "2021:228:08:17:33.722 2021:229:17:41:45.525      RETR      RETR    NONE         hetg",  # noqa
+        "2021:229:17:41:45.525 2021:229:17:45:08.525 INSR_MOVE      RETR    LETG grating,letg",  # noqa
+        "2021:229:17:45:08.525 2021:230:00:37:56.002      INSR      RETR    LETG         letg",  # noqa
+        "2021:230:00:37:56.002 2021:230:00:41:19.002 RETR_MOVE      RETR    NONE grating,letg",  # noqa
+        "2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg",  # noqa
     ]
     assert sts.pformat_all() == exp
 

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1637,6 +1637,30 @@ def test_grating_motion_states():
     assert sts.pformat_all() == exp
 
 
+def test_hrc_states():
+    sts = states.get_states(
+        start="2022:140",
+        stop="2022:280",
+        state_keys=["hrc_15v", "hrc_i", "hrc_s"],
+        merge_identical=True,
+        continuity={"hrc_15v": "OFF", "hrc_i": "OFF", "hrc_s": "OFF"},
+    )
+    del sts["tstart"]
+    del sts["tstop"]
+    exp = [
+        "      datestart              datestop       hrc_15v hrc_i hrc_s   trans_keys ",
+        "--------------------- --------------------- ------- ----- ----- -------------",
+        "2022:140:00:00:00.000 2022:237:18:50:01.000     OFF   OFF   OFF              ",
+        "2022:237:18:50:01.000 2022:237:18:52:49.000      ON   OFF   OFF       hrc_15v",
+        "2022:237:18:52:49.000 2022:237:21:45:53.000      ON    ON   OFF         hrc_i",
+        "2022:237:21:45:53.000 2022:263:17:20:01.000     OFF   OFF   OFF hrc_15v,hrc_i",
+        "2022:263:17:20:01.000 2022:263:17:22:42.000      ON   OFF   OFF       hrc_15v",
+        "2022:263:17:22:42.000 2022:263:21:36:06.000      ON   OFF    ON         hrc_s",
+        "2022:263:21:36:06.000 2022:280:00:00:00.000     OFF   OFF   OFF hrc_15v,hrc_s",
+    ]
+    assert sts.pformat_all() == exp
+
+
 def test_early_start_exception():
     with pytest.raises(
         ValueError, match="no continuity found for start='2002:001:00:00:00.000'"

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -136,9 +136,10 @@ def get_ifot(
 
 
 def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
-    """Put the ``local_files`` onto lucky in /``user``/``ftp_dirname``. First put it at the top
-    level, then when complete move it into a subdir eng_archive.  This lets the OCC side
-    just watch for fully-uploaded files in that directory.
+    """Put the ``local_files`` onto lucky in /``user``/``ftp_dirname``.
+    First put it at the top level, then when complete move it into a subdir
+    eng_archive.  This lets the OCC side just watch for fully-uploaded files in
+    that directory.
 
     The directory paths of ``local_files`` are stripped off so they all wind up
     in a flat structure within ``ftp_dirname``.


### PR DESCRIPTION
## Description

In support of HRC operations and load review checking (in particular https://github.com/acisops/acis_thermal_check/pull/54), this adds three new HRC commanded state variables: `hrc_15v`, `hrc_i` and `hrc_v`. All three have state values of `OFF` or `ON`.

I regenerated the list of available commanded states in the documentation and found a few previously-added states that were not reflected in the docs.

A bug in the testing code was also discovered and fixed, namely that the fixture for temporarily setting the effective processing stop date was not clearing the commands cache at the end. This meant that subsequent tests were running with a truncated commands archive.

Finally, this PR cleans up a bunch of flake8 warnings related to line length.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
- [x] Used in integration testing with https://github.com/acisops/acis_thermal_check/pull/54.
