### PR TITLE
Fix issue with cmd query around 30 days before current time

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -225,7 +225,7 @@ def get_cmds(
             # Query does not overlap with recent commands, just use archive.
             logger.info("Getting commands from archive only")
             cmds = IDX_CMDS
-        elif start < CxoTime(cmds_recent["date"][0]) + 3 * u.day:
+        elif start < CxoTime(cmds_recent.meta["loads_start"]) + 3 * u.day:
             # Query starts near beginning of recent commands and *might* need some
             # archive commands. The margin is set at 3 days to ensure that OBS
             # command continuity is maintained (there is at least one maneuver).
@@ -418,6 +418,7 @@ def update_archive_and_get_cmds_recent(
     cmds_recent.deduplicate_orbit_cmds()
     cmds_recent.remove_not_run_cmds()
     cmds_recent = add_obs_cmds(cmds_recent, pars_dict, rev_pars_dict)
+    cmds_recent.meta["loads_start"] = start.date
 
     if cache:
         # Cache recent commands so future requests for the same scenario are fast

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -198,6 +198,7 @@ def get_cmds(
 
     :returns: CommandTable
     """
+    logger.info(f"Getting commands from {start} to {stop} for {scenario=}")
     scenario = os.environ.get("KADI_SCENARIO", scenario)
     start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)
@@ -210,7 +211,10 @@ def get_cmds(
     before_recent_cmds = stop < default_stop - conf.default_lookback * u.day
     if scenario == "flight" or not HAS_INTERNET or before_recent_cmds:
         cmds = IDX_CMDS
-        logger.info("Getting commands from archive only")
+        logger.info(
+            "Getting commands from archive only because of:"
+            f" {scenario=} {before_recent_cmds=} {HAS_INTERNET=}"
+        )
     else:
         if scenario not in CMDS_RECENT:
             cmds_recent = update_archive_and_get_cmds_recent(
@@ -223,18 +227,28 @@ def get_cmds(
         # the requested date range.
         if stop.date < cmds_recent["date"][0]:
             # Query does not overlap with recent commands, just use archive.
-            logger.info("Getting commands from archive only")
+            logger.info(
+                "Getting commands from archive only: stop < first commands recent for"
+                " {scenario=}"
+            )
             cmds = IDX_CMDS
         elif start < CxoTime(cmds_recent.meta["loads_start"]) + 3 * u.day:
             # Query starts near beginning of recent commands and *might* need some
             # archive commands. The margin is set at 3 days to ensure that OBS
             # command continuity is maintained (there is at least one maneuver).
+            # See also the DESIGN commentary after the function.
             cmds = _merge_cmds_archive_recent(start, scenario)
-            logger.info(f"Getting commands from archive + recent {scenario=}")
+            logger.info(
+                "Getting commands from archive + recent: start < recent loads start +"
+                f" 3 days for {scenario=}"
+            )
         else:
             # Query is strictly within recent commands.
             cmds = cmds_recent
-            logger.info(f"Getting commands from recent only {scenario=}")
+            logger.info(
+                "Getting commands from recent only: start and stop are within recent"
+                f" commands for {scenario=}"
+            )
 
     # Select the requested time range and make a copy. (Slicing is a view so
     # in theory bad things could happen without a copy).
@@ -259,6 +273,23 @@ def get_cmds(
     cmds["time"].info.format = ".3f"
 
     return cmds
+
+
+# DESIGN commentary on this line in the above code::
+#    start < CxoTime(cmds_recent.meta["loads_start"]) + 3 * u.day
+#
+# The question being asked here is "are there any applicable archive load
+# commands which are NOT available from the recent load commands (i.e. the last
+# 4 weeks of weekly loads)?".  Imagine these inputs:
+#
+#   start = Apr-02-2022
+#   Loads = APR0122 (Never run due to anomaly), APR0622 (replan), APR0822,  APR1522, APR2222
+#   cmds_recent.meta["loads_start"] = Apr-01-2022 (first command in APR0122 approx)
+#
+# So what we care about is the first command in the applicable loads in the time
+# span, not the first actually run load command in the span. The reason is that
+# the archive is not going to provide additional commands here because the
+# APR0122 commands will also not be in the archive.
 
 
 def update_archive_and_get_cmds_recent(
@@ -333,9 +364,7 @@ def update_archive_and_get_cmds_recent(
             if rltt is None and load_name not in not_run_loads["Load"]:
                 # This is unexpected but press ahead anyway
                 logger.error(f"No RLTT for {load_name=}")
-            logger.info(
-                f"Load {load_name} has {len(cmds)} commands" f" with RLTT={rltt}"
-            )
+            logger.info(f"Load {load_name} has {len(cmds)} commands with RLTT={rltt}")
             cmds_list.append(cmds)
         else:
             logger.info(f"Load {load_name} has no commands, skipping")
@@ -600,7 +629,8 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
             for ii, cmd in enumerate(cmds_obs):
                 if nsm_date > cmd["params"]["manvr_start"] and nsm_date <= cmd["date"]:
                     logger.info(
-                        f"NSM at {nsm_date} happened during maneuver preceding obs\n{cmd}"
+                        f"NSM at {nsm_date} happened during maneuver preceding"
+                        f" obs\n{cmd}"
                     )
                     log_context_obs(cmds, cmd)
                     bad_idxs.append(ii)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1187,3 +1187,19 @@ def test_no_rltt_for_not_run_load(stop_date_2022_236):
     cmds = commands_v2.get_cmds("2022:232:03:00:00", "2022:233:18:30:00")
     cmds = cmds[cmds["type"] == "ACISPKT"]
     assert cmds["date", "tlmsid", "scs"].pformat() == exp
+
+
+stop_date_2022_352 = stop_date_fixture_factory("2022:352")
+
+
+def test_30_day_lookback_issue(stop_date_2022_352):
+    """Test for fix in PR #265 of somewhat obscure issue where a query
+    within the default 30-day lookback could give zero commands. Prior to
+    the fix the query below would give zero commands (with the default stop date
+    set accordingly)."""
+    cmds = commands_v2.get_cmds("2022:319", "2022:324")
+    assert len(cmds) > 200
+
+    # Hit the CMDS_RECENT cache as well
+    cmds = commands_v2.get_cmds("2022:319:00:00:01", "2022:324:00:00:01")
+    assert len(cmds) > 200


### PR DESCRIPTION
## Description

This fixes a bug in the `get_cmds` query logic which resulted in missing commands from the query under somewhat unusual circumstances:
- Query start is between 30 to 44 days before current time
- Within that window there is a non-load command from a Command Event.
- Query start is later than that non-load command time + 3 days.

The basic problem is that the code was checking for the first command of any type in the recent commands. Instead it should have been checking for the first load command in recent commands (within 30 days).

The unit test demonstrates the problem as it applies for a current date of 2022:352. In this case the OORMPEN non-load command at 2022:312:03:09:55.000 causes the problem.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->
Added unit test which failed prior to the fix and passes now.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
