### PR TITLE
WIP : Change time threshold for auto-enable of SPM following eclipse

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -782,7 +782,7 @@ class SPMEclipseEnableTransition(BaseTransition):
     Automatic enable of sun position monitor.
 
     This occurs 11 minutes after eclipse exit, but only if the battery-connect
-    command occurs within 2:05 minutes of eclipse entry.
+    command occurs within 2.5 minutes of eclipse entry.
 
     Connect batteries is an event type COMMAND_SW and TLMSID= EOESTECN
     Eclipse entry is event type ORBPOINT with TYPE=PENTRY or TYPE=LSPENTRY
@@ -834,7 +834,7 @@ class EclipseEnableSPM(BaseTransition):
     """Flag to indicate whether SPM will be enabled 11 minutes after eclipse exit.
 
     This is evaluated at the time of eclipse entry and checks that the most recent
-    battery connect command (via the ``battery_connect`` state) was within 2:05 minutes
+    battery connect command (via the ``battery_connect`` state) was within 2.5 minutes
     of eclipse entry.
     """
 
@@ -878,7 +878,7 @@ class EclipseEnableSPM(BaseTransition):
         """
         battery_connect_time = date2secs(state["battery_connect"])
         eclipse_entry_time = date2secs(date)
-        enable_spm = eclipse_entry_time - battery_connect_time < 125
+        enable_spm = eclipse_entry_time - battery_connect_time < 150
         transition = {"date": date, "eclipse_enable_spm": enable_spm}
         add_transition(transitions, idx, transition)
 


### PR DESCRIPTION
## Description

The matching time threshold of 125 seconds between battery connect time and eclipse entry appears to be too low. Eclipses on 2024:043 and 2024:046 had a delta of 129 to 130 seconds. This results in the `sun_pos_mon` remaining disabled coming out of eclipse.

This PR changes that value to 150 sec (2.5 minutes). **This value may be changed since it causes test fails.**

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For about 30 seconds I changed the status of the two `COMMAND_SW | TLMSID=AOFUNCEN, AOPCADSE=30` commands on day 43 and 46 to be `In-work`. With that in place I ran kadi validate states locally and confirmed that the `sun_pos_mon` state matches telemetry.
