### PR TITLE
Use single date for agasc1p8 promotion

### DIFF
--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -151,37 +151,17 @@ def set_star_ids(aca: dict) -> None:
     """
     from kadi.config import conf
 
-    date = aca["meta"]["date"]
-    if date < conf.date_start_agasc1p8_earliest:
-        # Always 1p7 before 2024-July-21 (before JUL2224 loads)
-        versions = ["1p7"]
-    elif date < conf.date_start_agasc1p8_latest:
-        # Could be 1p8 or 1p7 within 30 days later (uncertainty in promotion date)
-        versions = ["1p8", "1p7"]
-    else:
-        # Always 1p8 after 30 days after JUL2224
-        versions = ["1p8"]
+    version = "1p7" if aca["meta"]["date"] < conf.date_start_agasc1p8 else "1p8"
 
-    # Try allowed versions and stop on first success. If no success then issue warning.
+    # Try the AGASC version for that date. If no success then issue warning.
     # Be aware that _set_star_ids works in place so the try/except is not atomic so the
     # ``aca`` dict can be partially updated. This is not expected to be an issue in
     # practice, and a warning is issue in any case.
-    err_star_id = None
-    for version in versions:
-        try:
-            agasc_file = agasc.get_agasc_filename(version=version)
-        except FileNotFoundError:
-            logger.warning(f"AGASC {version} file not found")
-            continue
-        try:
-            _set_star_ids(aca, agasc_file)
-        except StarIdentificationFailed as err:
-            err_star_id = err
-        else:
-            break
-    else:
-        # All versions failed, issue warning
-        logger.warning(str(err_star_id))
+    agasc_file = agasc.get_agasc_filename(version=version)
+    try:
+        _set_star_ids(aca, agasc_file)
+    except StarIdentificationFailed as err:
+        logger.warning(str(err))
 
 
 def _set_star_ids(aca: dict, agasc_file: str) -> None:

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -841,14 +841,14 @@ def test_get_starcats_each_year(year):
         assert np.all(starcat["id"][ok] != -999)
 
 
-def test_get_starcat_agasc1p8_then_1p7():
+def test_get_starcat_only_agasc1p7():
     """
-    For obsid 2576, try AGASC 1.8 then fall back to 1.7 and show successful star
+    For obsids 3829 and 2576, try AGASC 1.7 only and show successful star
     identification.
     """
     with (
         conf.set_temp("cache_starcats", False),
-        conf.set_temp("date_start_agasc1p8_earliest", "1994:001"),
+        conf.set_temp("date_start_agasc1p8", "2003:001"),
     ):
         starcat = get_starcats(
             "2002:365:18:00:00", "2002:365:19:00:00", scenario="flight"
@@ -865,10 +865,9 @@ def test_get_starcat_only_agasc1p8():
     """
     with (
         conf.set_temp("cache_starcats", False),
-        conf.set_temp("date_start_agasc1p8_earliest", "1994:001"),
-        conf.set_temp("date_start_agasc1p8_latest", "1994:002"),
+        conf.set_temp("date_start_agasc1p8", "1994:001"),
     ):
-        # Force AGASC 1.7 and show that star identification fails
+        # Force AGASC 1.8 and show that star identification fails
         with ska_helpers.utils.set_log_level(kadi.logger, "CRITICAL"):
             starcats = get_starcats(
                 "2002:365:16:00:00", "2002:365:19:00:00", scenario="flight"

--- a/kadi/config.py
+++ b/kadi/config.py
@@ -69,7 +69,7 @@ class Conf(ConfigNamespace):
     )
 
     date_start_agasc1p8 = ConfigItem(
-        "2024:203",  # 2024-July-21
+        "2024:217:21:59:00",  # 2024-08-04, start of AUG0524B loads
         "Start date for using AGASC 1.8 catalog.",
     )
 

--- a/kadi/config.py
+++ b/kadi/config.py
@@ -68,14 +68,9 @@ class Conf(ConfigNamespace):
         False, "Include In-work command events that are not yet approved."
     )
 
-    date_start_agasc1p8_earliest = ConfigItem(
-        "2024:210",  # 2024-July-28
-        "Start date (earliest) for using AGASC 1.8 catalog.",
-    )
-
-    date_start_agasc1p8_latest = ConfigItem(
-        "2024:233",  # 2024-July-28 + 23 days
-        "Start date (latest) for using AGASC 1.8 catalog.",
+    date_start_agasc1p8 = ConfigItem(
+        "2024:203",  # 2024-July-21
+        "Start date for using AGASC 1.8 catalog.",
     )
 
 


### PR DESCRIPTION
## Description

This uses a single date for the AGASC 1p7-1p8 promotion. Note that this is based on the branch of #332. It leaves the logic to be able to change the AGASC catalog file when getting star catalogs.

The main reason for this is that, even though the promotion dates are configurable parameters, the result also depends on whether the 1p8 file is present in `$SKA/data/agasc` or not, which means the parameters are not enough to guarantee reproducible results. With that out the window, a single date is as good, with simpler code.

This PR has the lint errors that are fixed in PR #336.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
