### PR TITLE
Fix, document, and test get_rltt and get_schedule_stop_time

### DIFF
--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -566,7 +566,6 @@ class CommandTable(Table):
                 cmd["type"] == "LOAD_EVENT"
                 and cmd["params"].get("event_type") == "RUNNING_LOAD_TERMINATION_TIME"
             ):
-                print("RLTT", cmd["date"])
                 return cmd["date"]
 
         return None

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -549,23 +549,44 @@ class CommandTable(Table):
         for cmd in self:
             cmd["params"]
 
-    def get_rltt(self):
-        # Find the RLTT, which should be near the start of the table.
+    def get_rltt(self) -> str | None:
+        """Return the first RLTT (Running Load Termination Time) command in table.
+
+        This is a command of type LOAD_EVENT with
+        event_type=RUNNING_LOAD_TERMINATION_TIME.
+
+        Returns
+        -------
+        str or None
+            RLTT as a date string (e.g. '2012:001:23:59:59.999') or None if
+            there is no RLTT in the table.
+        """
         for cmd in self:
             if (
                 cmd["type"] == "LOAD_EVENT"
-                and cmd["params"]["event_type"] == "RUNNING_LOAD_TERMINATION_TIME"
+                and cmd["params"].get("event_type") == "RUNNING_LOAD_TERMINATION_TIME"
             ):
+                print("RLTT", cmd["date"])
                 return cmd["date"]
 
         return None
 
-    def get_scheduled_stop_time(self):
+    def get_scheduled_stop_time(self) -> str | None:
+        """Return the last scheduled stop time in table.
+
+        This is a command of type LOAD_EVENT with event_type=SCHEDULED_STOP_TIME.
+
+        Returns
+        -------
+        str or None
+            Scheduled stop time as a date string (e.g. '2012:001:23:59:59.999')
+            or None if there is no scheduled stop time in the table.
+        """
         for idx in range(len(self), 0, -1):
             cmd = self[idx - 1]
             if (
                 cmd["type"] == "LOAD_EVENT"
-                and cmd["params"]["event_type"] == "SCHEDULED_STOP_TIME"
+                and cmd["params"].get("event_type") == "SCHEDULED_STOP_TIME"
             ):
                 return cmd["date"]
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1315,3 +1315,17 @@ def test_fill_gaps():
     is_nan = np.isnan(vals_out)
     assert np.all(is_nan == np.isnan(vals_exp))
     assert np.all(vals_out[~is_nan] == vals_exp[~is_nan])
+
+
+def test_get_rltt_scheduled_stop_time():
+    """RLTT and scheduled stop time are both 2023:009:04:14:00.000."""
+    cmds = commands.get_cmds("2023:009", "2023:010")
+    rltt = cmds.get_rltt()
+    assert rltt == "2023:009:04:14:00.000"
+
+    stt = cmds.get_scheduled_stop_time()
+    assert stt == "2023:009:04:14:00.000"
+
+    cmds = commands.get_cmds("2023:009:12:00:00", "2023:010")
+    assert cmds.get_rltt() is None
+    assert cmds.get_scheduled_stop_time() is None


### PR DESCRIPTION
## Description

Fix, document, and test `CommandTable.get_rltt()` and `CommandTable.get_schedule_stop_time()`.

Fixes #306 

This is based off of `validate-finish-line` so all tests pass, but could be rebased and merged into master if need be.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

I confirmed that `get_rltt()` is called many times in the testing so the coverage is good. The new test is the only time `get_scheduled_stop_time` gets covered.

```
(ska3-perf) ➜  kadi git:(fix-rltt-schedule-stop) git rev-parse HEAD
ead858540edf30ab55e4d127022e48f249e1af57
(ska3-perf) ➜  kadi git:(fix-rltt-schedule-stop) pytest     
==================================================== test session starts =====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 220 items                                                                                                          

kadi/commands/tests/test_commands.py ............................................................................      [ 34%]
kadi/commands/tests/test_states.py ......................x.............................................x.............. [ 72%]
.........                                                                                                              [ 76%]
kadi/commands/tests/test_validate.py ....................                                                              [ 85%]
kadi/tests/test_events.py ..........                                                                                   [ 90%]
kadi/tests/test_occweb.py ......................                                                                       [100%]

========================================= 218 passed, 2 xfailed in 91.65s (0:01:31) ==========================================
```
Independent check of unit tests by Jean with that conftest.py and with a ska3-masters environment and dev/local versions of chandra_aca, ska_sun, and chandra_maneuver in PYTHONPATH.
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
