### PR TITLE
Fix issue always logging about NSM during maneuver

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -634,7 +634,7 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
                         f"NSM at {nsm_date} happened during maneuver preceding"
                         f" obs\n{cmd}"
                     )
-                    log_context_obs(cmds, cmd)
+                    log_context_obs(cmds, cmd, log_level="info")
                     bad_idxs.append(ii)
         if bad_idxs:
             logger.info(f"Removing obss at {bad_idxs}")
@@ -820,12 +820,13 @@ def get_cmds_obs_final(cmds, pars_dict, rev_pars_dict, schedule_stop_time):
     return cmds_obs
 
 
-def log_context_obs(cmds, cmd, before=3600, after=3600):
+def log_context_obs(cmds, cmd, before=3600, after=3600, log_level="warning"):
     """Log commands before and after ``cmd``"""
     date_before = (CxoTime(cmd["date"]) - before * u.s).date
     date_after = (CxoTime(cmd["date"]) + after * u.s).date
     ok = (cmds["date"] >= date_before) & (cmds["date"] <= date_after)
-    logger.warning(f"\n{cmds[ok]}")
+    log_func = getattr(logger, log_level)
+    log_func(f"\n{cmds[ok]}")
 
 
 def is_google_id(scenario):


### PR DESCRIPTION
## Description

Fix the problem in #276 by adding a keyword arg to the debug function to specify the logging level. In most cases a warning is appropriate (the default) but this particular situation is just informational.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #276

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (ska3-prime)

Independent check of unit tests by Jean
- [x] There is a test fail on linux / fido on test_commands_create_archive_regress using ska3-prime.  This appears unrelated so I'm opening a separate issue.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Before the patch this code would generate the informational output shown in #276 (circa 2023:048):
```
cmds = get_cmds(CxoTime.now())
```
After the patch this runs quietly. I also confirmed that with the patch if the `kadi.logger` is set to `"INFO"` log level then the expected INFO output appears.
