### PR TITLE
Update log statement with a time that prints

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -200,7 +200,7 @@ def get_cmds(
 
     :returns: CommandTable
     """
-    logger.info(f"Getting commands from {start.date} to {stop.date} for {scenario=}")
+    logger.info(f"Getting commands from {CxoTime(start).date} to {CxoTime(stop).date} for {scenario=}")
     scenario = os.environ.get("KADI_SCENARIO", scenario)
     start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -172,7 +172,7 @@ def get_matching_block_idx_simple(cmds_recent, cmds_arch, min_match):
         i0_arch += 1
         if cmds_arch["date"][i0_arch] != date0:
             raise ValueError(
-                f"No matching commands block in archive found for recent_commands"
+                "No matching commands block in archive found for recent_commands"
             )
 
     logger.info(f"Found matching commands block in archive at {i0_arch}")
@@ -200,7 +200,8 @@ def get_cmds(
 
     :returns: CommandTable
     """
-    logger.info(f"Getting commands from {CxoTime(start).date} to {CxoTime(stop).date} for {scenario=}")
+    logger.info(
+        f"Getting commands from {CxoTime(start).date} to {CxoTime(stop).date} for {scenario=}")
     scenario = os.environ.get("KADI_SCENARIO", scenario)
     start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -200,7 +200,7 @@ def get_cmds(
 
     :returns: CommandTable
     """
-    logger.info(f"Getting commands from {start} to {stop} for {scenario=}")
+    logger.info(f"Getting commands from {start.date} to {stop.date} for {scenario=}")
     scenario = os.environ.get("KADI_SCENARIO", scenario)
     start = CxoTime("1999:001" if start is None else start)
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes log statements like:
```
2023-08-10 08:31:15,261 get_cmds: Getting commands from <chandra_time.Time.DateTime object at 0x7fa1eb0053f0> to <chandra_time.Time.DateTime object at 0x7fa1eb005600> for scenario=Non
e
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
- [x] Linux 

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
On master at eb5868
```
In [1]: import kadi.commands.commands_v2
In [2]: kadi.commands.commands_v2.logger.setLevel('INFO')
In [4]: from Chandra.Time import DateTime
In [5]: cmds = kadi.commands.commands_v2.get_cmds(DateTime("2023:001"), DateTime("2023:005"))
2023-10-20 09:46:46,002 get_cmds: Getting commands from <chandra_time.Time.DateTime object at 0x1179b62f0> to <chandra_time.Time.DateTime object at 0x1179b7550> for scenario=None
2023-10-20 09:46:46,007 get_cmds: Getting commands from archive only because of: scenario=None before_recent_cmds=True HAS_INTERNET=True
```
On this PR at [507ad83](https://github.com/sot/kadi/pull/294/commits/507ad83e8e8854dfb075c4dc09a6162f0a688b4e)
```
In [1]: import kadi.commands.commands_v2
In [4]: kadi.commands.commands_v2.logger.setLevel('INFO')
In [9]: from Chandra.Time import DateTime
In [10]: cmds = kadi.commands.commands_v2.get_cmds(DateTime("2023:001"), DateTime("2023:005"))
2023-10-20 09:46:19,730 get_cmds: Getting commands from 2023:001:00:00:00.000 to 2023:005:00:00:00.000 for scenario=None
2023-10-20 09:46:19,732 get_cmds: Getting commands from archive only because of: scenario=None before_recent_cmds=True HAS_INTERNET=True
```
