### PR TITLE
Add task_schedule_validate.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,12 @@ if "--user" not in sys.argv:
     data_files = [
         (
             share_path,
-            ["task_schedule_cmds.cfg", "task_schedule_events.cfg", "ltt_bads.dat"],
+            [
+                "task_schedule_cmds.cfg",
+                "task_schedule_events.cfg",
+                "task_schedule_validate.cfg",
+                "ltt_bads.dat",
+            ],
         )
     ]
 else:

--- a/task_schedule_validate.cfg
+++ b/task_schedule_validate.cfg
@@ -1,0 +1,42 @@
+# Configuration file for task_schedule.pl to run astromon jobs
+
+subject           Kadi commands state validation
+timeout           3000              # Default tool timeout
+heartbeat_timeout 10                # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA}/data/kadi       # Data file directory
+log_dir      $ENV{SKA}/data/kadi/logs  # Log file directory
+heartbeat    task_sched_heartbeat_validate
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+alert       aca@cfa.harvard.edu
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+# This has multiple jobs which get run in specified order
+# Note the syntax 'exec <number> : cmd', which means that the given command is
+# executed only once for each <number> of times the task is executed.  In the
+# example below, the commands are done once each 1, 2, and 4 minutes, respectively.
+
+<task kadi_validate>
+      cron       * * * * *
+      exec kadi_validate_states --out-dir=$ENV{SKA}/www/ASPECT/validate_states
+</task>


### PR DESCRIPTION
## Description

This puts the new kadi commands validation into action.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Supercedes the Python 2 `validate_states` package version.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
No code changes.


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

The new `task_schedule_validate.cfg` has been manually installed on HEAD and is now running as a regular cron job. The Py2 `validate_states` version is disabled. The Aspect Cron jobs page has been updated accordingly.

To do:

- [ ] Install test to verify  `setup.py`
