### PR TITLE
Deprecate kadi load_ska_dir() in favor of parse_cm load_dir_from_load_name

### DIFF
--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -1103,14 +1103,14 @@ def get_par_idx_update_pars_dict(pars_dict, cmd, params=None, rev_pars_dict=None
     return par_idx
 
 
-def ska_load_dir(load_name):
-    root = Path(os.environ["SKA"]) / "data" / "mpcrit1" / "mplogs"
-    year = load_name[5:7]
-    if year == "99":
-        year = 1999
-    else:
-        year = 2000 + int(year)
-    load_rev = load_name[-1].lower()
-    load_dir = load_name[:-1]
-    load_dir = root / str(year) / load_dir / f"ofls{load_rev}"
-    return load_dir
+def ska_load_dir(load_name: str) -> Path:
+    """Return a load directory path in $SKA/data from a load name like "DEC1123B"."""
+
+    warnings.warn(
+        "ska_load_dir() is deprecated. Use parse_cm.paths.load_dir_from_load_name()",
+        FutureWarning,
+        stacklevel=2,
+    )
+    from parse_cm.paths import load_dir_from_load_name
+
+    return load_dir_from_load_name(load_name)


### PR DESCRIPTION
## Description

The `kadi.commands.core` function `load_ska_dir()` has been superceded by `parse_cm.paths.load_dir_from_load_name()`. This PR re-implements the kadi `load_ska_dir()` function as a call to `load_dir_from_load_name()` and issues a deprecation `FutureWarning`. 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This function is now deprecated and using it will cause unit tests to fail or issue warnings to the console.
From https://github.com/search?q=org%3Asot%20ska_load_dir&type=code it seems that only `mica` was using this (fixed in https://github.com/sot/mica/pull/288).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
With https://github.com/sot/mica/pull/288 installed:
```
(razl) ➜  kadi git:(deprecate-ska-load-dir) git rev-parse HEAD  
1d6011d8e0cd5ba9a2babc8dc57b1755d5e465ff
(razl) ➜  kadi git:(deprecate-ska-load-dir) pytest            
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 230 items                                                                                                                                                            

kadi/commands/tests/test_commands.py ......................................................................................                                              [ 37%]
kadi/commands/tests/test_states.py ......................x.............................................x.......................                                          [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                                                                [ 86%]
kadi/tests/test_events.py ..........                                                                                                                                     [ 90%]
kadi/tests/test_occweb.py ......................                                                                                                                         [100%]

================================================================== 228 passed, 2 xfailed in 98.30s (0:01:38) ===================================================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
