### PR TITLE
Hardwire time zone to US/Eastern

### DIFF
--- a/kadi/settings.py
+++ b/kadi/settings.py
@@ -79,3 +79,5 @@ DATABASES = {
         "NAME": EVENTS_DB_PATH(),
     }
 }
+
+TIME_ZONE = "US/Eastern"


### PR DESCRIPTION
## Description

Django defaults to the [America/Chicago](https://github.com/django/django/blob/066aabcb77579cf8d549119c860d11cd15e3eef1/docs/ref/settings.txt#L2822) time zone. Annoyingly, when `django.setup()` gets run on Unix it sets the `TZ` environment variable to that default. This then spills over to impacting the [local time zone in the Python `time`](https://github.com/python/cpython/blob/fda95aa19447fe444ac2670afbf98ec42aca0c6f/Modules/timemodule.c#L1158) or `datetime` modules.

What this means is that applications trying to print a time in the local time zone were using `America/Chicago` after `django.setup()` is called. This happens when kadi events are queried.

This solution of hardwiring to `US/Eastern` is not very nice, but in practice it is going to work since all CXC operations and operational use of `kadi` are in this time zone.

An alternate idea was to unset the `TZ` environment variable after `django.setup()` is called. This appears to work but I am worried about some unexpected problems in `django` if it expects that env var to be set. Therefore I opted for a documented django fix.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
After using kadi events then local times will always be displayed in Eastern instead of Chicago.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### In flight ska (2023.1)
```
In [1]: import datetime
   ...: 
   ...: dt = datetime.datetime(2020, 11, 1, 1)

In [2]: dt.astimezone()
Out[2]: datetime.datetime(2020, 11, 1, 1, 0, 
  tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000), 'EDT'))

In [3]: import kadi.events

In [4]: kadi.events.eclipses
Out[4]: <EventQuery: Eclipse>

## Central Daylight Time
In [5]: dt.astimezone()
Out[5]: datetime.datetime(2020, 11, 1, 1, 0, 
  tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=68400), 'CDT')) 
```
#### With this patch
```
In [1]: import datetime
   ...: 
   ...: dt = datetime.datetime(2020, 11, 1, 1)

In [2]: dt.astimezone()
Out[2]: datetime.datetime(2020, 11, 1, 1, 0, 
  tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000), 'EDT'))

In [3]: import kadi.events

In [4]: kadi.events.eclipses
Out[4]: <EventQuery: Eclipse>

# Still EDT
In [5]: dt.astimezone()
Out[5]: datetime.datetime(2020, 11, 1, 1, 0, 
  tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000), 'EDT'))
```

