### PR TITLE
Fix numpy str FutureWarning and modernize get_ifot slightly

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -2367,7 +2367,7 @@ class DsnComm(IFotEvent):
         "soe",
         "station",
     ]
-    ifot_types = {"DSN_COMM.bot": "str", "DSN_COMM.eot": "str"}
+    ifot_types = {"DSN_COMM.bot": str, "DSN_COMM.eot": str}
 
     lookback = 21  # days of lookback
     lookback_delete = 7  # Remove all comms in database prior to 7 days ago to account

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -13,7 +13,6 @@ from collections import OrderedDict as odict
 from pathlib import Path
 
 import configobj
-import numpy as np
 import requests
 from astropy.io import ascii
 from astropy.table import Table
@@ -99,10 +98,47 @@ def get_url(page, timeout=TIMEOUT):
 
 
 def get_ifot(
-    event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT, types={}
+    event_type,
+    start=None,
+    stop=None,
+    props=None,
+    columns=None,
+    timeout=TIMEOUT,
+    types=None,
 ):
+    """Get the iFOT event table for a given event type.
+
+    Parameters
+    ----------
+    event_type : str
+        Event type (e.g. "ECLIPSE", "LOADSEG", "CAP")
+    start : str, CxoTimeLike
+        Start time for query
+    stop : str, CxoTimeLike
+        Stop time for query
+    props : list of str
+        List of iFOT properties to return
+    columns : list of str
+        List of columns to return
+    timeout : float
+        Timeout for the request
+    types : dict
+        Dictionary of column types
+
+    Returns
+    -------
+    dat : astropy.table.Table
+        Table of iFOT events
+    """
     start = DateTime("1998:001:12:00:00" if start is None else start)
     stop = DateTime(stop)
+    if props is None:
+        props = []
+    if columns is None:
+        columns = []
+    if types is None:
+        types = {}
+
     event_props = ".".join([event_type] + props)
 
     params = odict(

--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -126,11 +126,8 @@ def get_ifot(
     text = re.sub(r"\r\n", " ", text)
     lines = [x for x in text.split("\t\n") if x.strip()]
 
-    converters = {
-        key: [ascii.convert_numpy(getattr(np, type_))] for key, type_ in types.items()
-    }
     dat = ascii.read(
-        lines, format="tab", guess=False, converters=converters, fill_values=None
+        lines, format="tab", guess=False, converters=types, fill_values=None
     )
     return dat
 


### PR DESCRIPTION
## Description

This fixes a FutureWarning caused by using `np.str`. The code got much cleaner due to an improvement in `io.ascii` since this kadi code was written. Now the `converters` kwarg can just be a dict of types (exactly the same as the `types` kwarg here). See https://docs.astropy.org/en/stable/io/ascii/read.html#parameters-for-read.

In addition I added a docstring and removed mutable values as keyword defaults in `get_ifot`.

Fixes #320

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
The `types` dict option of `get_ifot` now requires that the type be specified as the actual type object (e.g. `str` or `np.int64`) instead of a `str` that is used in `getattr(np, type)`.

I searched the `sot` repo on GitHub and found no instances outside of kadi that used the `types` kwarg of `get_ifot`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(numpy-str-deprecation) git rev-parse HEAD                            
80834453bf4d9dc7dac0b9a5d8ae73e6bde8c375
(ska3) ➜  kadi git:(numpy-str-deprecation) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 232 items                                                                                                                 

kadi/commands/tests/test_commands.py ......................................................................................   [ 37%]
kadi/commands/tests/test_states.py .......................x..............................................x................... [ 75%]
....                                                                                                                          [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                     [ 86%]
kadi/tests/test_events.py ..........                                                                                          [ 90%]
kadi/tests/test_occweb.py ......................                                                                              [100%]
```

I don't have a `speedy` environment handy but that might be a good thing for the reviewer to test.

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I ran the `kadi_update_events` script locally in current ska3-flight and confirmed that it ran successfully. I also confirmed that it fails without the fix changing `"str"` to `str` in `models.py`.
