### PR TITLE
Improve error message for stale local commands archive

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1232,7 +1232,7 @@ def get_matching_block_idx(cmds_arch, cmds_recent):
     else:
         raise ValueError(
             f"No matching blocks at least {MATCHING_BLOCK_SIZE} long. This most likely "
-            "means that you have recently synced your local Ska data using `ska_sync`."
+            "means that you have not recently synced your local Ska data using `ska_sync`."
         )
 
     # Index into idx_cmds at the end of the large matching block.  block.b is the

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1231,7 +1231,8 @@ def get_matching_block_idx(cmds_arch, cmds_recent):
             break
     else:
         raise ValueError(
-            "No matching blocks at least {} long".format(MATCHING_BLOCK_SIZE)
+            f"No matching blocks at least {MATCHING_BLOCK_SIZE} long. This most likely "
+            "means that you have recently synced your local Ska data using `ska_sync`."
         )
 
     # Index into idx_cmds at the end of the large matching block.  block.b is the


### PR DESCRIPTION
## Description

This gives a more useful error message for a common exception in the kadi commands archive.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
