### PR TITLE
Just test commands version 2

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -39,7 +39,7 @@ from kadi.scripts import update_cmds_v1, update_cmds_v2
 
 HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()
-VERSIONS = ["1", "2"] if HAS_INTERNET else ["1"]
+VERSIONS = ["2"]
 
 
 @pytest.fixture(scope="module", params=VERSIONS)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -39,7 +39,7 @@ from kadi.scripts import update_cmds_v1, update_cmds_v2
 
 HAS_MPDIR = Path(os.environ["SKA"], "data", "mpcrit1", "mplogs", "2020").exists()
 HAS_INTERNET = has_internet()
-VERSIONS = ["2"]
+VERSIONS = ["2"] if HAS_INTERNET else []
 
 
 @pytest.fixture(scope="module", params=VERSIONS)

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -12,7 +12,6 @@ from astropy.table import Table
 from chandra_time import DateTime
 from cheta import fetch
 from cxotime import CxoTime
-from testr.test_helper import has_internet
 
 warnings.filterwarnings(
     "ignore",

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -12,6 +12,7 @@ from astropy.table import Table
 from chandra_time import DateTime
 from cheta import fetch
 from cxotime import CxoTime
+from testr.test_helper import has_internet
 
 warnings.filterwarnings(
     "ignore",
@@ -28,7 +29,7 @@ try:
 except Exception:
     HAS_PITCH = False
 
-VERSIONS = ["2"]
+VERSIONS = ["2"] if has_internet() else []
 
 
 @pytest.fixture(scope="module", params=VERSIONS)

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -29,7 +29,7 @@ try:
 except Exception:
     HAS_PITCH = False
 
-VERSIONS = ["1", "2"] if has_internet() else ["1"]
+VERSIONS = ["2"]
 
 
 @pytest.fixture(scope="module", params=VERSIONS)


### PR DESCRIPTION
## Description

Just test commands version 2.

I started to strip out the rest of the machinery (that is in the testing infrastructure to be *able* to test v1 or v2), and then figured for a first go maybe it makes sense to leave it in there and just do this super-tiny change to just stop running the v1 tests.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
1144d455f8d9f5bdd05a6c7bf17806a0e24c25db
ska3-jeanconn-fido> pytest
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 178 items                                                                                                                                                              

kadi/commands/tests/test_commands.py ...............................................................................                                                       [ 44%]
kadi/commands/tests/test_states.py .......................x.......................                                                                                         [ 70%]
kadi/commands/tests/test_validate.py ....................                                                                                                                  [ 82%]
kadi/tests/test_events.py ..........                                                                                                                                       [ 87%]
kadi/tests/test_occweb.py ......................                                                                                                                           [100%]

================================================================================ warnings summary ================================================================================
kadi/kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year0]
  /proj/sot/ska3/flight/lib/python3.11/site-packages/setuptools_scm/git.py:308: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 177 passed, 1 xfailed, 1 warning in 172.71s (0:02:52)
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
