### PR TITLE
Fix unintended side-effect of add_cmds

### DIFF
--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -608,16 +608,17 @@ class CommandTable(Table):
         -------
         CommandTable
         """
+        orig = self
         if rltt is not None:
-            remove_idxs = np.where(self["date"] > rltt)[0]
-            self.remove_rows(remove_idxs)
+            ok = orig["date"] <= rltt
+            orig = orig[ok]
 
         try:
             # Substantially faster than plain Table vstack (this is slow due to
             # checks for strings overflowing and other generalities)
-            out = vstack_exact([self, cmds])
+            out = vstack_exact([orig, cmds])
         except ValueError:
-            out = vstack([self, cmds])
+            out = vstack([orig, cmds])
         out.sort_in_backstop_order()
         out.rev_pars_dict = self.rev_pars_dict
 


### PR DESCRIPTION
## Description

The `CommandTable.add_cmds()` method had a bug where it would update the original `self` table in place (using `remove_rows`) prior to using it for computing the new table with additional commands. I think the original idea of this method was for the whole thing to be in-place but that was inconvenient.

This fixes the issue by not using `remove_rows` and defines a new reference to the original commands which is filtered NOT in-place.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
