### PR TITLE
Change time threshold for auto-enable of SPM following eclipse

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -782,7 +782,7 @@ class SPMEclipseEnableTransition(BaseTransition):
     Automatic enable of sun position monitor.
 
     This occurs 11 minutes after eclipse exit, but only if the battery-connect
-    command occurs within 2.5 minutes of eclipse entry.
+    command occurs within 135 seconds of eclipse entry.
 
     Connect batteries is an event type COMMAND_SW and TLMSID= EOESTECN
     Eclipse entry is event type ORBPOINT with TYPE=PENTRY or TYPE=LSPENTRY

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -782,7 +782,7 @@ class SPMEclipseEnableTransition(BaseTransition):
     Automatic enable of sun position monitor.
 
     This occurs 11 minutes after eclipse exit, but only if the battery-connect
-    command occurs within 2:05 minutes of eclipse entry.
+    command occurs within 2.5 minutes of eclipse entry.
 
     Connect batteries is an event type COMMAND_SW and TLMSID= EOESTECN
     Eclipse entry is event type ORBPOINT with TYPE=PENTRY or TYPE=LSPENTRY
@@ -834,14 +834,19 @@ class EclipseEnableSPM(BaseTransition):
     """Flag to indicate whether SPM will be enabled 11 minutes after eclipse exit.
 
     This is evaluated at the time of eclipse entry and checks that the most recent
-    battery connect command (via the ``battery_connect`` state) was within 2:05 minutes
+    battery connect command (via the ``battery_connect`` state) was within 135 seconds
     of eclipse entry.
+
+    See email thread "Criteria for SPM auto-enable following eclipse" around 2024-Feb-17
+    for more details on the 135 second threshold.
     """
 
     command_attributes = {"type": "ORBPOINT"}
     command_params = {"event_type": ["PENTRY", "LSPENTRY"]}
     state_keys = SPM_STATE_KEYS
     default_value = False
+
+    BATTERY_CONNECT_MAX_DT = 135  # seconds
 
     @classmethod
     def set_transitions(cls, transitions_dict, cmds, start, stop):
@@ -873,12 +878,15 @@ class EclipseEnableSPM(BaseTransition):
     def callback(cls, date, transitions, state, idx):
         """Set flag if SPM will be enabled 11 minutes after eclipse exit.
 
-        ``battery_connect_time`` is the time of the battery connect EOESTECN command,
+        ``battery_connect`` is the time of the battery connect EOESTECN command,
         which must occur prior to this command which is eclipse entry.
         """
         battery_connect_time = date2secs(state["battery_connect"])
         eclipse_entry_time = date2secs(date)
-        enable_spm = eclipse_entry_time - battery_connect_time < 125
+        # By definition, the battery connect time is always less than the eclipse entry.
+        enable_spm = (
+            eclipse_entry_time - battery_connect_time < cls.BATTERY_CONNECT_MAX_DT
+        )
         transition = {"date": date, "eclipse_enable_spm": enable_spm}
         add_transition(transitions, idx, transition)
 

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1854,7 +1854,7 @@ def test_sun_pos_mon_within_eclipse():
         assert sts[names][-2:].pformat_all() == exp
 
 
-def test_sun_pos_mon_within_eclipse_no_spm_enab():
+def test_sun_pos_mon_within_eclipse_no_spm_enab(monkeypatch):
     """
     Test a case where battery connect is more than 125 sec before pentry.
 
@@ -1862,6 +1862,12 @@ def test_sun_pos_mon_within_eclipse_no_spm_enab():
     2005:014:15:33:49.164 | ORBPOINT         | None       | JAN1005B | PENTRY
     2005:014:16:38:09.164 | ORBPOINT         | None       | JAN1005B | PEXIT
     """
+    # PR #323 changed the time threshold from 125 to 135 sec. Here we monkeypatch back
+    # to 125 sec to test the case where battery connect is more than 125 sec
+    # before pentry. From telemetry this case with a dt of around 133 sec actually did
+    # end up with the SPM enabled.
+    monkeypatch.setattr(states.EclipseEnableSPM, "BATTERY_CONNECT_MAX_DT", 125)
+
     sts = states.get_states(
         "2005:014:16:38:10",  # Just after pexit
         "2005:014:17:00:00",  # 22 min later


### PR DESCRIPTION
## Description

The matching time threshold of 125 seconds between battery connect time and eclipse entry appears to be too low. Eclipses on 2024:043 and 2024:046 had a delta of 129 to 130 seconds. This results in the `sun_pos_mon` remaining disabled coming out of eclipse.

This PR changes that value to 135 sec. This has been confirmed as an acceptable value with FOT eng. See the email thread "Criteria for SPM auto-enable following eclipse" around 2024-Feb-17 for details.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(spm-eclipse-reenable-fix) git rev-parse HEAD                         
1ed12413410dbd49cf1adcf29ced7d5377aa44f1
(ska3) ➜  kadi git:(spm-eclipse-reenable-fix) pytest
========================================================== test session starts ==========================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 233 items                                                                                                                     

kadi/commands/tests/test_commands.py .......................................................................................      [ 37%]
kadi/commands/tests/test_states.py .......................x..............................................x....................... [ 77%]
                                                                                                                                  [ 77%]
kadi/commands/tests/test_validate.py ....................                                                                         [ 86%]
kadi/tests/test_events.py ..........                                                                                              [ 90%]
kadi/tests/test_occweb.py ......................                                                                                  [100%]
```

Independent check of unit tests by Jean
- [x] Linux ska3-flight

```
ska3-jeanconn-fido> git rev-parse HEAD
f37a897bdf0d8906766f5e8308cd9ce00b2fe0e1
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git, configfile: pytest.ini
plugins: anyio-3.6.2, timeout-2.1.0
collected 233 items                                                            

kadi/commands/tests/test_commands.py ................................... [ 15%]
....................................................                     [ 37%]
kadi/commands/tests/test_states.py .......................x............. [ 53%]
.................................x.......................                [ 77%]
kadi/commands/tests/test_validate.py ....................                [ 86%]
kadi/tests/test_events.py ..........                                     [ 90%]
kadi/tests/test_occweb.py ......................                         [100%]

=============================== warnings summary
```


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For about 30 seconds I changed the status of the two `COMMAND_SW | TLMSID=AOFUNCEN, AOPCADSE=30` commands on day 43 and 46 to be `In-work`. With that in place I ran kadi validate states locally and confirmed that the `sun_pos_mon` state matches telemetry. This was done in the git repo checked out at 1ed12413410dbd49cf1adcf29ced7d5377aa44f1.
