### PR TITLE
Add command events to implement maneuver to pitch and roll about sun line

### DIFF
--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -133,6 +133,18 @@ def cmd_set_nsm(date=None):
     return out
 
 
+def cmd_set_maneuver_sun_pitch(pitch, date=None):
+    """Maneuver to ``pitch`` Sun pitch angle (absolute)."""
+    cmd = dict(type="LOAD_EVENT", tlmsid="SUN_PITCH", params={"PITCH": pitch})
+    return (cmd,)
+
+
+def cmd_set_maneuver_roll_sun(roll, date=None):
+    """Maneuver by ``angle`` degrees in roll about Sun line (relative to current)."""
+    cmd = dict(type="LOAD_EVENT", tlmsid="ROLL_SUN", params={"ROLL": roll})
+    return (cmd,)
+
+
 def cmd_set_safe_mode(date=None):
     safe_mode_cmds = (
         dict(type="COMMAND_SW", tlmsid="ACPCSFSU"),  # CPE set pcad mode to safe sun

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -139,9 +139,9 @@ def cmd_set_maneuver_sun_pitch(pitch, date=None):
     return (cmd,)
 
 
-def cmd_set_maneuver_roll_sun(roll, date=None):
+def cmd_set_maneuver_sun_rasl(rasl, date=None):
     """Maneuver by ``angle`` degrees in roll about Sun line (relative to current)."""
-    cmd = dict(type="LOAD_EVENT", tlmsid="ROLL_SUN", params={"ROLL": roll})
+    cmd = dict(type="LOAD_EVENT", tlmsid="SUN_RASL", params={"RASL": rasl})
     return (cmd,)
 
 

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -17,7 +17,7 @@ import ska_sun
 from astropy.table import Column, Table
 from chandra_time import DateTime, date2secs, secs2date
 from cxotime import CxoTime
-from Quaternion import quat_to_equatorial
+from Quaternion import Quat, quat_to_equatorial
 
 from kadi import commands
 
@@ -1392,6 +1392,58 @@ class NormalSunTransition(ManeuverTransition):
 
         # Do the maneuver
         cls.add_manvr_transitions(date, transitions, state, idx)
+
+
+class ManeuverToPitchTransition(ManeuverTransition):
+    """
+    Like ``ManeuverTransition`` except perform a pure-pitch maneuver from attitude.
+
+    This does not change the PCAD mode.
+    """
+
+    command_attributes = {"type": "LOAD_EVENT", "tlmsid": "SUN_PITCH"}
+    state_keys = PCAD_STATE_KEYS
+
+    @classmethod
+    def set_transitions(cls, transitions, cmds, start, stop):
+        state_cmds = cls.get_state_changing_commands(cmds)
+
+        for cmd in state_cmds:
+            transitions[cmd["date"]]["maneuver_transition"] = functools.partial(
+                cls.callback, cmd["params"]["pitch"]
+            )
+
+    @staticmethod
+    def callback(pitch, date, transitions, state, idx):
+        """
+        This is a transition function callback.
+
+        It directly sets the state pcad_mode to NSUN and target quaternion to
+        the expected sun pointed attitude.  It then calls the parent method to
+        add the actual maneuver.
+        """
+        # Setup for maneuver to sun-pointed attitude from current att
+        curr_att = [state[qc] for qc in QUAT_COMPS]
+
+        # If current attitude is not defined then just drop the NSM maneuver on
+        # the floor. The state will start getting defined when the first normal
+        # maneuver happens.
+        if None in curr_att:
+            return
+
+        curr_att = Quat(curr_att)
+        sun_ra, sun_dec = ska_sun.position(date)
+        curr_pitch = ska_sun.pitch(
+            curr_att.ra, curr_att.dec, sun_ra=sun_ra, sun_dec=sun_dec
+        )
+        targ_att = ska_sun.apply_sun_pitch_yaw(
+            curr_att, pitch=pitch - curr_pitch, yaw=0, sun_ra=sun_ra, sun_dec=sun_dec
+        )
+        for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
+            state["targ_" + qc] = targ_q
+
+        # Do the maneuver
+        ManeuverTransition.add_manvr_transitions(date, transitions, state, idx)
 
 
 ###################################################################

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -1394,7 +1394,7 @@ class NormalSunTransition(ManeuverTransition):
         cls.add_manvr_transitions(date, transitions, state, idx)
 
 
-class ManeuverToPitchTransition(ManeuverTransition):
+class ManeuverSunPitchTransition(ManeuverTransition):
     """
     Like ``ManeuverTransition`` except perform a pure-pitch maneuver from attitude.
 
@@ -1415,13 +1415,6 @@ class ManeuverToPitchTransition(ManeuverTransition):
 
     @staticmethod
     def callback(pitch, date, transitions, state, idx):
-        """
-        This is a transition function callback.
-
-        It directly sets the state pcad_mode to NSUN and target quaternion to
-        the expected sun pointed attitude.  It then calls the parent method to
-        add the actual maneuver.
-        """
         # Setup for maneuver to sun-pointed attitude from current att
         curr_att = [state[qc] for qc in QUAT_COMPS]
 
@@ -1438,6 +1431,48 @@ class ManeuverToPitchTransition(ManeuverTransition):
         )
         targ_att = ska_sun.apply_sun_pitch_yaw(
             curr_att, pitch=pitch - curr_pitch, yaw=0, sun_ra=sun_ra, sun_dec=sun_dec
+        )
+        for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
+            state["targ_" + qc] = targ_q
+
+        # Do the maneuver
+        ManeuverTransition.add_manvr_transitions(date, transitions, state, idx)
+
+
+class ManeuverSunRaslTransition(ManeuverTransition):
+    """
+    Like ``ManeuverTransition`` except roll about the sun line.
+
+    This does not change the PCAD mode.
+    """
+
+    command_attributes = {"type": "LOAD_EVENT", "tlmsid": "SUN_RASL"}
+    state_keys = PCAD_STATE_KEYS
+
+    @classmethod
+    def set_transitions(cls, transitions, cmds, start, stop):
+        state_cmds = cls.get_state_changing_commands(cmds)
+
+        for cmd in state_cmds:
+            transitions[cmd["date"]]["maneuver_transition"] = functools.partial(
+                cls.callback, cmd["params"]["rasl"]
+            )
+
+    @staticmethod
+    def callback(rasl, date, transitions, state, idx):
+        # Setup for maneuver to sun-pointed attitude from current att
+        curr_att = [state[qc] for qc in QUAT_COMPS]
+
+        # If current attitude is not defined then just drop the NSM maneuver on
+        # the floor. The state will start getting defined when the first normal
+        # maneuver happens.
+        if None in curr_att:
+            return
+
+        curr_att = Quat(curr_att)
+        sun_ra, sun_dec = ska_sun.position(date)
+        targ_att = ska_sun.apply_sun_pitch_yaw(
+            curr_att, yaw=rasl, sun_ra=sun_ra, sun_dec=sun_dec
         )
         for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
             state["targ_" + qc] = targ_q

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -639,7 +639,7 @@ Definitive,2024:024:09:44:06,NSM,,,,
     pitch2, rasl2 = ska_sun.get_sun_pitch_yaw(q2.ra, q2.dec, dates[1])
     assert np.isclose(pitch1, 160, atol=0.1)
     assert np.isclose(pitch2, 160, atol=0.5)
-    assert np.isclose(rasl2 - rasl1, 90, atol=0.5)
+    assert np.isclose((rasl2 - rasl1) % 360, 90, atol=0.5)
 
     commands_v2.clear_caches()
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -21,6 +21,7 @@ warnings.filterwarnings(
     message="kadi commands v1 is deprecated, use v2 instead",
 )
 
+import kadi.commands.states as kcs
 from kadi import commands
 from kadi.commands import (
     commands_v1,
@@ -553,6 +554,72 @@ Date,Event,Params,Author,Comment
         " hex=7E00000, msid=CNOOPLR, scs=128",
     ]
     assert cmds.pformat_like_backstop() == exp
+    commands_v2.clear_caches()
+
+
+stop_date_2024_01_30 = stop_date_fixture_factory("2024-01-30")
+
+
+@pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
+def test_nsm_offset_pitch_command_event(stop_date_2024_01_30):  # noqa: ARG001
+    """Test custom scenario with NSM offset pitch load event command"""
+    # First make the cmd_events.csv file for the scenario
+    scenario = "test_nsm_offset_pitch"
+    cmds_dir = Path(commands_v2.conf.commands_dir) / scenario
+    cmds_dir.mkdir(exist_ok=True, parents=True)
+    # Note variation in format of date, since this comes from humans.
+    cmd_evts_text = """\
+State,Date,Event,Params,Author,Reviewer,Comment
+Definitive,2024:025:00:00:00.000,Maneuver sun pitch,160,Tom Aldcroft,John Scott,
+Definitive,2024:024:09:44:06.000,NSM,,John Scott,Julia Zachary,
+"""
+    (cmds_dir / "cmd_events.csv").write_text(cmd_evts_text)
+
+    # Now get commands in a time range that includes the new command events
+    cmds = commands_v2.get_cmds(
+        "2024-01-24 12:00:00", "2024-01-25 02:00:00", scenario=scenario
+    )
+    cmds = cmds[(cmds["tlmsid"] != "OBS") & (cmds["type"] != "ORBPOINT")]
+    exp = [
+        "2024:025:00:00:00.000 | LOAD_EVENT       | SUN_PITCH  | CMD_EVT  |"
+        " event=Maneuver_sun_pitch, event_date=2024:025:00:00:00, pitch=160, scs=0"
+    ]
+
+    assert cmds.pformat_like_backstop() == exp
+
+    states = kcs.get_states(
+        "2024:024:09:00:00",
+        "2024:025:12:00:00",
+        state_keys=["pitch", "pcad_mode"],
+        scenario=scenario,
+    )
+    exp = [
+        "      datestart       pitch pcad_mode",
+        "--------------------- ----- ---------",
+        "2024:024:09:00:00.000 172.7      NPNT",
+        "2024:024:09:13:49.112 172.7      NMAN",
+        "2024:024:09:13:59.363 170.9      NMAN",
+        "2024:024:09:18:48.003 162.4      NMAN",
+        "2024:024:09:23:36.644 145.8      NMAN",
+        "2024:024:09:28:25.284 126.1      NMAN",
+        "2024:024:09:33:13.925 109.8      NMAN",
+        "2024:024:09:38:02.565 101.5      NMAN",
+        "2024:024:09:42:51.205  99.6      NPNT",
+        "2024:024:09:44:06.000  97.2      NSUN",
+        "2024:024:09:49:20.973  92.4      NSUN",
+        "2024:024:09:54:35.946  90.0      NSUN",
+        "2024:025:00:00:00.000  93.0      NSUN",
+        "2024:025:00:05:17.540 104.5      NSUN",
+        "2024:025:00:10:35.081 125.2      NSUN",
+        "2024:025:00:15:52.621 146.0      NSUN",
+        "2024:025:00:21:10.161 157.4      NSUN",
+        "2024:025:00:26:27.701 160.0      NSUN",
+    ]
+
+    out = states["datestart", "pitch", "pcad_mode"]
+    out["pitch"].format = ".1f"
+    assert out.pformat_all() == exp
+
     commands_v2.clear_caches()
 
 

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -579,12 +579,12 @@ Definitive,2024:024:09:44:06,NSM,,,,
 
     # Now get commands in a time range that includes the new command events
     cmds = commands_v2.get_cmds(
-        "2024-01-24 12:00:00", "2024-01-25 02:00:00", scenario=scenario
+        "2024-01-24 12:00:00", "2024-01-25 05:00:00", scenario=scenario
     )
     cmds = cmds[(cmds["tlmsid"] != "OBS") & (cmds["type"] != "ORBPOINT")]
     exp = [
-        "2024:025:00:00:00.000 | LOAD_EVENT       | SUN_PITCH  | CMD_EVT  |"
-        " event=Maneuver_sun_pitch, event_date=2024:025:00:00:00, pitch=160, scs=0"
+        "2024:025:00:00:00.000 | LOAD_EVENT       | SUN_PITCH  | CMD_EVT  | event=Maneuver_sun_pitch, event_date=2024:025:00:00:00, pitch=160, scs=0",
+        "2024:025:04:00:00.000 | LOAD_EVENT       | SUN_RASL   | CMD_EVT  | event=Maneuver_sun_rasl, event_date=2024:025:04:00:00, rasl=90, scs=0",
     ]
 
     assert cmds.pformat_like_backstop() == exp


### PR DESCRIPTION
## Description

This adds two new command events for the Chandra Comment Events sheet:
- `Maneuver sun pitch`: maneuver to a specified absolute sun pitch angle
- `Maneuver sun rasl`: roll about sun line by specified angle

Note that this passes tests with or without https://github.com/sot/ska_sun/pull/37 which changes the sign convention of roll about the sun line. This is the case because the code applies the rasl using `apply_sun_pitch_yaw` and then measures the change using `get_sun_pitch_yaw`. Those use the same sign convention so `rasl2 - rasl1` is the same in both cases (with/without 37).

Closes #316

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
No code impacts but this adds new command events. When this is ready to merge I will update the FOT MP command events TWiki documentation to include the two new command event types.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
Tested with https://github.com/sot/ska_sun/pull/37 in the PYTHONPATH.

- [x] Mac
```
(ska3) ➜  kadi git:(nsm-offset-pitch) printenv PYTHONPATH                                   
/Users/aldcroft/git/ska_sun
(ska3) ➜  kadi git:(nsm-offset-pitch) python -c "import ska_sun; print(ska_sun.__version__)"
3.13.1.dev1+g3579ca1
(ska3) ➜  kadi git:(nsm-offset-pitch) git rev-parse HEAD                                    
31358c88273b96c9ece0899c7320048303aa2faf
(ska3) ➜  kadi git:(nsm-offset-pitch) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 233 items                                                                                                                 

kadi/commands/tests/test_commands.py .......................................................................................  [ 37%]
kadi/commands/tests/test_states.py .......................x..............................................x................... [ 75%]
....                                                                                                                          [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                     [ 86%]
kadi/tests/test_events.py ..........                                                                                          [ 90%]
kadi/tests/test_occweb.py ......................                                                                              [100%]

```

Independent check of unit tests by Jean with a ska3-masters with ska_sun PR up-to-date
- [x] OSX
```

(ska3) flame:kadi jean$ pytest
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 233 items                                                                                                                                           

kadi/commands/tests/test_commands.py .......s.......s......................................................................s                            [ 37%]
kadi/commands/tests/test_states.py .......................x..............................................x.......................                       [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                                               [ 86%]
kadi/tests/test_events.py ..........                                                                                                                    [ 90%]
kadi/tests/test_occweb.py ......................                                                                                                        [100%]

====================================================================== warnings summary =======================================================================
kadi/kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year0]
  /Users/jean/miniconda3/envs/ska3/lib/python3.10/site-packages/setuptools_scm/git.py:295: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 228 passed, 3 skipped, 2 xfailed, 1 warning in 91.89s (0:01:31) ===============================================
(ska3) flame:kadi jean$ git rev-parse HEAD
31358c88273b96c9ece0899c7320048303aa2faf
(ska3) flame:kadi jean$ python -c "import ska_sun; print(ska_sun.__version__)"
3.13.1.dev2+g2ec26c1
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
