### PR TITLE
Compare regression test quaternions with delta-quat tolerance check

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -11,6 +11,8 @@ import parse_cm.tests
 import pytest
 from astropy.table import Table, vstack
 from Chandra.Time import secs2date
+from Quaternion import Quat
+from agasc import sphere_dist
 from cxotime import CxoTime
 from testr.test_helper import has_internet
 
@@ -314,12 +316,39 @@ def test_commands_create_archive_regress(tmpdir, version_env):
                 # Path("cmds_local.txt").write_text(out)
                 assert len(cmds_flight) == len(cmds_local)
 
+            # Roughly validate NSM quaternions and remove from later comparison
+            nsm_idxs = np.flatnonzero(cmds_flight['npnt_enab'] == False)
+            for idx in nsm_idxs:
+                flight_att = cmds_flight[idx]['params']['targ_att']
+                flight_q = Quat(q=flight_att)
+                local_q = Quat(q=cmds_local[idx]['params']['targ_att'])
+                delta_point = sphere_dist(flight_q.ra, flight_q.dec,
+                                          local_q.ra, local_q.dec)
+
+                assert delta_point < 0.1
+                assert np.isclose(flight_q.roll, local_q.roll, atol=0.1)
+
+                for cmd in (cmds_local[idx], cmds_flight[idx]):
+                    del cmd['params']['targ_att']
+
+                # Not sure if it would be OK to just remove all 'prev_att'
+                # from the comparisons but here just remove the ones that
+                # have just been checked above.
+                for i in range(idx + 1, len(cmds_flight)):
+                    if 'prev_att' in cmds_flight[i]['params']:
+                        if (cmds_flight[i]['params']['prev_att'] == flight_att):
+                            del cmds_flight[i]['params']['prev_att']
+                            del cmds_local[i]['params']['prev_att']
+                        else:
+                            break
+
             # 'starcat_idx' param in OBS cmd does not match since the pickle files
             # are different, so remove it.
             for cmds in (cmds_local, cmds_flight):
                 for cmd in cmds:
                     if cmd["tlmsid"] == "OBS" and "starcat_idx" in cmd["params"]:
                         del cmd["params"]["starcat_idx"]
+
 
             for attr in ("tlmsid", "date", "params"):
                 assert np.all(cmds_flight[attr] == cmds_local[attr])

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -317,7 +317,7 @@ def test_commands_create_archive_regress(tmpdir, version_env):
                 assert len(cmds_flight) == len(cmds_local)
 
             # Roughly validate NSM quaternions and remove from later comparison
-            nsm_idxs = np.flatnonzero(cmds_flight['npnt_enab'] == False)
+            nsm_idxs = np.flatnonzero(cmds_flight['npnt_enab'] == False) # noqa
             for idx in nsm_idxs:
                 flight_att = cmds_flight[idx]['params']['targ_att']
                 flight_q = Quat(q=flight_att)
@@ -348,7 +348,6 @@ def test_commands_create_archive_regress(tmpdir, version_env):
                 for cmd in cmds:
                     if cmd["tlmsid"] == "OBS" and "starcat_idx" in cmd["params"]:
                         del cmd["params"]["starcat_idx"]
-
 
             for attr in ("tlmsid", "date", "params"):
                 assert np.all(cmds_flight[attr] == cmds_local[attr])


### PR DESCRIPTION
## Description
Compare regression test quaternions with delta-quat tolerance check instead of == test.

This fixes the issue that the calculated quaternions on fido present insignificant numeric differences from the same quaternions calculated on kady.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux on fido at ska3-matlab 2023.4rc6

Independent check of unit tests by @taldcroft
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
