### PR TITLE
Fix bug when getting states starting just before NSM

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1168,6 +1168,13 @@ class NormalSunTransition(ManeuverTransition):
 
         # Setup for maneuver to sun-pointed attitude from current att
         curr_att = [state[qc] for qc in QUAT_COMPS]
+
+        # If current attitude is not defined then just drop the NSM maneuver on
+        # the floor. The state will start getting defined when the first normal
+        # maneuver happens.
+        if None in curr_att:
+            return
+
         targ_att = Chandra.Maneuver.NSM_attitude(curr_att, date)
         for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
             state["targ_" + qc] = targ_q

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1667,3 +1667,11 @@ def test_early_start_exception():
         ValueError, match="no continuity found for start='2002:001:00:00:00.000'"
     ):
         states.get_states("2002:001", "2003:001", state_keys=["orbit_point"])
+
+
+def test_nsm_continuity():
+    """Test continuity when the 7-day lookback is before an NSM / safe sun
+    where current state attitude is None. Tests fix for #258.
+    """
+    # Prior to the fix this raised an exception, so just check that it runs.
+    states.get_continuity("2022:301:12:42:00", scenario="flight")


### PR DESCRIPTION
## Description

When getting states (with no defined continuity) starting from just before a normal sun mode transition there was an exception due to the current attitude state quaternions being `None`. This PR fixes the issue ala #199 by dropping the NSM command and letting the next defined maneuver take over.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #258

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.  Unit test added.
