### PR TITLE
fix package data regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     package_data={
         "kadi.commands": ["templates/*.html"],
-        "kadi.commands.tests": ["data/*.gz"],
+        "kadi.commands.tests": ["data/*.gz", "data/*.yaml"],
     },
     tests_require=["pytest"],
     data_files=data_files,


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes the regex to specify the package data.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->


Independent check of unit tests by Jean
```
In [1]: import kadi

In [2]: kadi.test()
============================================== test session starts ===============================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, arraydiff-0.6.1, mock-3.14.0
collected 181 items

kadi/commands/tests/test_commands.py .......s............................................................. [ 38%]
...........s                                                                                               [ 44%]
kadi/commands/tests/test_states.py .......................x.........................                       [ 71%]
kadi/commands/tests/test_validate.py ...................                                                   [ 82%]
kadi/tests/test_events.py ..........                                                                       [ 87%]
kadi/tests/test_occweb.py ......................                                                           [100%]

================================================ warnings summary ================================================
jupyter_client/connect.py:27
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

kadi/commands/tests/test_commands.py: 12 warnings
kadi/commands/tests/test_states.py: 1 warning
kadi/commands/tests/test_validate.py: 1 warning
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 178 passed, 2 skipped, 1 xfailed, 17 warnings in 102.26s (0:01:42) =======================
Out[2]: False

In [3]: kadi.__version__
Out[3]: '7.12.1.dev4+g0ef8959'
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests are the functional test in this case.
