### PR TITLE
fix test on windows

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1142,7 +1142,7 @@ def test_scenario_with_rts(monkeypatch):
     assert np.count_nonzero(ok) == 14
 
 
-stop_date_2022_236 = stop_date_fixture_factory("2022:236")
+stop_date_2022_236 = stop_date_fixture_factory("2022-08-23")
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
@@ -1171,7 +1171,7 @@ def test_no_rltt_for_not_run_load(stop_date_2022_236):
     assert cmds["date", "tlmsid", "scs"].pformat() == exp
 
 
-stop_date_2022_352 = stop_date_fixture_factory("2022:352")
+stop_date_2022_352 = stop_date_fixture_factory("2022-12-17")
 
 
 def test_30_day_lookback_issue(stop_date_2022_352):


### PR DESCRIPTION
This fixes some test failures on windows.

## Description

The following statement in the test

```
stop_date_2022_352 = stop_date_fixture_factory("2022:352")
```

causes the following error:

```
NotADirectoryError: [WinError 267] The directory name is invalid
```

The cause is the colon in the name, so this PR replaces the argument with an ISO date.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [x] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
