### PR TITLE
Update to use get_nsm_attitude

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.1
+  rev: v0.6.1
   hooks:
     # Run the linter.
     - id: ruff

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -750,7 +750,7 @@ def manvr_duration(q1, q2):
     q_manvr_3 = abs(-q2[0] * q1[0] - q2[1] * q1[1] - q2[2] * q1[2] + q2[3] * -q1[3])
 
     # 4th component is cos(theta/2)
-    if q_manvr_3 > 1:
+    if q_manvr_3 > 1: # noqa PLR1730
         q_manvr_3 = 1
     phimax = 2 * math.acos(q_manvr_3)
 
@@ -764,7 +764,7 @@ def manvr_duration(q1, q2):
             np.sqrt(MANVR_DELTA**2 + 4 * phimax / MANVR_ALPHAMAX) / 2
             - 1.5 * MANVR_DELTA
         )
-        if eps < 0:
+        if eps < 0: # noqa PLR1730
             eps = 0
 
     tm = 4 * MANVR_DELTA + 2 * eps + tau

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -750,7 +750,7 @@ def manvr_duration(q1, q2):
     q_manvr_3 = abs(-q2[0] * q1[0] - q2[1] * q1[1] - q2[2] * q1[2] + q2[3] * -q1[3])
 
     # 4th component is cos(theta/2)
-    if q_manvr_3 > 1: # noqa PLR1730
+    if q_manvr_3 > 1:  # noqa PLR1730
         q_manvr_3 = 1
     phimax = 2 * math.acos(q_manvr_3)
 
@@ -764,7 +764,7 @@ def manvr_duration(q1, q2):
             np.sqrt(MANVR_DELTA**2 + 4 * phimax / MANVR_ALPHAMAX) / 2
             - 1.5 * MANVR_DELTA
         )
-        if eps < 0: # noqa PLR1730
+        if eps < 0:  # noqa PLR1730
             eps = 0
 
     tm = 4 * MANVR_DELTA + 2 * eps + tau

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -25,11 +25,17 @@ from testr.test_helper import has_internet
 
 from kadi import occweb, paths
 from kadi.commands.command_sets import get_cmds_from_event
-from kadi.commands.core import (CommandTable, LazyVal, _find,
-                                get_cmds_from_backstop,
-                                get_par_idx_update_pars_dict, load_idx_cmds,
-                                load_name_to_cxotime, load_pars_dict,
-                                vstack_exact)
+from kadi.commands.core import (
+    CommandTable,
+    LazyVal,
+    _find,
+    get_cmds_from_backstop,
+    get_par_idx_update_pars_dict,
+    load_idx_cmds,
+    load_name_to_cxotime,
+    load_pars_dict,
+    vstack_exact,
+)
 from kadi.config import conf
 
 __all__ = ["clear_caches", "get_cmds"]

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -18,24 +18,18 @@ import astropy.units as u
 import numpy as np
 import requests
 from astropy.table import Table
-from chandra_maneuver import NSM_attitude
 from cxotime import CxoTime
 from parse_cm.paths import load_dir_from_load_name
+from ska_sun import get_nsm_attitude
 from testr.test_helper import has_internet
 
 from kadi import occweb, paths
 from kadi.commands.command_sets import get_cmds_from_event
-from kadi.commands.core import (
-    CommandTable,
-    LazyVal,
-    _find,
-    get_cmds_from_backstop,
-    get_par_idx_update_pars_dict,
-    load_idx_cmds,
-    load_name_to_cxotime,
-    load_pars_dict,
-    vstack_exact,
-)
+from kadi.commands.core import (CommandTable, LazyVal, _find,
+                                get_cmds_from_backstop,
+                                get_par_idx_update_pars_dict, load_idx_cmds,
+                                load_name_to_cxotime, load_pars_dict,
+                                vstack_exact)
 from kadi.config import conf
 
 __all__ = ["clear_caches", "get_cmds"]
@@ -649,7 +643,7 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
         elif tlmsid in ("AOMANUVR", "AONSMSAF"):
             if tlmsid == "AONSMSAF":
                 targ_att = tuple(
-                    NSM_attitude(prev_att or (0, 0, 0, 1), cmd["date"]).q.tolist()
+                    get_nsm_attitude(prev_att or (0, 0, 0, 1), cmd["date"]).q.tolist()
                 )
                 npnt_enab = False
             if targ_att is None:

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -19,6 +19,7 @@ from astropy.table import Column, Table
 from chandra_time import DateTime, date2secs, secs2date
 from cxotime import CxoTime
 from Quaternion import Quat, quat_to_equatorial
+from ska_sun import get_nsm_attitude
 
 from kadi import commands
 
@@ -1415,7 +1416,7 @@ class NormalSunTransition(ManeuverTransition):
         if None in curr_att:
             return
 
-        targ_att = chandra_maneuver.NSM_attitude(curr_att, date)
+        targ_att = get_nsm_attitude(curr_att, date)
         for qc, targ_q in zip(QUAT_COMPS, targ_att.q):
             state["targ_" + qc] = targ_q
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -58,6 +58,7 @@ extend-exclude = [
   "docs",
   "utils",
   "validate",
+  "kadi_demo.ipynb",
 ]
 
 [lint.pycodestyle]


### PR DESCRIPTION
## Description

Update to use ska_sun.get_nsm_attitude

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Requires https://github.com/sot/ska_sun/pull/38

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac arm64
```
(ska3) flame:kadi jean$ git rev-parse HEAD
63db05639fb2f35d169a1248ace40e602b2f25bd
(ska3) flame:kadi jean$ pytest -vs
================================================================ test session starts =================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0 -- /Users/jean/miniconda_m1/envs/ska3/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 182 items                                                                                                                                  

kadi/commands/tests/test_commands.py::test_find PASSED
kadi/commands/tests/test_commands.py::test_get_cmds PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_zero_length_result PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_inclusive_stop PASSED
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict PASSED
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict_ska_parsecm PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_backstop_and_add_cmds PASSED
kadi/commands/tests/test_commands.py::test_commands_create_archive_regress SKIPPED (condition: not HAS_MPDIR)
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_only PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_recent PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_v2_recent_only PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_nsm_2021 PASSED
kadi/commands/tests/test_commands.py::test_cmds_scenario PASSED
kadi/commands/tests/test_commands.py::test_nsm_offset_pitch_rasl_command_events PASSED
kadi/commands/tests/test_commands.py::test_command_set_bsh PASSED
kadi/commands/tests/test_commands.py::test_command_set_safe_mode PASSED
kadi/commands/tests/test_commands.py::test_bright_star_hold_event PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_single PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_multi PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_start_date PASSED
kadi/commands/tests/test_commands.py::test_get_observations_by_start_stop_date_with_scenario PASSED
kadi/commands/tests/test_commands.py::test_get_observations_no_match PASSED
kadi/commands/tests/test_commands.py::test_get_observations_start_stop_inclusion PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year0] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year1] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year2] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year3] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year4] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year5] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year6] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year7] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year8] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year9] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year10] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year11] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year12] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year13] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year14] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year15] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year16] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year17] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year18] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year19] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year20] PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year21] PASSED
kadi/commands/tests/test_commands.py::test_get_starcat_agasc1p8_then_1p7 PASSED
kadi/commands/tests/test_commands.py::test_get_starcat_only_agasc1p8 PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_with_cmds PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_obsid PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_date PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_by_date PASSED
kadi/commands/tests/test_commands.py::test_get_starcats_as_table PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID= aa0000000, par1 = 1 ,   par2=-1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[AcisPKT|TLmSID=AA0000000 ,par1=1, par2=-1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID = aa0000000 , par1  =1,    par2 =  -1.0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[0] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[1] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[2] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[3] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[4] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[5] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[6] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[7] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[8] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[9] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[10] PASSED
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[11] PASSED
kadi/commands/tests/test_commands.py::test_scenario_with_rts PASSED
kadi/commands/tests/test_commands.py::test_no_rltt_for_not_run_load PASSED
kadi/commands/tests/test_commands.py::test_30_day_lookback_issue PASSED
kadi/commands/tests/test_commands.py::test_fill_gaps PASSED
kadi/commands/tests/test_commands.py::test_get_rltt_scheduled_stop_time PASSED
kadi/commands/tests/test_commands.py::test_hrc_not_run_scenario PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case0] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case1] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case2] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case3] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case4] PASSED
kadi/commands/tests/test_commands.py::test_command_not_run[case5] PASSED
kadi/commands/tests/test_commands.py::test_add_cmds PASSED
kadi/commands/tests/test_commands.py::test_read_backstop_with_observations SKIPPED (No backstop file found)
kadi/commands/tests/test_states.py::test_acis_vidboard PASSED
kadi/commands/tests/test_states.py::test_acis_simode PASSED
kadi/commands/tests/test_states.py::test_cmd_line_interface PASSED
kadi/commands/tests/test_states.py::test_quick PASSED
kadi/commands/tests/test_states.py::test_states_2017 PASSED
kadi/commands/tests/test_states.py::test_pitch_2017 PASSED
kadi/commands/tests/test_states.py::test_sun_vec_versus_telemetry PASSED
kadi/commands/tests/test_states.py::test_dither PASSED
kadi/commands/tests/test_states.py::test_fids_state PASSED
kadi/commands/tests/test_states.py::test_get_continuity_regress PASSED
kadi/commands/tests/test_states.py::test_get_continuity_vs_states PASSED
kadi/commands/tests/test_states.py::test_get_states_with_cmds_and_start_stop PASSED
kadi/commands/tests/test_states.py::test_get_continuity_keys PASSED
kadi/commands/tests/test_states.py::test_get_continuity_fail PASSED
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[True] PASSED
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[False] PASSED
kadi/commands/tests/test_states.py::test_reduce_states_cmd_states PASSED
kadi/commands/tests/test_states.py::test_backstop_format PASSED
kadi/commands/tests/test_states.py::test_backstop_subformat PASSED
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon PASSED
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon_lunar PASSED
kadi/commands/tests/test_states.py::test_backstop_ephem_update PASSED
kadi/commands/tests/test_states.py::test_backstop_radmon_no_scs107 PASSED
kadi/commands/tests/test_states.py::test_backstop_radmon_with_scs107 XFAIL
kadi/commands/tests/test_states.py::test_backstop_scs98 PASSED
kadi/commands/tests/test_states.py::test_backstop_scs84 PASSED
kadi/commands/tests/test_states.py::test_backstop_simpos PASSED
kadi/commands/tests/test_states.py::test_backstop_simfa_pos PASSED
kadi/commands/tests/test_states.py::test_backstop_grating PASSED
kadi/commands/tests/test_states.py::test_backstop_eclipse_entry PASSED
kadi/commands/tests/test_states.py::test_regress_eclipse PASSED
kadi/commands/tests/test_states.py::test_continuity_just_after_command PASSED
kadi/commands/tests/test_states.py::test_continuity_far_future PASSED
kadi/commands/tests/test_states.py::test_acis_power_cmds PASSED
kadi/commands/tests/test_states.py::test_continuity_with_transitions_SPM PASSED
kadi/commands/tests/test_states.py::test_continuity_with_no_transitions_SPM PASSED
kadi/commands/tests/test_states.py::test_get_pitch_from_mid_maneuver PASSED
kadi/commands/tests/test_states.py::test_get_states_start_between_aouptarg_aomanuvr_cmds PASSED
kadi/commands/tests/test_states.py::test_get_continuity_and_pitch_from_mid_maneuver PASSED
kadi/commands/tests/test_states.py::test_acisfp_setpoint_state PASSED
kadi/commands/tests/test_states.py::test_grating_motion_states PASSED
kadi/commands/tests/test_states.py::test_hrc_states PASSED
kadi/commands/tests/test_states.py::test_hrc_states_with_scs_commanding PASSED
kadi/commands/tests/test_states.py::test_early_start_exception PASSED
kadi/commands/tests/test_states.py::test_nsm_continuity PASSED
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse PASSED
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse_no_spm_enab PASSED
kadi/commands/tests/test_states.py::test_get_continuity_acis_cmd_requires_obsid PASSED
kadi/commands/tests/test_states.py::test_get_continuity_spm_eclipse PASSED
kadi/commands/tests/test_validate.py::test_validate_subclasses Reading validation regression data from /Users/jean/git/kadi/kadi/commands/tests/data/validators_2022297_5_False.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePitch] Reading validation regression data from /Users/jean/git/kadi/kadi/commands/tests/data/validators_2022297_5_False.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateRoll] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateDither] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePcadMode] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSimpos] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateObsid] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateLETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateHETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSunPosMon] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePitch] Reading validation regression data from /Users/jean/git/kadi/kadi/commands/tests/data/validators_2022297_5_True.pkl.gz
PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateRoll] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateDither] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePcadMode] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSimpos] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateObsid] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateLETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateHETG] PASSED
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSunPosMon] PASSED
kadi/commands/tests/test_validate.py::test_off_nominal_roll_violations PASSED
kadi/tests/test_events.py::test_xdg_config_home_env_var Checking normal import path
PASSED
kadi/tests/test_events.py::test_overlapping_intervals PASSED
kadi/tests/test_events.py::test_interval_pads PASSED
kadi/tests/test_events.py::test_query_event_intervals PASSED
kadi/tests/test_events.py::test_basic_query PASSED
kadi/tests/test_events.py::test_short_query PASSED
kadi/tests/test_events.py::test_get_obsid PASSED
kadi/tests/test_events.py::test_intervals_filter PASSED
kadi/tests/test_events.py::test_get_overlaps PASSED
kadi/tests/test_events.py::test_select_overlapping PASSED
kadi/tests/test_occweb.py::test_put_get_user_none PASSED
kadi/tests/test_occweb.py::test_ifot_fetch PASSED
kadi/tests/test_occweb.py::test_get_fdb_major_events PASSED
kadi/tests/test_occweb.py::test_get_fot_major_events PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[False-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[False-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[update-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[update-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[True-str] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir[True-Path] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-True] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-True] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[FOT] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[GRETA/mission/Backstop] PASSED
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[vweb] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[True] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[False] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[update] PASSED
kadi/tests/test_occweb.py::test_get_occweb_page_binary[True] PASSED

================================================================== warnings summary ==================================================================
kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniconda_m1/envs/ska3/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniconda_m1/envs/ska3/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 179 passed, 2 skipped, 1 xfailed, 2 warnings in 73.53s (0:01:13)





```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
