### PR TITLE
Add "HRC not run" event to handle HRC being disabled

### DIFF
--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -162,6 +162,14 @@ def cmd_set_observing_not_run(load_name, date=None):
     return (cmd,)
 
 
+def cmd_set_hrc_not_run(load_name, date=None):
+    cmd = {
+        "type": "LOAD_EVENT",
+        "params": {"EVENT_TYPE": "HRC_NOT_RUN", "LOAD": load_name},
+    }
+    return (cmd,)
+
+
 def cmd_set_command(*args, date=None):
     params_str = args[0]
     cmd_type, args_str = params_str.split("|", 1)

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -163,11 +163,13 @@ def cmd_set_observing_not_run(load_name, date=None):
 
 
 def cmd_set_hrc_not_run(load_name, date=None):
-    cmd = {
-        "type": "LOAD_EVENT",
-        "params": {"EVENT_TYPE": "HRC_NOT_RUN", "LOAD": load_name},
-    }
-    return (cmd,)
+    cmds = (
+        {"type": "COMMAND_HW", "tlmsid": "215PCAOF"},  # 15 V off
+        {"type": "COMMAND_HW", "tlmsid": "224PCAOF"},  # 24 V off
+        {"type": "COMMAND_HW", "tlmsid": "2IMHVOF"},  # HRC-I off
+        {"type": "COMMAND_HW", "tlmsid": "2SPHVOF"},  # HRC-S off
+    )
+    return cmds
 
 
 def cmd_set_command(*args, date=None):

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -380,7 +380,8 @@ def update_archive_and_get_cmds_recent(
             # Cut HRC state-changing commands
             date = not_run_loads["HRC"][load_name]
             bad = (
-                ((cmds["tlmsid"] == "COACTSX") & (cmds["coacts1"] == 134))
+                (cmds["tlmsid"] == "224PCAON")
+                | ((cmds["tlmsid"] == "COACTSX") & (cmds["coacts1"] == 134))
                 | ((cmds["tlmsid"] == "COENASX") & (cmds["coenas1"] == 89))
                 | ((cmds["tlmsid"] == "COENASX") & (cmds["coenas1"] == 90))
             ) & (cmds["date"] > date)


### PR DESCRIPTION
## Description

This PR provides a better way to handle HRC being disabled than adding a bunch of `Command not run` events. It follows the pattern from `Load not run` and `Observing not run`.

I have added this new event type to the FOT MP documentation page just to get it done with now. There is no danger of this accidentally getting into the flight Events Sheet.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Supports new HRC not run entry on Events Sheet.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new unit test)
```
➜  kadi git:(hrc-disable) git rev-parse HEAD                                                        
8158e773d3a87499373378d17a5e414fd669b46d
➜  kadi git:(hrc-disable) pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 221 items                                                                                                            

kadi/commands/tests/test_commands.py .............................................................................       [ 34%]
kadi/commands/tests/test_states.py ......................x.............................................x................ [ 73%]
.......                                                                                                                  [ 76%]
kadi/commands/tests/test_validate.py ....................                                                                [ 85%]
kadi/tests/test_events.py ..........                                                                                     [ 90%]
kadi/tests/test_occweb.py ......................                                                                         [100%]

========================================== 219 passed, 2 xfailed in 141.11s (0:02:21) ==========================================
```

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
