### PR TITLE
[bugfix] Add commands to turn HRC off to SCS 107

### DIFF
--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -100,6 +100,11 @@ def cmd_set_scs107(date=None):
         dict(type="ACISPKT", tlmsid="AA00000000", dur=1.025),
         dict(type="ACISPKT", tlmsid="AA00000000", dur=10.25),
         dict(type="ACISPKT", tlmsid=pow_cmd),
+        dict(type="COMMAND_HW", tlmsid="215PCAOF"),
+        dict(type="COMMAND_HW", tlmsid="224PCAOF"),
+        dict(type="COMMAND_HW", tlmsid="2IMHVOF"),
+        dict(type="COMMAND_HW", tlmsid="2SPHVOF"),
+        dict(type="COMMAND_HW", tlmsid="2S2HVOF"),
     )
     return cmds
 

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -97,7 +97,8 @@ def cmd_set_scs107(date=None):
         dict(type="ACISPKT", tlmsid="AA00000000", dur=10.25),
         dict(type="ACISPKT", tlmsid=pow_cmd),
     )
-    # Potentially exclude HRC SCS-107 commanding for some regression testing. This is
+    # Note that the following block to include HRC turn-off commands is wrapped in a
+    # config variable to make this conditional in support of regression testing. This is
     # needed for tests of command generation vs. commands in the archive which did not
     # include this HRC SCS-107 commanding (prior to #344).
     if not kadi.commands.conf.disable_hrc_scs107_commanding:

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -104,7 +104,6 @@ def cmd_set_scs107(date=None):
     if not kadi.commands.conf.disable_hrc_scs107_commanding:
         cmds += (
             dict(type="COMMAND_HW", tlmsid="215PCAOF", dur=1.205),
-            dict(type="COMMAND_HW", tlmsid="224PCAOF", dur=1.025),
             dict(type="COMMAND_HW", tlmsid="2IMHVOF", dur=1.025),
             dict(type="COMMAND_HW", tlmsid="2SPHVOF", dur=1.025),
             dict(type="COMMAND_HW", tlmsid="2S2STHV", dur=1.025),

--- a/kadi/commands/command_sets.py
+++ b/kadi/commands/command_sets.py
@@ -7,6 +7,7 @@ from parse_cm.backstop import parse_backstop_params
 from Quaternion import Quat
 from ska_helpers.utils import convert_to_int_float_str
 
+import kadi.commands
 from kadi.commands.core import CommandTable
 
 RTS_PATH = Path("FOT/configuration/products/rts")
@@ -90,22 +91,27 @@ def cmd_set_scs107(date=None):
     cmds = cmd_set_end_observing()
     cmds += (
         dict(type="COMMAND_SW", dur=1.025, tlmsid="OORMPDS"),
-        dict(
-            type="COMMAND_HW",
-            # dur=1.025,
-            tlmsid="AFIDP",
-            msid="AFLCRSET",
-        ),
+        dict(type="COMMAND_HW", tlmsid="AFIDP", msid="AFLCRSET"),
         dict(type="SIMTRANS", params=dict(POS=-99616), dur=65.66),
         dict(type="ACISPKT", tlmsid="AA00000000", dur=1.025),
         dict(type="ACISPKT", tlmsid="AA00000000", dur=10.25),
         dict(type="ACISPKT", tlmsid=pow_cmd),
-        dict(type="COMMAND_HW", tlmsid="215PCAOF"),
-        dict(type="COMMAND_HW", tlmsid="224PCAOF"),
-        dict(type="COMMAND_HW", tlmsid="2IMHVOF"),
-        dict(type="COMMAND_HW", tlmsid="2SPHVOF"),
-        dict(type="COMMAND_HW", tlmsid="2S2HVOF"),
     )
+    # Potentially exclude HRC SCS-107 commanding for some regression testing. This is
+    # needed for tests of command generation vs. commands in the archive which did not
+    # include this HRC SCS-107 commanding (prior to #344).
+    if not kadi.commands.conf.disable_hrc_scs107_commanding:
+        cmds += (
+            dict(type="COMMAND_HW", tlmsid="215PCAOF", dur=1.205),
+            dict(type="COMMAND_HW", tlmsid="224PCAOF", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2IMHVOF", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2SPHVOF", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2S2STHV", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2S1STHV", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2S2HVOF", dur=1.025),
+            dict(type="COMMAND_HW", tlmsid="2S1HVOF", dur=1.025),
+        )
+
     return cmds
 
 

--- a/kadi/commands/tests/conftest.py
+++ b/kadi/commands/tests/conftest.py
@@ -1,7 +1,14 @@
 import pytest
 import ska_sun
 
+import kadi.commands
+
 
 @pytest.fixture()
 def fast_sun_position_method(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(ska_sun.conf, "sun_position_method_default", "fast")
+
+
+@pytest.fixture()
+def disable_hrc_scs107_commanding(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(kadi.commands.conf, "disable_hrc_scs107_commanding", True)

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -681,13 +681,12 @@ def test_command_set_bsh():
 2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:17.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:19.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:20.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:21.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:22.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:23.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:24.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:25.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0"""
+2000:001:00:01:19.165 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:20.190 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:21.215 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:22.240 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:23.265 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:24.290 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0"""
 
     assert cmds.pformat_like_backstop(max_params_width=None) == exp.splitlines()
     commands.clear_caches()
@@ -711,14 +710,13 @@ def test_command_set_safe_mode():
 2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:17.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:19.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:20.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:21.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:22.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:23.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:24.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:25.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:26.340 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0"""
+2000:001:00:01:19.165 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:20.190 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:21.215 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:22.240 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:23.265 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:24.290 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:25.315 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0"""
     assert cmds.pformat_like_backstop(max_params_width=None) == exp.splitlines()
     commands.clear_caches()
 
@@ -1359,14 +1357,13 @@ def test_scenario_with_rts(monkeypatch, fast_sun_position_method):
 2021:296:10:43:04.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:10:43:14.960 | ACISPKT          | WSPOW0002A | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:10:43:14.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:16.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:17.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:18.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:19.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:20.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:21.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:22.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:23.340 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:16.165 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:17.190 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:18.215 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:19.240 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:20.265 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:21.290 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:22.315 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:11:08:12.966 | LOAD_EVENT       | OBS        | CMD_EVT  | manvr_start=2021:296:10:41:57.000, prev_att=(0.594590732, 0.
 2021:297:01:41:01.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | event=Maneuver, event_date=2021:297:01:41:01, msid=AONMMODE,
 2021:297:01:41:01.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | event=Maneuver, event_date=2021:297:01:41:01, msid=AONM2NPE,

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -236,7 +236,9 @@ def test_get_cmds_from_backstop_and_add_cmds():
 
 @pytest.mark.skipif("not HAS_MPDIR")
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
-def test_commands_create_archive_regress(tmpdir, fast_sun_position_method):
+def test_commands_create_archive_regress(
+    tmpdir, fast_sun_position_method, disable_hrc_scs107_commanding
+):
     """Create cmds archive from scratch and test that it matches flight
 
     This tests over an eventful month that includes IU reset/NSM, SCS-107
@@ -462,7 +464,7 @@ def test_get_cmds_v2_recent_only(stop_date_2020_12_03):  # noqa: ARG001
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
-def test_get_cmds_nsm_2021(stop_date_2021_10_24):  # noqa: ARG001
+def test_get_cmds_nsm_2021(stop_date_2021_10_24, disable_hrc_scs107_commanding):
     """NSM at ~2021:296:10:41. This tests non-load commands from cmd_events."""
     cmds = commands.get_cmds("2021:296:10:35:00")  # , '2021:298:01:58:00')
     cmds = cmds[cmds["tlmsid"] != "OBS"]
@@ -538,6 +540,7 @@ def test_get_cmds_nsm_2021(stop_date_2021_10_24):  # noqa: ARG001
         "2021:297:14:01:00.000 | LOAD_EVENT       | None       | OCT1821A | "
         "event_type=SCHEDULED_STOP_TIME, scs=0",
     ]
+
     assert cmds.pformat_like_backstop(max_params_width=200) == exp
     commands.clear_caches()
 
@@ -676,7 +679,15 @@ def test_command_set_bsh():
 2000:001:00:00:01.025 | SIMTRANS         | None       | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, pos=-99616, scs=0
 2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0"""
+2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:17.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:19.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:20.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:21.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:22.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:23.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:24.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:25.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Bright_star_hold, event_date=2000:001:00:00:00, scs=0"""
 
     assert cmds.pformat_like_backstop(max_params_width=None) == exp.splitlines()
     commands.clear_caches()
@@ -699,13 +710,23 @@ def test_command_set_safe_mode():
 2000:001:00:01:06.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:07.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
 2000:001:00:01:17.960 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
-2000:001:00:01:17.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0"""
+2000:001:00:01:17.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:19.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:20.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:21.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:22.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:23.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:24.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:25.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0
+2000:001:00:01:26.340 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=Safe_mode, event_date=2000:001:00:00:00, scs=0"""
     assert cmds.pformat_like_backstop(max_params_width=None) == exp.splitlines()
     commands.clear_caches()
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
-def test_bright_star_hold_event(cmds_dir, stop_date_2020_12_03):  # noqa: ARG001
+def test_bright_star_hold_event(
+    cmds_dir, stop_date_2020_12_03, disable_hrc_scs107_commanding
+):
     """Make a scenario with a bright star hold event.
 
     Confirm that this inserts expected commands and interrupts all load commands.
@@ -1265,7 +1286,7 @@ cmd_events_all_exps = [
 
 
 @pytest.mark.parametrize("idx", range(len(cmd_events_all_exps)))
-def test_get_cmds_from_event_all(idx):
+def test_get_cmds_from_event_all(idx, disable_hrc_scs107_commanding):
     """Test getting commands from every event type in the Command Events sheet"""
     cevt = cmd_events_all[idx]
     exp = cmd_events_all_exps[idx]
@@ -1337,7 +1358,15 @@ def test_scenario_with_rts(monkeypatch, fast_sun_position_method):
 2021:296:10:43:03.685 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:10:43:04.710 | ACISPKT          | AA00000000 | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:10:43:14.960 | ACISPKT          | WSPOW0002A | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
-2021:296:10:43:14.960 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:14.960 | COMMAND_HW       | 215PCAOF   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:16.165 | COMMAND_HW       | 224PCAOF   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:17.190 | COMMAND_HW       | 2IMHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:18.215 | COMMAND_HW       | 2SPHVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:19.240 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:20.265 | COMMAND_HW       | 2S1STHV    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:21.290 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:22.315 | COMMAND_HW       | 2S1HVOF    | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
+2021:296:10:43:23.340 | COMMAND_SW       | AODSDITH   | CMD_EVT  | event=NSM, event_date=2021:296:10:41:57, scs=0
 2021:296:11:08:12.966 | LOAD_EVENT       | OBS        | CMD_EVT  | manvr_start=2021:296:10:41:57.000, prev_att=(0.594590732, 0.
 2021:297:01:41:01.000 | COMMAND_SW       | AONMMODE   | CMD_EVT  | event=Maneuver, event_date=2021:297:01:41:01, msid=AONMMODE,
 2021:297:01:41:01.256 | COMMAND_SW       | AONM2NPE   | CMD_EVT  | event=Maneuver, event_date=2021:297:01:41:01, msid=AONM2NPE,

--- a/kadi/commands/tests/test_validate.py
+++ b/kadi/commands/tests/test_validate.py
@@ -155,7 +155,13 @@ def get_one_validator_data(cls: type[Validate], stop, days, no_exclude):
 @pytest.mark.skipif(not HAS_INTERNET, reason="Command sheet not available")
 @pytest.mark.parametrize("cls", Validate.subclasses)
 @pytest.mark.parametrize("no_exclude", [False, True])
-def test_validate_regression(cls, no_exclude, fast_sun_position_method, regress_stop):
+def test_validate_regression(
+    cls,
+    no_exclude,
+    fast_sun_position_method,
+    regress_stop,
+    disable_hrc_scs107_commanding,
+):
     """Test that validator data matches regression data
 
     This is likely to be fragile. In the future we may need helper function to output

--- a/kadi/config.py
+++ b/kadi/config.py
@@ -73,6 +73,12 @@ class Conf(ConfigNamespace):
         "Start date for using AGASC 1.8 catalog.",
     )
 
+    disable_hrc_scs107_commanding = ConfigItem(
+        False,
+        "Disable HRC SCS-107 commanding from #344, strictly for regression testing "
+        "of command generation prior to that patch.",
+    )
+
 
 # Create a configuration instance for the user
 conf = Conf()


### PR DESCRIPTION
## Description

The DEC2324 load was interrupted by a radiation shutdown, in the middle of an HRC-S observation. SCS-107 should power the HRC off. 

The `cea_check` run for the JAN0325 return-to-science loads incorrectly indicated that the HRC was on at the beginning of the load, which resulted in a thermal violation. This PR ensures that the HRC is turned off from the perspective of kadi states. 

This includes an unrelated fix to one regression test `test_get_starcats_each_year`. This was failing in 2025 because the first 4 days include an SCS-107 run. I think that testing a fixed set of years 2003 to 2024 inclusive is fine.

## Deployment

This should NOT be installed to flight prior to Feb 15. Otherwise this will result in duplication of the same commands which are in the Command Events sheet. Kadi command processing has a 30-day lookback, so wait until Feb 15 to be sure.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
New HRC commands result from any SCS-107 run (including NSM, Safe Mode). The command timing is different due to the addition of new commands with 1.025 sec waits.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
#### Jean
- [x] Linux
```
jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 183 items                                                            

kadi/commands/tests/test_commands.py ................................... [ 19%]
...............................................                                                [ 44%]
kadi/commands/tests/test_states.py .......................x............. [ 65%]
.............                                                                                  [ 72%]
kadi/commands/tests/test_validate.py ...................                                       [ 82%]
kadi/tests/test_events.py ..........                                                           [ 87%]
kadi/tests/test_occweb.py ......................                                               [100%]

========================================== warnings summary ==========================================
kadi/kadi/commands/tests/test_commands.py: 88 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /proj/sot/ska3/test/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================== 182 passed, 1 xfailed, 116 warnings in 225.76s (0:03:45) ======================
jeanconn-fido> git rev-parse HEAD
54e6f15c1e9e4e17e48106fe107b63b272b0dfe5
```

Independent check of unit tests by JZ:
- [x] HEAD Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Without this change, the JAN0325 thermal model run indicated that the HRC was still on at the beginning of the load when run through `cea_check`, despite the fact that it had been turned off by the SCS-107 run. With the change included, the HRC is correctly marked as off at the beginning of the thermal model run.