### PR TITLE
Broaden setup.py package data glob to install pkl.gz and ecsv.gz test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     package_data={
         "kadi.commands": ["templates/*.html"],
-        "kadi.commands.tests": ["data/*.ecsv.gz"],
+        "kadi.commands.tests": ["data/*.gz"],
     },
     tests_require=["pytest"],
     data_files=data_files,


### PR DESCRIPTION
## Description

Broaden setup.py package data glob to install pkl.gz and ecsv.gz test data.  This is a tiny fix for #300 .

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested with a local ska3-masters but with this kadi PR "python setup.py installed".

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests don't pass without this fix and show errors like
```
E           FileNotFoundError: validation regression data /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/kadi/commands/tests/data/validators_2022297_5_True.pkl.gz not found.
E           Run `python -m kadi.commands.tests.test_validate` to generate it.
```
