### PR TITLE
Factor out `get_ofp_states` and `get_telem_values` for cheta #249 improvements

### DIFF
--- a/kadi/scripts/validate_states.py
+++ b/kadi/scripts/validate_states.py
@@ -62,6 +62,7 @@ def main(args=None):
     # Enable logging in relevant packages
     logging.getLogger("kadi").setLevel(opt.log_level)
     fetch.add_logging_handler(level=opt.log_level)
+    fetch.data_source.set("cxc", "maude allow_subset=False")
     maude.set_logger_level(opt.log_level)
 
     maude.conf.cache_msid_queries = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-    ignore:'soft_unicode' has been renamed to 'soft_str'
-    ignore:`np.object` is a deprecated alias for the builtin `object`


### PR DESCRIPTION
## Description

This PR is paired with https://github.com/sot/cheta/pull/249 to factor out the `get_ofp_states` and `get_telem_values` functions into `cheta` where they more logically belong.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
`get_ofp_states` and `get_telem_values` are no longer available in `kadi.utils`. Both of these are currently used only internally within `cheta` and `kadi` in SOT repos on GitHub. Any other usages in non-versioned tools can just be fixed.

The API for both of these were changed as well, hence it would not make sense to include a reference in `kadi.utils` (from cheta) for back-compatibility.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Validation script was run from inside the repo for the `branch` outputs and outside the repo for `release`. The `cheta` repository was checked out with https://github.com/sot/cheta/pull/249.

In both cases below I did a side-by-side visual / by-eye text comparison of the outputs from this branch and ska3 2023.1 respectively. No diffs were seen.

#### Run with default arguments covering last 14 days (uses MAUDE)
`env PYTHONPATH=/Users/aldcroft/git/cheta python -m kadi.scripts.validate_states --out-dir current-branch`
`python -m kadi.scripts.validate_states --out-dir current-release`
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi-pr285/current-branch/
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi-pr285/current-release/

#### Run with arguments covering 2022:283 safe mode (no MAUDE)
`env PYTHONPATH=/Users/aldcroft/git/cheta python -m kadi.scripts.validate_states --out-dir safe-2022-branch --stop=2022:297 --days=5`
`python -m kadi.scripts.validate_states --out-dir safe-2022-release --stop 2022:297 --days=5`
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi-pr285/safe-2022-branch/
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi-pr285/safe-2022-release/


