### PR TITLE
Squelch logging warning message in one test

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -9,6 +9,7 @@ import numpy as np
 import parse_cm.paths
 import parse_cm.tests
 import pytest
+import ska_helpers.utils
 import ska_sun
 from astropy.table import Table, vstack
 from chandra_time import secs2date
@@ -16,6 +17,7 @@ from cxotime import CxoTime
 from Quaternion import Quat
 from testr.test_helper import has_internet
 
+import kadi
 import kadi.commands.states as kcs
 from kadi import commands
 from kadi.commands import (
@@ -867,9 +869,10 @@ def test_get_starcat_only_agasc1p8():
         conf.set_temp("date_start_agasc1p8_latest", "1994:002"),
     ):
         # Force AGASC 1.7 and show that star identification fails
-        starcats = get_starcats(
-            "2002:365:16:00:00", "2002:365:19:00:00", scenario="flight"
-        )
+        with ska_helpers.utils.set_log_level(kadi.logger, "CRITICAL"):
+            starcats = get_starcats(
+                "2002:365:16:00:00", "2002:365:19:00:00", scenario="flight"
+            )
         assert np.count_nonzero(starcats[0]["id"] == -999) == 0
         assert np.count_nonzero(starcats[0]["mag"] == -999) == 0
         assert np.count_nonzero(starcats[1]["id"] == -999) == 3


### PR DESCRIPTION
## Description

Set log leve to CRITICAL when calling the test function. Otherwise a message with WARNING gets logged and this causes a ska testr failure.

This PR supercedes:

- https://github.com/sot/ska_testr/pull/80.

## Requires
- https://github.com/sot/ska_helpers/pull/58

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(quiet-starcat-only-agasc1p8-test) env PYTHONPATH=/Users/aldcroft/git/ska_helpers pytest -k test_get_starcat_only_agasc1p8 -sv
============================================ test session starts ============================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /Users/aldcroft/miniconda3-arm/envs/ska3/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 182 items / 181 deselected / 1 selected                                                           

kadi/commands/tests/test_commands.py::test_get_starcat_only_agasc1p8 PASSED

===================================== 1 passed, 181 deselected in 4.16s =====================================
(ska3) ➜  kadi git:(quiet-starcat-only-agasc1p8-test) env PYTHONPATH=/Users/aldcroft/git/ska_helpers pytest 
============================================ test session starts ============================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 182 items                                                                                         

kadi/commands/tests/test_commands.py ................................................................ [ 35%]
.................                                                                                     [ 44%]
kadi/commands/tests/test_states.py .......................x.........................                  [ 71%]
kadi/commands/tests/test_validate.py ....................                                             [ 82%]
kadi/tests/test_events.py ..........                                                                  [ 87%]
kadi/tests/test_occweb.py ......................                                                      [100%]

============================================= warnings summary ==============================================
kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/aldcroft/miniconda3-arm/envs/ska3/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/aldcroft/miniconda3-arm/envs/ska3/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== 181 passed, 1 xfailed, 2 warnings in 68.11s (0:01:08) ===========================
(ska3) ➜  kadi git:(quiet-starcat-only-agasc1p8-test) git rev-parse HEAD
06f57762745b75e68c6e298d080bc3d76a347122
```


Independent check of unit tests by Jean
- [x] Linux
```
(ska3-masters) jeanconn-fido> git rev-parse HEAD
06f57762745b75e68c6e298d080bc3d76a347122
(ska3-masters) jeanconn-fido> pytest -vs
============================================================== test session starts ==============================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /fido.real/conda/envs/ska3-masters/bin/python3.11
cachedir: .pytest_cache
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 182 items                                                                                                                             

kadi/commands/tests/test_commands.py::test_find PASSED
kadi/commands/tests/test_commands.py::test_get_cmds PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_zero_length_result PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_inclusive_stop PASSED
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict PASSED
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict_ska_parsecm PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_backstop_and_add_cmds PASSED
kadi/commands/tests/test_commands.py::test_commands_create_archive_regress ******************************************
Running: /proj/sot/ska/jeanproj/git/kadi/kadi/scripts/update_cmds_v2.py
Version: 7.11.1.dev1+g06f5776
Time: Tue Aug 13 17:23:51 2024
User: jeanconn
Machine: fido.cfa.harvard.edu
Processing args:
{'data_root': '/tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0',
 'log_level': 10,
 'lookback': 30,
 'scenario': None,
 'stop': '2021:320:00:00:00.000'}
******************************************
2024-08-13 17:23:51,687 update_cmd_events: Getting cmd_events from https://docs.google.com/spreadsheets/d/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ/export?format=csv
2024-08-13 17:23:52,005 update_cmd_events: Writing 123 cmd_events to /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/cmd_events.csv
2024-08-13 17:23:52,022 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT with cache=False
2024-08-13 17:23:52,098 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT1821A with cache=False
2024-08-13 17:23:52,174 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT1821A/CR290_2101.backstop with cache=True
2024-08-13 17:23:52,226 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/OCT1821A.pkl.gz
2024-08-13 17:23:52,238 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521A with cache=False
2024-08-13 17:23:52,314 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521A/CR297_1402.backstop with cache=True
2024-08-13 17:23:52,370 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/OCT2521A.pkl.gz
2024-08-13 17:23:52,383 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521B with cache=False
2024-08-13 17:23:52,462 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521B/CR298_0204.backstop with cache=True
2024-08-13 17:23:52,515 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/OCT2521B.pkl.gz
2024-08-13 17:23:52,528 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2821A with cache=False
2024-08-13 17:23:52,602 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2821A/CR301_2101.backstop with cache=True
2024-08-13 17:23:52,628 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/OCT2821A.pkl.gz
2024-08-13 17:23:52,633 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT3021A with cache=False
2024-08-13 17:23:52,712 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT3021A/CR303_2205.backstop with cache=True
2024-08-13 17:23:52,789 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/OCT3021A.pkl.gz
2024-08-13 17:23:52,808 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV with cache=False
2024-08-13 17:23:52,885 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV0821A with cache=False
2024-08-13 17:23:52,968 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV0821A/CR312_0801.backstop with cache=True
2024-08-13 17:23:53,031 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/NOV0821A.pkl.gz
2024-08-13 17:23:53,046 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV1521A with cache=False
2024-08-13 17:23:53,133 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV1521A/CR318_2001.backstop with cache=True
2024-08-13 17:23:53,187 parse_backstop_and_write: Saving /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/loads/NOV1521A.pkl.gz
2024-08-13 17:23:53,203 update_archive_and_get_cmds_recent: Including loads OCT1821A, OCT2521A, OCT2521B, OCT2821A, OCT3021A, NOV0821A, NOV1521A
2024-08-13 17:23:53,206 update_archive_and_get_cmds_recent: Load OCT1821A has 1362 commands with RLTT=2021:290:21:37:46.377
2024-08-13 17:23:53,211 update_archive_and_get_cmds_recent: Load OCT2521A has 72 commands with RLTT=None
2024-08-13 17:23:53,214 update_archive_and_get_cmds_recent: Load OCT2521B has 1375 commands with RLTT=2021:298:01:57:00.000
2024-08-13 17:23:53,216 update_archive_and_get_cmds_recent: Load OCT2821A has 357 commands with RLTT=2021:301:21:38:28.115
2024-08-13 17:23:53,222 update_archive_and_get_cmds_recent: Load OCT3021A has 2158 commands with RLTT=2021:303:22:31:59.642
2024-08-13 17:23:53,226 update_archive_and_get_cmds_recent: Load NOV0821A has 1608 commands with RLTT=2021:312:08:17:31.883
2024-08-13 17:23:53,230 update_archive_and_get_cmds_recent: Load NOV1521A has 1587 commands with RLTT=2021:318:20:10:00.000
2024-08-13 17:23:53,273 update_archive_and_get_cmds_recent: Including cmd_events:
  Obsid at 2021:301:23:42:01
  Observing not run at 2021:301:18:00:00
  SCS-107 at 2021:301:16:35:54
  Maneuver at 2021:297:01:41:01
  Load not run at 2021:296:10:41:57
  Obsid at 2021:296:10:42:20
  NSM at 2021:296:10:41:57
2024-08-13 17:23:53,305 update_archive_and_get_cmds_recent: Processing OCT1821A with 1362 commands
2024-08-13 17:23:53,306 update_archive_and_get_cmds_recent: Adding 1362 commands from OCT1821A
2024-08-13 17:23:53,306 update_archive_and_get_cmds_recent: Processing CMD_EVT Load_not_run at 2021:296:10:41:57.000 with 1 commands
2024-08-13 17:23:53,306 update_archive_and_get_cmds_recent: Adding 1 commands from CMD_EVT Load_not_run at 2021:296:10:41:57.000
2024-08-13 17:23:53,306 update_archive_and_get_cmds_recent: Processing CMD_EVT NSM at 2021:296:10:41:57.000 with 14 commands
2024-08-13 17:23:53,306 update_archive_and_get_cmds_recent: Removing 207 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT1821A due to DISABLE SCS in CMD_EVT at 2021:296:10:41:57.000
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Adding 14 commands from CMD_EVT NSM at 2021:296:10:41:57.000
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Processing CMD_EVT Obsid at 2021:296:10:42:20.000 with 1 commands
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Adding 1 commands from CMD_EVT Obsid at 2021:296:10:42:20.000
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Processing CMD_EVT Maneuver at 2021:297:01:41:01.000 with 4 commands
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Adding 4 commands from CMD_EVT Maneuver at 2021:297:01:41:01.000
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Processing OCT2521A with 72 commands
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Adding 72 commands from OCT2521A
2024-08-13 17:23:53,307 update_archive_and_get_cmds_recent: Processing OCT2521B with 1375 commands
2024-08-13 17:23:53,309 update_archive_and_get_cmds_recent: Adding 1375 commands from OCT2521B
2024-08-13 17:23:53,309 update_archive_and_get_cmds_recent: Processing CMD_EVT SCS-107 at 2021:301:16:35:54.000 with 9 commands
2024-08-13 17:23:53,310 update_archive_and_get_cmds_recent: Removing 231 cmds in SCS slots [131, 132, 133] from OCT2521B due to DISABLE SCS in CMD_EVT at 2021:301:16:35:54.000
2024-08-13 17:23:53,310 update_archive_and_get_cmds_recent: Adding 9 commands from CMD_EVT SCS-107 at 2021:301:16:35:54.000
2024-08-13 17:23:53,310 update_archive_and_get_cmds_recent: Processing CMD_EVT Observing_not_run at 2021:301:18:00:00.000 with 1 commands
2024-08-13 17:23:53,310 update_archive_and_get_cmds_recent: Adding 1 commands from CMD_EVT Observing_not_run at 2021:301:18:00:00.000
2024-08-13 17:23:53,310 update_archive_and_get_cmds_recent: Processing OCT2821A with 357 commands
2024-08-13 17:23:53,311 update_archive_and_get_cmds_recent: Removing 332 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT2521B due to RLTT in OCT2821A
2024-08-13 17:23:53,312 update_archive_and_get_cmds_recent: Adding 357 commands from OCT2821A
2024-08-13 17:23:53,312 update_archive_and_get_cmds_recent: Processing CMD_EVT Obsid at 2021:301:23:42:01.000 with 1 commands
2024-08-13 17:23:53,312 update_archive_and_get_cmds_recent: Adding 1 commands from CMD_EVT Obsid at 2021:301:23:42:01.000
2024-08-13 17:23:53,312 update_archive_and_get_cmds_recent: Processing OCT3021A with 2158 commands
2024-08-13 17:23:53,313 update_archive_and_get_cmds_recent: Removing 84 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT2821A due to RLTT in OCT3021A
2024-08-13 17:23:53,315 update_archive_and_get_cmds_recent: Adding 2158 commands from OCT3021A
2024-08-13 17:23:53,315 update_archive_and_get_cmds_recent: Processing NOV0821A with 1608 commands
2024-08-13 17:23:53,315 update_archive_and_get_cmds_recent: Adding 1608 commands from NOV0821A
2024-08-13 17:23:53,315 update_archive_and_get_cmds_recent: Processing NOV1521A with 1587 commands
2024-08-13 17:23:53,316 update_archive_and_get_cmds_recent: Adding 1587 commands from NOV1521A
2024-08-13 17:23:53,657 get_cmds_obs_final: No starcat for obsid 0 at 2021:297:02:05:11.042 even though npnt_enab is True
2024-08-13 17:23:53,782 _update_cmds_archive: Appending 7814 new commands after removing 0 from existing archive
2024-08-13 17:23:53,782 _update_cmds_archive:  starting with cmds_arch[:0] and adding cmds_recent[0:7814]
2024-08-13 17:23:53,785 _update_cmds_archive: Writing 7814 commands to /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/cmds2.h5
2024-08-13 17:23:53,806 _update_cmds_archive: Writing updated pars_dict to /tmp/pytest-of-jeanconn/pytest-9108/test_commands_create_archive_r0/cmds2.pkl
PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_only PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_recent PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_v2_recent_only PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_nsm_2021 PASSED
kadi/commands/tests/test_commands.py::test_cmds_scenario PASSED
kadi/commands/tests/test_commands.py::test_nsm_offset_pitch_rasl_command_events PASSED
kadi/commands/tests/test_commands.py::test_command_set_bsh PASSED
kadi/commands/tests/test_commands.py::test_command_set_safe_mode PASSED
kadi/commands/tests/test_commands.py::test_bright_star_hold_event PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_single PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_multi PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_start_date PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_start_stop_date_with_scenario PASSED
kadi/commands/tests/test_commands.py::test_get_observations_no_match PASSED
kadi/commands/tests/test_commands.py::test_get_observations_start_stop_inclusion PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year0] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year1] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year2] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year3] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year4] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year5] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year6] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year7] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year8] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year9] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year10] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year11] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year12] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year13] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year14] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year15] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year16] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year17] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year18] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year19] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year20] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year21] PASSED
kadi/commands/tests/test_commands.py::test_get_starcat_agasc1p8_then_1p7 PASSED
kadi/commands/tests/test_commands.py::test_get_starcat_only_agasc1p8 PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_with_cmds PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_obsid PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_date PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_by_date PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_as_table PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID= aa0000000, par1 = 1 ,   par2=-1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[AcisPKT|TLmSID=AA0000000 ,par1=1, par2=-1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID = aa0000000 , par1  =1,    par2 =  -1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[1] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[2] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[3] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[4] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[5] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[6] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[7] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[8] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[9] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[10] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[11] PASSED
kadi/commands/tests/test_commands.py::test_scenario_with_rts PASSED
kadi/commands/tests/test_commands.py::test_no_rltt_for_not_run_load PASSED
kadi/commands/tests/test_commands.py::test_30_day_lookback_issue PASSED
kadi/commands/tests/test_commands.py::test_fill_gaps PASSED
kadi/commands/tests/test_commands.py::test_get_rltt_scheduled_stop_time PASSED
kadi/commands/tests/test_commands.py::test_hrc_not_run_scenario PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case0] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case1] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case2] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case3] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case4] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case5] PASSED
kadi/commands/tests/test_commands.py::test_add_cmds PASSED
kadi/commands/tests/test_commands.py::test_read_backstop_with_observations PASSED
kadi/commands/tests/test_states.py::test_acis_vidboard PASSED
kadi/commands/tests/test_states.py::test_acis_simode PASSED
kadi/commands/tests/test_states.py::test_cmd_line_interface PASSED
kadi/commands/tests/test_states.py::test_quick PASSED
kadi/commands/tests/test_states.py::test_states_2017 PASSED
kadi/commands/tests/test_states.py::test_pitch_2017 PASSED
kadi/commands/tests/test_states.py::test_sun_vec_versus_telemetry PASSED
kadi/commands/tests/test_states.py::test_dither PASSED
kadi/commands/tests/test_states.py::test_fids_state PASSED
kadi/commands/tests/test_states.py::test_get_continuity_regress PASSED
kadi/commands/tests/test_states.py::test_get_continuity_vs_states PASSED
kadi/commands/tests/test_states.py::test_get_states_with_cmds_and_start_stop PASSED
kadi/commands/tests/test_states.py::test_get_continuity_keys PASSED
kadi/commands/tests/test_states.py::test_get_continuity_fail PASSED
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[True] PASSED
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[False] PASSED
kadi/commands/tests/test_states.py::test_reduce_states_cmd_states PASSED
kadi/commands/tests/test_states.py::test_backstop_format PASSED
kadi/commands/tests/test_states.py::test_backstop_subformat PASSED
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon PASSED
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon_lunar PASSED
kadi/commands/tests/test_states.py::test_backstop_ephem_update PASSED
kadi/commands/tests/test_states.py::test_backstop_radmon_no_scs107 PASSED
kadi/commands/tests/test_states.py::test_backstop_radmon_with_scs107 XFAIL
kadi/commands/tests/test_states.py::test_backstop_scs98 PASSED
kadi/commands/tests/test_states.py::test_backstop_scs84 PASSED
kadi/commands/tests/test_states.py::test_backstop_simpos PASSED
kadi/commands/tests/test_states.py::test_backstop_simfa_pos PASSED
kadi/commands/tests/test_states.py::test_backstop_grating PASSED
kadi/commands/tests/test_states.py::test_backstop_eclipse_entry PASSED
kadi/commands/tests/test_states.py::test_regress_eclipse PASSED
kadi/commands/tests/test_states.py::test_continuity_just_after_command PASSED
kadi/commands/tests/test_states.py::test_continuity_far_future PASSED
kadi/commands/tests/test_states.py::test_acis_power_cmds PASSED
kadi/commands/tests/test_states.py::test_continuity_with_transitions_SPM PASSED
kadi/commands/tests/test_states.py::test_continuity_with_no_transitions_SPM PASSED
kadi/commands/tests/test_states.py::test_get_pitch_from_mid_maneuver PASSED
kadi/commands/tests/test_states.py::test_get_states_start_between_aouptarg_aomanuvr_cmds PASSED
kadi/commands/tests/test_states.py::test_get_continuity_and_pitch_from_mid_maneuver PASSED
kadi/commands/tests/test_states.py::test_acisfp_setpoint_state PASSED
kadi/commands/tests/test_states.py::test_grating_motion_states PASSED
kadi/commands/tests/test_states.py::test_hrc_states PASSED
kadi/commands/tests/test_states.py::test_hrc_states_with_scs_commanding PASSED
kadi/commands/tests/test_states.py::test_early_start_exception PASSED
kadi/commands/tests/test_states.py::test_nsm_continuity PASSED
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse PASSED
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse_no_spm_enab PASSED
kadi/commands/tests/test_states.py::test_get_continuity_acis_cmd_requires_obsid PASSED
kadi/commands/tests/test_states.py::test_get_continuity_spm_eclipse PASSED
kadi/commands/tests/test_validate.py::test_validate_subclasses Reading validation regression data from /proj/sot/ska/jeanproj/git/kadi/kadi/commands/tests/data/validators_2022297_5_False.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePitch] Reading validation regression data from /proj/sot/ska/jeanproj/git/kadi/kadi/commands/tests/data/validators_2022297_5_False.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateRoll] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateDither] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePcadMode] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSimpos] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateObsid] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateLETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateHETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSunPosMon] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePitch] Reading validation regression data from /proj/sot/ska/jeanproj/git/kadi/kadi/commands/tests/data/validators_2022297_5_True.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateRoll] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateDither] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePcadMode] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSimpos] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateObsid] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateLETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateHETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSunPosMon] PASSED
kadi/commands/tests/test_validate.py::test_off_nominal_roll_violations PASSED
kadi/tests/test_events.py::test_xdg_config_home_env_var Checking normal import path
PASSED
kadi/tests/test_events.py::test_overlapping_intervals PASSED
kadi/tests/test_events.py::test_interval_pads PASSED
kadi/tests/test_events.py::test_query_event_intervals PASSED
kadi/tests/test_events.py::test_basic_query PASSED
kadi/tests/test_events.py::test_short_query PASSED
kadi/tests/test_events.py::test_get_obsid PASSED
kadi/tests/test_events.py::test_intervals_filter PASSED
kadi/tests/test_events.py::test_get_overlaps PASSED
kadi/tests/test_events.py::test_select_overlapping PASSED
kadi/tests/test_occweb.py::test_put_get_user_none PASSED
kadi/tests/test_occweb.py::test_ifot_fetch PASSED
kadi/tests/test_occweb.py::test_get_fdb_major_events PASSED
kadi/tests/test_occweb.py::test_get_fot_major_events PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[False-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[False-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[update-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[update-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[True-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[True-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-True] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-True] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[FOT] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[GRETA/mission/Backstop] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[vweb] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[True] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[update] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[True] PASSED

================================================== 181 passed, 1 xfailed in 166.96s (0:02:46
```



### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
As this was a test fix - for functional testing Jean confirmed that the warning is not emitted or caught from the ska_testr log checking when the kadi tests are run via run_testr .
