### PR TITLE
Use ska_helpers.utils.convert_to_int_float_str to stop Deprecation warns

### DIFF
--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import astropy.units as u
 from cxotime import CxoTime
-from parse_cm.common import _coerce_type as coerce_type
+from ska_helpers.utils import convert_to_int_float_str
 from Quaternion import Quat
 
 from kadi.commands.core import CommandTable
@@ -166,7 +166,7 @@ def cmd_set_command(*args, date=None):
         if key == "TLMSID":
             cmd["tlmsid"] = val
         else:
-            params[key] = coerce_type(val)
+            params[key] = convert_to_int_float_str(val)
     cmd["params"] = params
 
     return (cmd,)
@@ -207,7 +207,7 @@ def get_cmds_from_event(date, event, params_str):
             args = [params_str]
         else:
             params_str = params_str.upper().split()
-            args = [coerce_type(p) for p in params_str]
+            args = [convert_to_int_float_str(p) for p in params_str]
     else:
         # Empty value means no args and implies params_str = np.ma.masked
         args = ()


### PR DESCRIPTION
Use ska_helpers.utils.convert_to_int_float_str directly instead of parse_cm.common._coerce_type .

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Stops warnings like
```
kadi/commands/tests/test_states.py: 1 warning
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/parse_cm/common.py:33: VisibleDeprecationWarning: The _coerce_type function is deprecated and will be removed in a future version of parse_cm. Use ska_helpers.utils.convert_to_int_float_str instead.
    warnings.warn(
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested in ska3-masters with https://github.com/sot/parse_cm/pull/44

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests with and without this PR show no warning with PR and warning without and otherwise pass.
