### PR TITLE
Improve `Command` and `Command not run` events

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -402,7 +402,7 @@ def update_archive_and_get_cmds_recent(
     start = CxoTime(min(loads["cmd_start"]))
     stop = CxoTime(max(loads["cmd_stop"]))
     # Allow for variations in input format of date
-    dates = np.array([CxoTime(date).date for date in cmd_events["Date"]])
+    dates = np.array([CxoTime(date).date for date in cmd_events["Date"]], dtype=str)
     bad = (dates < (start - 14 * u.day).date) | (dates > stop.date)
     cmd_events = cmd_events[~bad]
     cmd_events_ids = [evt["Event"] + " at " + evt["Date"] for evt in cmd_events]

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -868,15 +868,41 @@ class CommandTable(Table):
         the "Command not run" event in the Command Events sheet, e.g. the
         LETG retract command in the loads after the LETG insert anomaly.
         """
-        idxs_remove = set()
         idxs_not_run = np.where(self["type"] == "NOT_RUN")[0]
+        if len(idxs_not_run) == 0:
+            return
+
+        idxs_remove = set()
         for idx in idxs_not_run:
-            cmd = self[idx]
-            ok = (self["date"] == cmd["date"]) & (self["tlmsid"] == cmd["tlmsid"])
-            idxs_remove.update(np.where(ok)[0])
-        if idxs_remove:
-            logger.info(f"Removing {len(idxs_remove)} NOT_RUN cmds")
-            self.remove_rows(list(idxs_remove))
+            cmd_not_run = self[idx]
+            ok = (
+                (self["date"] == cmd_not_run["date"])
+                & (self["tlmsid"] == cmd_not_run["tlmsid"])
+                # Recover original command type
+                & (self["type"] == cmd_not_run["__type__"])
+            )
+            # Indexes of self commands that *might* match cmd_not_run.
+            idxs = np.arange(len(self))[ok].tolist()
+
+            # Now check that the params match.
+            idxs_match = []
+            for idx in idxs:
+                # Get the intersection of the keys in cmd_not_run["params"] and self["params"][idx]
+                self_params = self["params"][idx]
+                cmd_not_run_params = cmd_not_run["params"]
+                keys = set(cmd_not_run_params) & set(self_params)
+
+                # Check that the values match for all common keys
+                match = all(cmd_not_run_params[key] == self_params[key] for key in keys)
+                if match:
+                    idxs_match.append(idx)
+
+            idxs_remove.update(idxs_match)
+
+        logger.info(f"Removing {len(idxs_remove)} NOT_RUN cmds")
+        for idx in sorted(idxs_remove, reverse=True):
+            logger.debug(f"  {self[idx]}")
+        self.remove_rows(list(idxs_remove) + list(idxs_not_run))
 
 
 def get_par_idx_update_pars_dict(pars_dict, cmd, params=None, rev_pars_dict=None):

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -877,10 +877,13 @@ class CommandTable(Table):
             cmd_not_run = self[idx]
             ok = (
                 (self["date"] == cmd_not_run["date"])
-                & (self["tlmsid"] == cmd_not_run["tlmsid"])
-                # Recover original command type
                 & (self["type"] == cmd_not_run["__type__"])
+                & (self["tlmsid"] == cmd_not_run["tlmsid"])
             )
+            for key in ("scs", "step"):
+                if cmd_not_run[key] != 0:
+                    ok &= self[key] == cmd_not_run[key]
+
             # Indexes of self commands that *might* match cmd_not_run.
             idxs = np.arange(len(self))[ok].tolist()
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -37,6 +37,7 @@ from kadi.scripts import update_cmds_v1, update_cmds_v2
 HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()
 VERSIONS = ["1", "2"] if HAS_INTERNET else ["1"]
+DATA_DIR = Path(__file__).parent / "data"
 
 
 @pytest.fixture(scope="module", params=VERSIONS)
@@ -1417,3 +1418,95 @@ Definitive,2023:184:20:00:00.000,HRC not run,JUL0323A,Tom,Jean,F_HRC_SAFING 2023
     assert states_out == states_exp
 
     commands_v2.clear_caches()
+
+
+test_command_not_run_cases = [
+    {
+        # Matches multiple commands
+        "event": {
+            "date": "2023:351:13:30:33.849",
+            "event": "Command not run",
+            "params_str": "COMMAND_SW | TLMSID= COACTSX",
+        },
+        "removed": [3, 4],
+    },
+    {
+        # Matches one command with multiple criteria
+        "event": {
+            "date": "2023:351:13:30:33.849",
+            "event": "Command not run",
+            "params_str": (
+                "COMMAND_SW | TLMSID= COACTSX, HEX= 840B100, "
+                "MSID= COACTSX, COACTS1=177 , COACTS2=0 , SCS= 128, STEP= 690"
+            ),
+        },
+        "removed": [3],
+    },
+    {
+        # Wrong TLMSID
+        "event": {
+            "date": "2023:351:13:30:33.849",
+            "event": "Command not run",
+            "params_str": (
+                "COMMAND_SW | TLMSID= XXXXXXX, HEX= 840B100, "
+                "MSID= COACTSX, COACTS1=177 , COACTS2=0 , SCS= 128, STEP= 690"
+            ),
+        },
+        "removed": [],
+    },
+    {
+        # Wrong SCS
+        "event": {
+            "date": "2023:351:13:30:33.849",
+            "event": "Command not run",
+            "params_str": (
+                "COMMAND_SW | TLMSID= XXXXXXX, HEX= 840B100, "
+                "MSID= COACTSX, COACTS1=177 , COACTS2=0 , SCS= 133, STEP= 690"
+            ),
+        },
+        "removed": [],
+    },
+    {
+        # Wrong Step
+        "event": {
+            "date": "2023:351:13:30:33.849",
+            "event": "Command not run",
+            "params_str": (
+                "COMMAND_SW | TLMSID= XXXXXXX, HEX= 840B100, "
+                "MSID= COACTSX, COACTS1=177 , COACTS2=0 , SCS= 128, STEP= 111"
+            ),
+        },
+        "removed": [],
+    },
+    {
+        # No TLMSID
+        "event": {
+            "date": "2023:351:19:38:41.550",
+            "event": "Command not run",
+            "params_str": "SIMTRANS   | POS= 92904, SCS= 131, STEP= 1191",
+        },
+        "removed": [6],
+    },
+]
+
+
+@pytest.mark.parametrize("case", test_command_not_run_cases)
+def test_command_not_run(case):
+    backstop_text = """
+2023:351:13:30:32.824 | 0 0 | COMMAND_SW | TLMSID= AOMANUVR, HEX= 8034101, MSID= AOMANUVR, SCS= 128, STEP= 686
+2023:351:13:30:33.849 | 1 0 | COMMAND_SW | TLMSID= AOACRSTE, HEX= 8032001, MSID= AOACRSTE, SCS= 128, STEP= 688
+2023:351:13:30:33.849 | 2 0 | COMMAND_SW | TLMSID= COENASX, HEX= 844B100, MSID= COENASX, COENAS1=177 , SCS= 128, STEP= 689
+2023:351:13:30:33.849 | 3 0 | COMMAND_SW | TLMSID= COACTSX, HEX= 840B100, MSID= COACTSX, COACTS1=177 , COACTS2=0 , SCS= 128, STEP= 690
+2023:351:13:30:33.849 | 4 0 | COMMAND_SW | TLMSID= COACTSX, HEX= 8402600, MSID= COACTSX, COACTS1=38 , COACTS2=0 , SCS= 128, STEP= 691
+2023:351:13:30:55.373 | 5 0 | COMMAND_HW | TLMSID= 4MC5AEN, HEX= 4800012, MSID= 4MC5AEN, SCS= 131, STEP= 892
+2023:351:19:38:41.550 | 6 0 | SIMTRANS   | POS= 92904, SCS= 131, STEP= 1191
+    """  # noqa
+    cmds = commands.read_backstop(backstop_text.strip().splitlines())
+    cmds["source"] = "DEC1123A"
+    cmds_exp = cmds.copy()
+    cmds_exp.remove_rows(case["removed"])
+    cmds_from_event = get_cmds_from_event(**case["event"])
+    cmds_with_event = cmds.add_cmds(cmds_from_event)
+    cmds_with_event.sort_in_backstop_order()
+    cmds_with_event.remove_not_run_cmds()
+    assert cmds_with_event.pformat_like_backstop() == cmds_exp.pformat_like_backstop()

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -37,7 +37,6 @@ from kadi.scripts import update_cmds_v1, update_cmds_v2
 HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()
 VERSIONS = ["1", "2"] if HAS_INTERNET else ["1"]
-DATA_DIR = Path(__file__).parent / "data"
 
 
 @pytest.fixture(scope="module", params=VERSIONS)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -892,9 +892,9 @@ def test_get_starcats_as_table():
 @pytest.mark.parametrize(
     "par_str",
     [
-        "ACISPKT|  TLmSID= aa0000000 par1 = 1    par2=-1.0",
-        "AcisPKT|TLmSID=AA0000000 par1=1 par2=-1.0",
-        "ACISPKT|  TLmSID = aa0000000  par1  =1    par2 =  -1.0",
+        "ACISPKT|  TLmSID= aa0000000, par1 = 1 ,   par2=-1.0",
+        "AcisPKT|TLmSID=AA0000000 ,par1=1, par2=-1.0",
+        "ACISPKT|  TLmSID = aa0000000 , par1  =1,    par2 =  -1.0",
     ],
 )
 def test_get_cmds_from_event_case(par_str):
@@ -914,8 +914,8 @@ cmd_events_all_text = """\
     Event,Params
     Observing not run,FEB1422A
     Load not run,OCT2521A
-    Command,ACISPKT | TLMSID=AA00000000
-    Command not run,COMMAND_SW | TLMSID=4OHETGIN
+    Command,"ACISPKT | TLMSID= AA00000000, CMDS= 3, WORDS= 3, PACKET(40)= D80000300030603001300"
+    Command not run,"COMMAND_SW | TLMSID=4OHETGIN, HEX= 8050300, MSID= 4OHETGIN"
     RTS,"RTSLOAD,1_4_CTI,NUM_HOURS=39:00:00,SCS_NUM=135"
     Obsid,65527
     Maneuver,0.70546907 0.32988307 0.53440901 0.32847766
@@ -934,10 +934,10 @@ cmd_events_all_exps = [
         "2020:001:00:00:00.000 | LOAD_EVENT       | None       | CMD_EVT  | event=Load_not_run, event_date=2020:001:00:00:00, event_type=LOAD_NOT_RUN, load=OCT2521A, scs=0"  # noqa
     ],
     [
-        "2020:001:00:00:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=Command, event_date=2020:001:00:00:00, scs=0"  # noqa
+        "2020:001:00:00:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=Command, event_date=2020:001:00:00:00, cmds=3, words=3, scs=0"  # noqa
     ],
     [
-        "2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, scs=0"  # noqa
+        "2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, hex=8050300, msid=4OHETGIN, __type__=COMMAND_SW, scs=0"  # noqa
     ],
     [
         "2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS,"

--- a/utils/make_hrc_disable_events.py
+++ b/utils/make_hrc_disable_events.py
@@ -1,0 +1,129 @@
+"""Create a scenario to handle HRC commands not run to to HRC being disabled.
+
+This removes HRC state-impacting commands::
+
+    {"tlmsid": "224PCAON"},
+    {"tlmsid": "215PCAON"},
+    {"tlmsid": "COACTSX", "coacts1": 134},
+    {"tlmsid": "COENASX", "coenas1": 89},
+    {"tlmsid": "COENASX", "coenas1": 90},
+
+In practice the hardware commands are not in loads since the HRC return to science.
+
+This script creates a scenario ~/.kadi/<scenario> that can be used to remove these
+commands from the flight kadi commands database. It then tests that by setting
+``KADI_SCENARIO=<scenario>`` and getting kadi states over the time period of interest.
+
+The simplest way to do import to the flight sheet is to import the CSV file into a
+temporary Google Sheet, then copy/paste that table into the flight Chandra Command
+Events Google Sheet. Remember to create empty rows for the copy/paste.
+"""
+
+import argparse
+
+import kadi.paths
+from astropy import table
+from cxotime import CxoTime
+from kadi.commands import get_cmds
+from kadi.commands.core import CommandTable
+from kadi.commands.states import get_states
+from ska_helpers.utils import temp_env_var
+
+
+# When was F_HRC_SAFING script run in late 2023
+hrc_safing_date = "2023:343:02:00:00"
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Print HRC state-impacting commands that were not run due to HRC being disabled."
+    )
+    parser.add_argument(
+        "--start",
+        default=hrc_safing_date,
+        help=f"Start time for searching for commands (default={hrc_safing_date}))",
+    )
+    parser.add_argument(
+        "--stop",
+        help="Stop time for searching for commands (default=NOW)",
+    )
+    parser.add_argument(
+        "--status",
+        default="Definitive",
+        help="Status of command events (Definitive or In-work)",
+    )
+    parser.add_argument(
+        "--scenario",
+        default="hrc_disable",
+        help="Scenario name (default=hrc_disable). This creates ~/.kadi/<scenario>/cmd_events.csv.",
+    )
+    return parser
+
+
+def main():
+    opt = get_parser().parse_args()
+    make_cmd_events(opt)
+    test_cmd_events(opt)
+
+
+def test_cmd_events(opt):
+    def get_states_local():
+        states = get_states(
+            start=opt.start,
+            stop=opt.stop,
+            state_keys=["hrc_15v", "hrc_24v", "hrc_i", "hrc_s"],
+            merge_identical=True,
+        )
+        return states
+
+    print("Current flight states:")
+    get_states_local().pprint_all()
+    print()
+    print(f"States with HRC disable scenario {opt.scenario}:")
+    with temp_env_var("KADI_SCENARIO", opt.scenario):
+        get_states_local().pprint_all()
+
+
+def make_cmd_events(opt):
+    cmd_kwargs_list = [
+        {"tlmsid": "224PCAON"},
+        {"tlmsid": "215PCAON"},
+        {"tlmsid": "COACTSX", "coacts1": 134},
+        {"tlmsid": "COENASX", "coenas1": 89},
+        {"tlmsid": "COENASX", "coenas1": 90},
+    ]
+
+    rows = []
+    start = CxoTime(opt.start)
+    stop = CxoTime(opt.stop)
+
+    for cmd_kwargs in cmd_kwargs_list:
+        cmds: CommandTable = get_cmds(start=start, stop=stop, **cmd_kwargs)
+        print(f"{len(cmds)} cmd(s) found for {cmd_kwargs}")
+        params_str = ", ".join([f"{k.upper()}={v}" for k, v in cmd_kwargs.items()])
+        for cmd in cmds:
+            row = (
+                opt.status,
+                cmd["date"],
+                "Command not run",
+                f"{cmd['type']} | {params_str}",
+                "Tom Aldcroft",
+                "Jean Connelly",
+                f"Not run due to F_HRC_SAFING at {hrc_safing_date}",
+            )
+            rows.append(row)
+
+    names = "State Date Event Params Author Reviewer Comment".split()
+    cmd_events = table.Table(rows=rows, names=names)
+    cmd_events.sort("Date", reverse=True)
+    cmd_events.pprint_all()
+
+    cmd_events_path = kadi.paths.CMD_EVENTS_PATH(opt.scenario)
+    cmd_events_path.parent.mkdir(parents=True, exist_ok=True)
+    print()
+    print(f"Writing {len(cmd_events)} events to {cmd_events_path}")
+    cmd_events.write(cmd_events_path, format="ascii.csv", overwrite=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This improves the `Command` and `Command not run` event types in the Command Events Sheet.

The documentation states that a `Command` or `Command not run` can be copy/pasted from the backstop file.  In that format the parameters are comma-delimited, but the code was expecting space-delimited. In the flight Sheet we had only previously used a single parameter `TLMSID=...` so it never came up. The code now uses the `parse_cm` backstop parser and thus requires comma-delimited parameters.

This PR adds the capability (along with a number of tests) to include multiple parameters in the `Command not run` event to match only a single command. Previously only the `date` and `TLMSID` were actually being used to select the command(s) to ignore. For disabling HRC this turns out to select an additional unwanted command [^1].

[^1]: This ends up being benign but still not desirable.

Note: this PR requires a `masters` environment to pass tests. (Test fails are unrelated to this PR, however).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Format for `Command` and `Command not run` event `Params` changed to match the existing documentation (see link in the Sheet).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
 ```
(razl) ➜  kadi git:(better-command-not-run) git rev-parse HEAD 
9649618e3f44b3d791d1bba5e3d3167ced1de4f4
(razl) ➜  kadi git:(better-command-not-run) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 228 items                                                                                                                 

kadi/commands/tests/test_commands.py ....................................................................................     [ 36%]
kadi/commands/tests/test_states.py ......................x.............................................x..................... [ 76%]
..                                                                                                                            [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                     [ 85%]
kadi/tests/test_events.py ..........                                                                                          [ 90%]
kadi/tests/test_occweb.py ......................                                                                              [100%]

============================================ 226 passed, 2 xfailed in 108.50s (0:01:48) =============================================
```

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
➜  kadi git:(better-command-not-run) ✗ cat ~/.kadi/scenario_no_events/cmd_events.csv 
State,Date,Event,Params,Author,Reviewer,Comment

➜  kadi git:(better-command-not-run) env PYTHONPATH=$PWD KADI_SCENARIO="scenario_no_events" python utils/make_hrc_disable_events.py
0 cmd(s) found for {'tlmsid': '224PCAON'}
0 cmd(s) found for {'tlmsid': '215PCAON'}
6 cmd(s) found for {'tlmsid': 'COACTSX', 'coacts1': 134}
6 cmd(s) found for {'tlmsid': 'COENASX', 'coenas1': 89}
0 cmd(s) found for {'tlmsid': 'COENASX', 'coenas1': 90}
  State             Date              Event                       Params                     Author       Reviewer                       Comment                     
---------- --------------------- --------------- ---------------------------------------- ------------ ------------- ------------------------------------------------
Definitive 2023:349:21:35:40.736 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:349:21:34:14.736 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:348:17:24:07.233 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:348:17:22:41.233 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:348:02:39:22.863 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:348:02:37:56.863 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:347:04:00:30.727 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:347:03:59:04.727 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:346:10:52:10.084 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:346:10:50:44.084 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:345:12:42:16.541 Command not run  COMMAND_SW | TLMSID=COENASX, COENAS1=89 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00
Definitive 2023:345:12:40:50.541 Command not run COMMAND_SW | TLMSID=COACTSX, COACTS1=134 Tom Aldcroft Jean Connelly Not run due to F_HRC_SAFING at 2023:343:02:00:00

Writing 12 events to /Users/aldcroft/.kadi/hrc_disable/cmd_events.csv
Current flight states:
      datestart              datestop           tstart        tstop     hrc_15v hrc_24v hrc_i hrc_s trans_keys
--------------------- --------------------- ------------- ------------- ------- ------- ----- ----- ----------
2023:343:02:00:00.000 2023:345:12:40:50.541 818474469.184 818685719.725     OFF     OFF   OFF   OFF           
2023:345:12:40:50.541 2023:345:12:42:16.541 818685719.725 818685805.725      ON     OFF   OFF   OFF    hrc_15v
2023:345:12:42:16.541 2023:345:16:39:04.541 818685805.725 818700013.725      ON     OFF    ON   OFF      hrc_i
2023:345:16:39:04.541 2023:345:16:39:16.541 818700013.725 818700025.725      ON     OFF   OFF   OFF      hrc_i
2023:345:16:39:16.541 2023:346:10:50:44.084 818700025.725 818765513.268     OFF     OFF   OFF   OFF    hrc_15v
2023:346:10:50:44.084 2023:346:10:52:10.084 818765513.268 818765599.268      ON     OFF   OFF   OFF    hrc_15v
2023:346:10:52:10.084 2023:346:14:46:41.281 818765599.268 818779670.465      ON     OFF    ON   OFF      hrc_i
2023:346:14:46:41.281 2023:346:14:46:53.281 818779670.465 818779682.465      ON     OFF   OFF   OFF      hrc_i
2023:346:14:46:53.281 2023:347:03:59:04.727 818779682.465 818827213.911     OFF     OFF   OFF   OFF    hrc_15v
2023:347:03:59:04.727 2023:347:04:00:30.727 818827213.911 818827299.911      ON     OFF   OFF   OFF    hrc_15v
2023:347:04:00:30.727 2023:347:05:52:18.727 818827299.911 818834007.911      ON     OFF    ON   OFF      hrc_i
2023:347:05:52:18.727 2023:347:05:52:30.727 818834007.911 818834019.911      ON     OFF   OFF   OFF      hrc_i
2023:347:05:52:30.727 2023:348:02:37:56.863 818834019.911 818908746.047     OFF     OFF   OFF   OFF    hrc_15v
2023:348:02:37:56.863 2023:348:02:39:22.863 818908746.047 818908832.047      ON     OFF   OFF   OFF    hrc_15v
2023:348:02:39:22.863 2023:348:03:16:10.863 818908832.047 818911040.047      ON     OFF    ON   OFF      hrc_i
2023:348:03:16:10.863 2023:348:03:16:22.863 818911040.047 818911052.047      ON     OFF   OFF   OFF      hrc_i
2023:348:03:16:22.863 2023:348:17:22:41.233 818911052.047 818961830.417     OFF     OFF   OFF   OFF    hrc_15v
2023:348:17:22:41.233 2023:348:17:24:07.233 818961830.417 818961916.417      ON     OFF   OFF   OFF    hrc_15v
2023:348:17:24:07.233 2023:348:21:03:53.006 818961916.417 818975102.190      ON     OFF    ON   OFF      hrc_i
2023:348:21:03:53.006 2023:348:21:04:05.006 818975102.190 818975114.190      ON     OFF   OFF   OFF      hrc_i
2023:348:21:04:05.006 2023:349:21:34:14.736 818975114.190 819063323.920     OFF     OFF   OFF   OFF    hrc_15v
2023:349:21:34:14.736 2023:349:21:35:40.736 819063323.920 819063409.920      ON     OFF   OFF   OFF    hrc_15v
2023:349:21:35:40.736 2023:349:23:22:28.736 819063409.920 819069817.920      ON     OFF    ON   OFF      hrc_i
2023:349:23:22:28.736 2023:349:23:22:40.736 819069817.920 819069829.920      ON     OFF   OFF   OFF      hrc_i
2023:349:23:22:40.736 2024:008:06:24:35.427 819069829.920 821082344.611     OFF     OFF   OFF   OFF    hrc_15v

States with HRC disable scenario hrc_disable:
      datestart              datestop           tstart        tstop     hrc_15v hrc_24v hrc_i hrc_s trans_keys
--------------------- --------------------- ------------- ------------- ------- ------- ----- ----- ----------
2023:343:02:00:00.000 2024:008:06:24:35.427 818474469.184 821082344.611     OFF     OFF   OFF   OFF           
```

