### PR TITLE
flatten namespace package names

### DIFF
--- a/kadi/cmds/cmds.py
+++ b/kadi/cmds/cmds.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import tables
 from astropy.table import Table
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 from kadi.paths import IDX_CMDS_PATH, PARS_DICT_PATH
 

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -18,7 +18,7 @@ import astropy.units as u
 import numpy as np
 import requests
 from astropy.table import Table
-from Chandra.Maneuver import NSM_attitude
+from chandra_maneuver import NSM_attitude
 from cxotime import CxoTime
 from testr.test_helper import has_internet
 

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -643,7 +643,7 @@ class CommandTable(Table):
         The command ``params`` are embedded as a dict for each command.
 
         If ``ska_parsecm`` is True then the output is made more compatible with
-        the legacy output from ``Ska.ParseCM.read_backstop()``, namely:
+        the legacy output from ``ska_parsecm.read_backstop()``, namely:
 
         - Add ``cmd`` key which is set to the ``type`` key
         - Make ``params`` keys uppercase.
@@ -651,7 +651,7 @@ class CommandTable(Table):
         Parameters
         ----------
         ska_parsecm : bool
-            Make output more Ska.ParseCM compatible
+            Make output more ska_parsecm compatible
 
         Returns
         -------

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -10,11 +10,11 @@ import itertools
 import re
 
 import astropy.units as u
-import Chandra.Maneuver
+import chandra_maneuver
 import numpy as np
-import Ska.Sun
+import ska_sun
 from astropy.table import Column, Table
-from Chandra.Time import DateTime, date2secs, secs2date
+from chandra_time import DateTime, date2secs, secs2date
 from cxotime import CxoTime
 from Quaternion import Quat, quat_to_equatorial
 
@@ -1103,8 +1103,8 @@ class SunVectorTransition(BaseTransition):
         """
         if state["pcad_mode"] == "NPNT":
             q_att = Quat([state[qc] for qc in QUAT_COMPS])
-            state["pitch"] = Ska.Sun.pitch(q_att.ra, q_att.dec, date)
-            state["off_nom_roll"] = Ska.Sun.off_nominal_roll(q_att, date)
+            state["pitch"] = ska_sun.pitch(q_att.ra, q_att.dec, date)
+            state["off_nom_roll"] = ska_sun.off_nominal_roll(q_att, date)
 
 
 class DitherEnableTransition(FixedTransition):
@@ -1310,7 +1310,7 @@ class ManeuverTransition(BaseTransition):
         curr_att = [state[qc] for qc in QUAT_COMPS]
 
         # Get attitudes for the maneuver at about 5-minute intervals.
-        atts = Chandra.Maneuver.attitudes(
+        atts = chandra_maneuver.attitudes(
             curr_att, targ_att, tstart=DateTime(date).secs
         )
 
@@ -1327,7 +1327,7 @@ class ManeuverTransition(BaseTransition):
         # Add transitions for each bit of the maneuver.  Note that this sets the
         # attitude (q1..q4) at the *beginning* of each state, while setting
         # pitch and off_nominal_roll at the *midpoint* of each state.  This is
-        # for legacy compatibility with Chandra.cmd_states but might be
+        # for legacy compatibility with chandra_cmd_states but might be
         # something to change since it would probably be better to have the
         # midpoint attitude.
         dates = secs2date(atts.time)
@@ -1381,7 +1381,7 @@ class NormalSunTransition(ManeuverTransition):
         if None in curr_att:
             return
 
-        targ_att = Chandra.Maneuver.NSM_attitude(curr_att, date)
+        targ_att = chandra_maneuver.NSM_attitude(curr_att, date)
         for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
             state["targ_" + qc] = targ_q
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -10,7 +10,7 @@ import numpy as np
 import parse_cm.tests
 import pytest
 from astropy.table import Table, vstack
-from Chandra.Time import secs2date
+from chandra_time import secs2date
 from cxotime import CxoTime
 from Quaternion import Quat
 from testr.test_helper import has_internet

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -9,9 +9,9 @@ import numpy as np
 import pytest
 from astropy.io import ascii
 from astropy.table import Table
-from Chandra.Time import DateTime
+from chandra_time import DateTime
+from cheta import fetch
 from cxotime import CxoTime
-from Ska.engarchive import fetch
 from testr.test_helper import has_internet
 
 warnings.filterwarnings(
@@ -253,7 +253,7 @@ def test_states_2017():
     Skip 'ccd_count' because https://github.com/sot/cmd_states/pull/39 changed
     that behavior.
 
-    Skip 'pitch' because Chandra.cmd_states only avoids pitch breaks within actual
+    Skip 'pitch' because chandra_cmd_states only avoids pitch breaks within actual
     maneuver commanding (so the NMAN period before maneuver starts is OK) while kadi
     will insert pitch breaks only in NPNT.  (Tested later).
     """
@@ -273,7 +273,7 @@ def test_states_2017():
     # uses the exact floating point time to start while kadi uses the string time
     # rounded to the nearest msec.  The float command time is not stored in kadi.
     # For this test drop the first state, which has a datestart mismatch because
-    # of the difference in startup between Chandra.cmd_states and kadi.states.
+    # of the difference in startup between chandra_cmd_states and kadi.states.
     rkstates = rkstates[1:]
     rcstates = rcstates[1:]
     bad = np.flatnonzero(rkstates["datestart"] != rcstates["datestart"])
@@ -287,7 +287,7 @@ def test_pitch_2017():
     """
     Test pitch for 100 days in 2017.  Includes 2017:066, 068, 090 anomalies.  This is done
     by interpolating states (at 200 second intervals) because the pitch generation differs
-    slightly between kadi and Chandra.cmd_states.  (See test_states_2017 note).
+    slightly between kadi and chandra_cmd_states.  (See test_states_2017 note).
 
     Make sure that pitch matches to within 0.5 deg in all samples, and 0.05 deg during
     NPNT.
@@ -633,10 +633,10 @@ def test_reduce_states_merge_identical(all_keys):
 
 
 def cmd_states_fetch_states(*args, **kwargs):
-    """Generate regression data files for states using Chandra.cmd_states.
+    """Generate regression data files for states using chandra_cmd_states.
 
     Once files have been created they are included in the package distribution
-    and Chandra.cmd_states is no longer needed. From this point kadi will be
+    and chandra_cmd_states is no longer needed. From this point kadi will be
     the definitive reference for states.
     """
     md5 = hashlib.md5()  # noqa: S324
@@ -655,7 +655,7 @@ def cmd_states_fetch_states(*args, **kwargs):
                 "cannot find test data. Define KADI_WRITE_TEST_DATA "
                 "env var to create it."
             )
-        import Chandra.cmd_states as cmd_states  # noqa: PLR0402
+        import chandra_cmd_states as cmd_states  # noqa: PLR0402
 
         cs = cmd_states.fetch_states(*args, **kwargs)
         cs = Table(cs)
@@ -1033,7 +1033,7 @@ def test_backstop_ephem_update():
 def test_backstop_radmon_no_scs107():
     """
     Test radmon states for nominal loads.  The current non-load commands from
-    Chandra.cmd_states does not have the RADMON disable associated with SCS107
+    chandra_cmd_states does not have the RADMON disable associated with SCS107
     runs.  This test does have a TOO interrupt.
     """
     history = """
@@ -1070,7 +1070,7 @@ def test_backstop_radmon_no_scs107():
 def test_backstop_radmon_with_scs107():
     """
     Test radmon states for nominal loads.  The current non-load commands from
-    Chandra.cmd_states does not have the RADMON disable associated with SCS107
+    chandra_cmd_states does not have the RADMON disable associated with SCS107
     runs.  This test will fail until that is corrected.
     """
     history = """
@@ -1522,7 +1522,7 @@ def test_get_states_start_between_aouptarg_aomanuvr_cmds():
 
     """
     # This fails prior to the fix with ValueError: cannot convert float NaN to
-    # integer in Chandra.Maneuver.
+    # integer in chandra_maneuver.
     sts = states.get_states(
         "2021:025:13:56:00.000",
         "2021:026:00:00:00",

--- a/kadi/commands/validate.py
+++ b/kadi/commands/validate.py
@@ -20,10 +20,7 @@ import jinja2
 import numpy as np
 import plotly.graph_objects as pgo
 import requests
-import Ska.Matplotlib
-import Ska.Numpy
-import Ska.Shell
-import Ska.tdb
+import ska_tdb
 from astropy.table import Table
 from cheta.utils import (
     NoTelemetryError,
@@ -483,7 +480,7 @@ class ValidateStateCode(Validate):
 
     @functools.cached_property
     def state_codes(self) -> Table:
-        tsc = Ska.tdb.msids.find(self.msid)[0].Tsc
+        tsc = ska_tdb.msids.find(self.msid)[0].Tsc
         _state_codes = Table(
             [tsc.data["LOW_RAW_COUNT"], tsc.data["STATE_CODE"]],
             names=["raw_val", "state_code"],

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -4,15 +4,15 @@ import sys
 from itertools import count
 from pathlib import Path
 
+import cheta.fetch_eng as fetch
 import numpy as np
 import pyyaks.logger
-import Ska.engarchive.fetch_eng as fetch
 from astropy import table
-from Chandra.Time import DateTime
+from chandra_time import DateTime
+from cheta import utils
 from django.db import models
 from Quaternion import Quat
-from Ska.engarchive import utils
-from Ska.Numpy import interpolate
+from ska_numpy import interpolate
 
 from .manvr_templates import get_manvr_templates
 
@@ -329,7 +329,7 @@ class BaseModel(models.Model):
 
             :returns: list of overlapping events
             """
-            from Chandra.Time import DateTime
+            from chandra_time import DateTime
 
             from .query import combine_intervals
 

--- a/kadi/events/orbit_funcs.py
+++ b/kadi/events/orbit_funcs.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 
 import numpy as np
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 
 class NotFoundError(Exception):

--- a/kadi/events/plot.py
+++ b/kadi/events/plot.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import matplotlib.pyplot as plt
-from Ska.Matplotlib import plot_cxctime, remake_ticks
+from ska_matplotlib import plot_cxctime, remake_ticks
 
 R2A = 206264.8  # radians to arcsec
 

--- a/kadi/events/query.py
+++ b/kadi/events/query.py
@@ -7,7 +7,7 @@ import warnings
 
 import django
 import numpy as np
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 
 @contextlib.contextmanager
@@ -169,7 +169,7 @@ class EventQuery(object):
     A key feature is that EventQuery objects can be combined with boolean
     and, or, and not logic to generate composite EventQuery objects.  From
     there the intervals() output can be used to select or remove the intervals
-    from Ska.engarchive fetch datasets.
+    from cheta fetch datasets.
     """
 
     interval_pad = IntervalPad()  # descriptor defining a Pad for intervals

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -2,7 +2,7 @@
 import re
 
 from bs4 import BeautifulSoup as parse_html
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 from kadi import occweb
 

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -18,7 +18,7 @@ import requests
 from astropy.io import ascii
 from astropy.table import Table
 from astropy.utils.data import download_file
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 # This is for deprecated functionality to cache to a local directory
 CACHE_DIR = "cache"
@@ -58,12 +58,12 @@ def get_auth(username=None, password=None):
     # If $SKA doesn't have occweb credentials try .netrc.
     if username is None:
         try:
-            import Ska.ftp
+            import ska_ftp
 
             # Do this as a tuple so the operation is atomic
             username, password = (
-                Ska.ftp.parse_netrc()["occweb"]["login"],
-                Ska.ftp.parse_netrc()["occweb"]["password"],
+                ska_ftp.parse_netrc()["occweb"]["login"],
+                ska_ftp.parse_netrc()["occweb"]["password"],
             )
         except Exception:
             pass
@@ -146,10 +146,10 @@ def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
     """
     import uuid
 
-    import Ska.File
-    import Ska.ftp
+    import ska_file
+    import ska_ftp
 
-    ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
+    ftp = ska_ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
     ftp.cd("/home/{}".format(user))
@@ -162,7 +162,7 @@ def ftp_put_to_lucky(ftp_dirname, local_files, user=None, logger=None):
     for local_file in local_files:
         file_dir, file_base = os.path.split(os.path.abspath(local_file))
         ftp_file = str(uuid.uuid4())  # random unique identifier
-        with Ska.File.chdir(file_dir):
+        with ska_file.chdir(file_dir):
             ftp.put(file_base, ftp_file)
             destination_file = "{}/{}".format(ftp_dirname, file_base)
             # If final destination of file already exists, delete that file.
@@ -181,17 +181,17 @@ def ftp_get_from_lucky(ftp_dirname, local_files, user=None, logger=None):
     are copied to the corresponding local_files names.  This is the converse
     of ftp_put_to_lucky and thus requires unique basenames for all files.
     """
-    import Ska.File
-    import Ska.ftp
+    import ska_file
+    import ska_ftp
 
-    ftp = Ska.ftp.SFTP(LUCKY, logger=logger, user=user)
+    ftp = ska_ftp.SFTP(LUCKY, logger=logger, user=user)
     if user is None:
         user = ftp.ftp.get_channel().transport.get_username()
     ftp.cd("/home/{}/{}".format(user, ftp_dirname))
     for local_file in local_files:
         file_dir, file_base = os.path.split(os.path.abspath(local_file))
         if file_base in ftp.ls():
-            with Ska.File.chdir(file_dir):
+            with ska_file.chdir(file_dir):
                 ftp.get(file_base)
                 ftp.delete(file_base)
 
@@ -229,7 +229,7 @@ def get_occweb_page(
       \\noodle\vweb
 
     If ``user`` and ``password`` are not provided then it is required that
-    credentials are stored in the file ``~/.netrc``. See the ``Ska.ftp`` package
+    credentials are stored in the file ``~/.netrc``. See the ``ska_ftp`` package
     for details.
 
     If the page is not found then a ``requests.exceptions.HTTPError`` is raised.
@@ -307,7 +307,7 @@ def get_occweb_dir(path, timeout=30, cache=False, user=None, password=None):
       https://occweb.cfa.harvard.edu/occweb/<path>
 
     If ``user`` and ``password`` are not provided then it is required that
-    credentials are stored in the file ``~/.netrc``. See the ``Ska.ftp`` package
+    credentials are stored in the file ``~/.netrc``. See the ``ska_ftp`` package
     for details.
 
     Parameters

--- a/kadi/scripts/update_cmds_v1.py
+++ b/kadi/scripts/update_cmds_v1.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import numpy as np
 import pyyaks.logger
-import Ska.DBI
-import Ska.File
+import ska_dbi
+import ska_file
 import tables
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 from ska_helpers.retry import retry_call
 from ska_helpers.run_info import log_run_info
 
@@ -80,7 +80,7 @@ def get_opt(args=None):
 
 def fix_nonload_cmds(nl_cmds):
     """
-    Convert non-load commands commands dict format from Chandra.cmd_states
+    Convert non-load commands commands dict format from chandra_cmd_states
     to the values/structure needed here.  A typical value is shown below:
     {'cmd': u'SIMTRANS',               # Needs to be 'type'
     'date': u'2017:066:00:24:22.025',
@@ -129,7 +129,7 @@ def _tl_to_bs_cmds(tl_cmds, tl_id, db):
     """
     Convert the commands ``tl_cmds`` (numpy recarray) that occur in the
     timeline ``tl_id'' to a format mimicking backstop commands from
-    Ska.ParseCM.read_backstop().  This includes reading parameter values
+    ska_parsecm.read_backstop().  This includes reading parameter values
     from the ``db``.
 
     Parameters
@@ -139,7 +139,7 @@ def _tl_to_bs_cmds(tl_cmds, tl_id, db):
     tl_id
         timeline id
     db
-        Ska.DBI db object
+        ska_dbi db object
 
     Returns
     -------
@@ -170,14 +170,14 @@ def get_cmds(start, stop, mp_dir=MPLOGS_DIR):
     Get backstop commands corresponding to the supplied timeline load segments.
     The timeline load segments must be ordered by 'id'.
 
-    Return cmds in the format defined by Ska.ParseCM.read_backstop().
+    Return cmds in the format defined by ska_parsecm.read_backstop().
     """
     mp_dir = str(mp_dir)
 
     # Get timeline_loads within date range.  Also get non-load commands
     # within the date range covered by the timelines.
     server = os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3")
-    with Ska.DBI.DBI(dbi="sqlite", server=server) as db:
+    with ska_dbi.DBI(dbi="sqlite", server=server) as db:
         timeline_loads = db.fetchall(
             """SELECT * from timeline_loads
                                         WHERE datestop > '{}' AND datestart < '{}'
@@ -215,7 +215,7 @@ def get_cmds(start, stop, mp_dir=MPLOGS_DIR):
     orbit_cmd_files = set()
 
     for tl in timeline_loads:
-        bs_file = Ska.File.get_globfiles(
+        bs_file = ska_file.get_globfiles(
             os.path.join(mp_dir + tl.mp_dir, "*.backstop")
         )[0]
         if bs_file not in BACKSTOP_CACHE:

--- a/kadi/scripts/update_events.py
+++ b/kadi/scripts/update_events.py
@@ -8,7 +8,7 @@ import time
 
 import numpy as np
 import pyyaks.logger
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 from ska_helpers.run_info import log_run_info
 
 from kadi import __version__  # noqa

--- a/kadi/tests/test_events.py
+++ b/kadi/tests/test_events.py
@@ -4,7 +4,7 @@ import sys
 from copy import deepcopy
 
 import numpy as np
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 from kadi import events
 

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 import pytest
 import requests
-import Ska.File
-import Ska.ftp
+import ska_file
+import ska_ftp
 
 from kadi import occweb
 
 try:
-    Ska.ftp.parse_netrc()["lucky"]["login"]
-    lucky = Ska.ftp.SFTP(occweb.LUCKY)
+    ska_ftp.parse_netrc()["lucky"]["login"]
+    lucky = ska_ftp.SFTP(occweb.LUCKY)
 except Exception:
     HAS_LUCKY = False
 else:
@@ -24,8 +24,8 @@ def _test_put_get(user):
     filenames = ["test.dat", "test2.dat"]
 
     # Make a local temp dir and put files there
-    local_tmpdir = Ska.File.TempDir()
-    with Ska.File.chdir(local_tmpdir.name):
+    local_tmpdir = ska_file.TempDir()
+    with ska_file.chdir(local_tmpdir.name):
         for filename in filenames:
             open(filename, "w").write(filename)
         local_filenames = [os.path.abspath(x) for x in os.listdir(local_tmpdir.name)]
@@ -34,19 +34,19 @@ def _test_put_get(user):
     occweb.ftp_put_to_lucky(remote_tmpdir, local_filenames, user=user)
 
     # Make a new local temp dir for the return
-    local_tmpdir2 = Ska.File.TempDir()
+    local_tmpdir2 = ska_file.TempDir()
     local_filenames = [os.path.join(local_tmpdir2.name, x) for x in filenames]
     occweb.ftp_get_from_lucky(remote_tmpdir, local_filenames, user=user)
 
     # Clean up remote temp dir
-    lucky = Ska.ftp.SFTP(occweb.LUCKY)
+    lucky = ska_ftp.SFTP(occweb.LUCKY)
     if user is None:
         user = lucky.ftp.get_channel().transport.get_username()
     lucky.rmdir("/home/{}/{}".format(user, remote_tmpdir))
     lucky.close()
 
     # Make sure round-tripped files are the same
-    with Ska.File.chdir(local_tmpdir2.name):
+    with ska_file.chdir(local_tmpdir2.name):
         for filename in filenames:
             assert open(filename).read() == filename
 

--- a/manual_test_cmds.py
+++ b/manual_test_cmds.py
@@ -8,8 +8,8 @@ Test cmds archive.
 import os
 
 import numpy as np
-import Ska.File
-from Chandra.Time import DateTime
+import ska_file
+from chandra_time import DateTime
 
 from kadi import update_cmds
 
@@ -24,7 +24,7 @@ def test_ingest():
     # Some funkiness to be able to use two different data root values
     # within the same python session.  Inject the correct PATH and make
     # sure the LazyVals will re-read.
-    data_root_tmp = Ska.File.TempDir()
+    data_root_tmp = ska_file.TempDir()
     data_root = data_root_tmp.name
     update_cmds.main(
         [
@@ -52,7 +52,7 @@ def test_ingest():
 
     # Second part of funkiness to be able to use two different data root values
     # within the same python session.
-    data_root_tmp = Ska.File.TempDir()
+    data_root_tmp = ska_file.TempDir()
     data_root = data_root_tmp.name
     os.environ["KADI"] = os.path.abspath(data_root)
 

--- a/utils/migrate_cmds_to_cmds2.py
+++ b/utils/migrate_cmds_to_cmds2.py
@@ -7,7 +7,7 @@ import pickle
 from pathlib import Path
 
 import numpy as np
-import Ska.DBI
+import ska_dbi
 from astropy.table import Column, Table, vstack
 from cxotime import CxoTime
 
@@ -105,7 +105,7 @@ def migrate_cmds1_to_cmds2(start=None):
     rev_pars_dict = commands_v1.REV_PARS_DICT._val.copy()
 
     # This code is to get the load name ("source") for each cmd
-    with Ska.DBI.DBI(dbi="sqlite", server=str(CMD_STATES_PATH)) as db:
+    with ska_dbi.DBI(dbi="sqlite", server=str(CMD_STATES_PATH)) as db:
         timelines = db.fetchall("""SELECT * from timelines""")
     timelines = Table(timelines)
 

--- a/validate/gratings/compare_grating_moves.py
+++ b/validate/gratings/compare_grating_moves.py
@@ -12,10 +12,10 @@ http://asc.harvard.edu/mta_days/mta_otg/OTG_filtered.html
 >>> print mta_kadi_bad
 """
 import numpy as np
-import Ska.Numpy
+import ska_numpy
 from astropy.io import ascii
 from astropy.table import Table
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 from kadi import events
 
@@ -38,7 +38,7 @@ mta_starts = DateTime(mta_moves["START_TIME"], format="greta").secs
 # Kadi to nearest MTA
 
 indexes = np.arange(len(mta_starts))
-i_nearest = Ska.Numpy.interpolate(
+i_nearest = ska_numpy.interpolate(
     indexes, mta_starts, kadi_starts, sorted=True, method="nearest"
 )
 mta_nearest = mta_moves[i_nearest]
@@ -54,7 +54,7 @@ kadi_mta_bad = kadi_mta[bad]
 # MTA to nearest Kadi
 
 indexes = np.arange(len(kadi_starts))
-i_nearest = Ska.Numpy.interpolate(
+i_nearest = ska_numpy.interpolate(
     indexes, kadi_starts, mta_starts, sorted=True, method="nearest"
 )
 kadi_nearest = kadi_moves[i_nearest]

--- a/validate/write_events_cmds.py
+++ b/validate/write_events_cmds.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 import kadi.cmds
 import kadi.events


### PR DESCRIPTION
## Description

Flatten namespace packages using automated script in development.

## Testing

- [x] MacOS
```
(ska3-perf) ➜  kadi git:(flatten-namespace-package-names) git rev-parse HEAD 
b4ba74572471814c165fc86ebb2c3d52010b8df9
(ska3-perf) ➜  kadi git:(flatten-namespace-package-names) pytest kadi
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 218 items                                                                                                         

kadi/commands/tests/test_commands.py ...........................................................................      [ 34%]
kadi/commands/tests/test_states.py ......................x.............................................x............. [ 72%]
..........                                                                                                            [ 76%]
kadi/commands/tests/test_validate.py ...................                                                              [ 85%]
kadi/tests/test_events.py ..........                                                                                  [ 89%]
kadi/tests/test_occweb.py ......................                                                                      [100%]

======================================== 216 passed, 2 xfailed in 124.02s (0:02:04) =========================================
```
## Interface impact
None

## Functional testing
None

