### PR TITLE
Revert the change to decorate `Validate.update_tlm` method

### DIFF
--- a/kadi/commands/validate.py
+++ b/kadi/commands/validate.py
@@ -10,7 +10,7 @@ or from the command-line application ``kadi_validate_states`` (defined in
 """
 import functools
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -155,8 +155,7 @@ class Validate(ABC):
             self.add_exclude_intervals()
         return self._tlm
 
-    @abstractmethod
-    def update_tlm(self):
+    def update_tlm(self):  # noqa: B027
         """Update the telemetry values with any subclass-specific processing"""
 
     @property


### PR DESCRIPTION
## Description

This is a critical fix that reverts a change made in #268. Unfortunately I did not appreciate what this actually meant and our testing does not cover this code at all. Without the fix the `kadi_validate_states` script fails to run at all.

I plan to add a unit test that does a regression test of the `validate` code, but in the meantime this PR uses functional testing.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-perf) ➜  kadi git:(revert-abstract-method) git rev-parse HEAD                  
b2e4f579b4ac6bee3be176c4d10272e07b310d4f
(ska3-perf) ➜  kadi git:(revert-abstract-method) pytest kadi
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 199 items                                                                                                         

kadi/commands/tests/test_commands.py ...........................................................................      [ 37%]
kadi/commands/tests/test_states.py ......................x.............................................x............. [ 78%]
..........                                                                                                            [ 83%]
kadi/tests/test_events.py ..........                                                                                  [ 88%]
kadi/tests/test_occweb.py ......................                                                                      [100%]

======================================== 197 passed, 2 xfailed in 101.15s (0:01:41) =========================================
```

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Compared the output of this branch with ska3-performance (effectively masters) to the output of the current flight release 7.6.0 in ska3. The results (see below) show no substantive differences. 

Branch run in ska3-performance:
```
python -m kadi.scripts.validate_states --out-dir test-revert --stop=2023:311 --days 3.5 >& test-revert.log
```
Output: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi/pr299/test-revert/

Flight run in ska3
```
kadi_validate_states --out-dir test-flight --stop=2023:311 --days 3.5 >& test-flight.log
```
Output: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/kadi/pr299/test-flight/

#### Diff of run logs after removing log timestamps

```
(ska3-perf) ➜  kadi git:(revert-abstract-method) diff test-flight.log test-revert.log
86c86
< ****  get_cmds: Getting commands from 815400069.5749999 to 815702469.175 for scenario=None
---
> ****  get_cmds: Getting commands from 2023:307:12:00:00.391 to 2023:310:23:59:59.991 for scenario=None
129c129
< ****  get_cmds: Getting commands from <chandra_time.Time.DateTime object at 0x1332bb220> to <chandra_time.Time.DateTime object at 0x1332ba590> for scenario=None
---
> ****  get_cmds: Getting commands from 2023:300:12:00:00.391 to 2023:307:12:00:00.391 for scenario=None
...
# A bunch more like that
```

