### PR TITLE
Add validator for sun position monitor

### DIFF
--- a/kadi/commands/utils.py
+++ b/kadi/commands/utils.py
@@ -97,7 +97,7 @@ def add_figure_regions(
 def convert_state_code_to_raw_val(state_vals, state_codes):
     raw_vals = np.zeros(len(state_vals), dtype=int)
     for raw_val, state_code in state_codes:
-        ok = state_vals == state_code
+        ok = np.char.strip(state_vals) == state_code
         raw_vals[ok] = raw_val
     return raw_vals
 

--- a/kadi/commands/validate.py
+++ b/kadi/commands/validate.py
@@ -678,6 +678,30 @@ class ValidateHETG(ValidateGrating):
     plot_attrs = PlotAttrs(title="HETG", ylabel="HETG")
 
 
+class ValidateSunPosMon(ValidateStateCode):
+    state_name = "sun_pos_mon"
+    msids = ["aopssupm"]
+    plot_attrs = PlotAttrs(title="Sun position monitor", ylabel="Sun position monitor")
+    min_violation_duration = 300
+
+    def add_exclude_intervals(self):
+        super().add_exclude_intervals()
+        self.exclude_ofp_intervals_except(["NRML"])
+
+    @functools.cached_property
+    def state_vals(self):
+        """Convert ENAB (commanded states) to ACT (telemetry).
+
+        The "ENAB" is an artifact of the backstop history sun position monitor states.
+        This method is otherwise equivalent to the ValidateStateCode method.
+        """
+        states_interp = interpolate_states(self.states, self.tlm["time"])
+        state_vals = states_interp[self.state_name]
+        state_vals[state_vals == "ENAB"] = "ACT"
+        state_vals_raw = convert_state_code_to_raw_val(state_vals, self.state_codes)
+        return state_vals_raw
+
+
 def get_overlap_mask(times: np.ndarray, intervals: Table):
     """Return a bool mask of ``times`` that are within any of the ``intervals``.
 


### PR DESCRIPTION
## Description

This adds a state validator for the `sun_pos_mon` state.

It also fixes a bug where telemetry values with a trailing space character (e.g. `"ACT "`) do not match the state codes.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a new plot in the state validation page.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [X] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

From within the git repo:
```
python -m kadi.scripts.validate_states
```
This generated the following output: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi-pr292/

