### PR TITLE
Remove WARNING in logging text

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -739,7 +739,7 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
                     obs_params["starcat_date"] = starcat_date
                 else:
                     logger.info(
-                        f"WARNING: no starcat for obsid {obsid} at {cmd['date']} "
+                        f"No starcat for obsid {obsid} at {cmd['date']} "
                         "even though npnt_enab is True"
                     )
 


### PR DESCRIPTION
## Description

This removes the word `WARNING` from the logging text for a situation that is common in anomaly recovery scenarios. This will reduce unnecessary alerts in Ska job watch.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

None

## Testing
<!-- If relevant describe any special setup for testing. -->

No testing given the scope of the change.
