### PR TITLE
Make noodle path be case insensitive

### DIFF
--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -253,8 +253,11 @@ def get_occweb_page(
         path = path.replace("\\", "/")
         if path.startswith("//noodle/"):
             for noodle_prefix, occweb_prefix in NOODLE_OCCWEB_MAP.items():
-                if path.startswith(noodle := "//noodle/" + noodle_prefix):
-                    path = path.replace(noodle, ROOTURL + "/" + occweb_prefix)
+                noodle = "//noodle/" + noodle_prefix
+                if re.match(noodle, path, re.IGNORECASE):
+                    path = re.sub(
+                        noodle, ROOTURL + "/" + occweb_prefix, path, flags=re.IGNORECASE
+                    )
                     break
             else:
                 raise ValueError(f"unrecognized noodle path: {path}")

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -115,11 +115,15 @@ def test_get_occweb_dir(str_or_Path, cache):
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
+@pytest.mark.parametrize("lowercase", [False, True])
 @pytest.mark.parametrize("backslash", [True, False])
-def test_get_occweb_noodle(backslash):
+def test_get_occweb_noodle(lowercase, backslash):
     """Test get_occweb_dir and get_occweb_page (which is called in the process)
     for a noodle directory"""
-    path = "//noodle/FOT/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR"
+    noodle = "//noodle/FOT"
+    if lowercase:
+        noodle = noodle.lower()
+    path = f"{noodle}/mission_planning/PRODUCTS/APPR_LOADS/2000/MAR"
     if backslash:
         path = path.replace("/", "\\")
     files_path = occweb.get_occweb_dir(path)
@@ -133,6 +137,15 @@ def test_get_occweb_noodle(backslash):
         "       MAR2600C/ 2002-04-30 13:38    -",
     ]
     assert files_path.pformat_all() == exp
+
+
+@pytest.mark.parametrize("noodle_path", occweb.NOODLE_OCCWEB_MAP)
+def test_all_get_occweb_noodle(noodle_path):
+    """Make sure we can get a directory from noodle for all available
+    translations"""
+    noodle = f"//noodle/{noodle_path}".lower()
+    files = occweb.get_occweb_dir(noodle)
+    assert len(files) > 0
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")


### PR DESCRIPTION
## Description

Make life a little easier if a noodle path has the wrong case.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
