### PR TITLE
Skip tests if internet is not available

### DIFF
--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -10,13 +10,19 @@ import pytest
 import ska_sun
 
 from kadi.commands.utils import compress_time_series
-from kadi.commands.validate import Validate, ValidateRoll
+from kadi.commands.validate import Validate, ValidateRoll, get_command_sheet_exclude_intervals
 
 # Regression testing for this 5-day period covering a safe mode with plenty of things
 # happening. There are a number of violations in this period and a couple of excluded
 # intervals.
 REGRESSION_STOP = "2022:297"
 REGRESSION_DAYS = 5
+
+try:
+    get_command_sheet_exclude_intervals()
+    CMD_SHEET_AVAILABLE = True
+except ConnectionError:
+    CMD_SHEET_AVAILABLE = False
 
 
 def write_regression_data(stop, days, no_exclude):
@@ -107,6 +113,7 @@ def test_validate_subclasses():
     assert set(data_all_exp.keys()) == {cls.state_name for cls in Validate.subclasses}
 
 
+@pytest.mark.skipif(not CMD_SHEET_AVAILABLE, reason="Command sheet not available")
 @pytest.mark.parametrize("cls", Validate.subclasses)
 @pytest.mark.parametrize("no_exclude", [False, True])
 def test_validate_regression(cls, no_exclude, fast_sun_position_method):
@@ -135,6 +142,7 @@ def test_validate_regression(cls, no_exclude, fast_sun_position_method):
     assert np.all(data_obs["violations"] == data_exp["violations"])
 
 
+@pytest.mark.skipif(not CMD_SHEET_AVAILABLE, reason="Command sheet not available")
 def test_off_nominal_roll_violations():
     """Test off_nominal_roll violations over a time range with tail sun observations"""
     # Default sun position method is "accurate".

--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -7,14 +7,13 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import requests
 import ska_sun
+from testr.test_helper import has_internet
 
 from kadi.commands.utils import compress_time_series
 from kadi.commands.validate import (
     Validate,
     ValidateRoll,
-    get_command_sheet_exclude_intervals,
 )
 
 # Regression testing for this 5-day period covering a safe mode with plenty of things
@@ -23,11 +22,7 @@ from kadi.commands.validate import (
 REGRESSION_STOP = "2022:297"
 REGRESSION_DAYS = 5
 
-try:
-    get_command_sheet_exclude_intervals()
-    CMD_SHEET_AVAILABLE = True
-except requests.exceptions.ConnectionError:
-    CMD_SHEET_AVAILABLE = False
+HAS_INTERNET = has_internet()
 
 
 def write_regression_data(stop, days, no_exclude):
@@ -118,7 +113,7 @@ def test_validate_subclasses():
     assert set(data_all_exp.keys()) == {cls.state_name for cls in Validate.subclasses}
 
 
-@pytest.mark.skipif(not CMD_SHEET_AVAILABLE, reason="Command sheet not available")
+@pytest.mark.skipif(not HAS_INTERNET, reason="Command sheet not available")
 @pytest.mark.parametrize("cls", Validate.subclasses)
 @pytest.mark.parametrize("no_exclude", [False, True])
 def test_validate_regression(cls, no_exclude, fast_sun_position_method):
@@ -147,7 +142,7 @@ def test_validate_regression(cls, no_exclude, fast_sun_position_method):
     assert np.all(data_obs["violations"] == data_exp["violations"])
 
 
-@pytest.mark.skipif(not CMD_SHEET_AVAILABLE, reason="Command sheet not available")
+@pytest.mark.skipif(not HAS_INTERNET, reason="Command sheet not available")
 def test_off_nominal_roll_violations():
     """Test off_nominal_roll violations over a time range with tail sun observations"""
     # Default sun position method is "accurate".

--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -10,7 +10,11 @@ import pytest
 import ska_sun
 
 from kadi.commands.utils import compress_time_series
-from kadi.commands.validate import Validate, ValidateRoll, get_command_sheet_exclude_intervals
+from kadi.commands.validate import (
+    Validate,
+    ValidateRoll,
+    get_command_sheet_exclude_intervals,
+)
 
 # Regression testing for this 5-day period covering a safe mode with plenty of things
 # happening. There are a number of violations in this period and a couple of excluded

--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -4,6 +4,7 @@ import functools
 import gzip
 import pickle
 from pathlib import Path
+import requests
 
 import numpy as np
 import pytest
@@ -25,7 +26,7 @@ REGRESSION_DAYS = 5
 try:
     get_command_sheet_exclude_intervals()
     CMD_SHEET_AVAILABLE = True
-except ConnectionError:
+except requests.exceptions.ConnectionError:
     CMD_SHEET_AVAILABLE = False
 
 

--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -4,10 +4,10 @@ import functools
 import gzip
 import pickle
 from pathlib import Path
-import requests
 
 import numpy as np
 import pytest
+import requests
 import ska_sun
 
 from kadi.commands.utils import compress_time_series

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 import ska_file
 import ska_ftp
+from testr.test_helper import has_internet
 
 from kadi import occweb
 
@@ -66,7 +67,7 @@ def test_put_get_user_none():
 # uses the /proj/sot/ska/data/aspect_authorization area, so existence of the right file
 # in there can just be checked by the get_auth routine
 user, passwd = occweb.get_auth()
-HAS_OCCWEB = bool(user is not None)
+HAS_OCCWEB = bool(user is not None) and has_internet()
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
@@ -139,6 +140,7 @@ def test_get_occweb_noodle(lowercase, backslash):
     assert files_path.pformat_all() == exp
 
 
+@pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 @pytest.mark.parametrize("noodle_path", occweb.NOODLE_OCCWEB_MAP)
 def test_all_get_occweb_noodle(noodle_path):
     """Make sure we can get a directory from noodle for all available


### PR DESCRIPTION
## Description

Skip tests if internet is not available.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (with WiFi on and off by @taldcroft)
```
masters) ➜  kadi git:(skip-test) git rev-parse HEAD
b47f543e7f61acd180fda7b649e0358c8411f39b
```
### Without internet (wifi off)
```
(masters) ➜  kadi git:(skip-test) pytest
===================================================== test session starts =====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 174 items                                                                                                           

kadi/commands/tests/test_commands.py ........sssss..ss...............................................ss...s......       [ 43%]
kadi/commands/tests/test_states.py ......................x.......................                                       [ 70%]
kadi/commands/tests/test_validate.py .sssssssssssssssssss                                                               [ 81%]
kadi/tests/test_events.py ..........                                                                                    [ 87%]
kadi/tests/test_occweb.py ssssssssssssssssssssss                                                                        [100%]

========================================= 122 passed, 51 skipped, 1 xfailed in 16.44s =========================================
```
### With internet
```
(masters) ➜  kadi git:(skip-test) pytest
===================================================== test session starts =====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 228 items                                                                                                           

kadi/commands/tests/test_commands.py .................................................................................. [ 35%]
..                                                                                                                      [ 36%]
kadi/commands/tests/test_states.py ......................x.............................................x............... [ 73%]
........                                                                                                                [ 77%]
kadi/commands/tests/test_validate.py ....................                                                               [ 85%]
kadi/tests/test_events.py ..........                                                                                    [ 90%]
kadi/tests/test_occweb.py ......................                                                                        [100%]

========================================= 226 passed, 2 xfailed in 100.15s (0:01:40) ==========================================
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
