### PR TITLE
Limit testing of starcats each year to 2003-2024

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -890,7 +890,7 @@ def test_get_observations_start_stop_inclusion():
     assert len(obss) == 0
 
 
-years = np.arange(2003, CxoTime.now().ymdhms.year + 1)
+years = np.arange(2003, 2025)
 
 
 @pytest.mark.parametrize("year", years)


### PR DESCRIPTION
## Description

Fix a latent test failure due to there being an SCS-107 run in the first four days of 2025. The test assumes a normal load run for that time frame. Instead of trying to be clever, this fix just stipulates that running this test for years 2003 to 2024 inclusive is sufficient.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
#### ska3-flight 2024.12
```
(ska3) ➜  kadi git:(fix-starcats-each-year-test) git rev-parse --short HEAD
02aa65a
(ska3) ➜  kadi git:(fix-starcats-each-year-test) pytest
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: cov-5.0.0, timeout-2.2.0, anyio-4.3.0
collected 182 items                                                                                                                                     

kadi/commands/tests/test_commands.py ..................................................................................                           [ 45%]
kadi/commands/tests/test_states.py .......................x.........................                                                              [ 71%]
kadi/commands/tests/test_validate.py ...................                                                                                          [ 82%]
kadi/tests/test_events.py ..........                                                                                                              [ 87%]
kadi/tests/test_occweb.py ......................                                                                                                  [100%]

====================================================== 181 passed, 1 xfailed in 120.70s (0:02:00) =======================================================
```
#### ska3-flight-2025.0rc2
```
(ska3-flight-2025.0rc2) ➜  kadi git:(fix-starcats-each-year-test) git rev-parse --short HEAD          
02aa65a
(ska3-flight-2025.0rc2) ➜  kadi git:(fix-starcats-each-year-test) pytest
================================================================== test session starts ==================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 182 items                                                                                                                                     

kadi/commands/tests/test_commands.py ..................................................................................                           [ 45%]
kadi/commands/tests/test_states.py .......................x.........................                                                              [ 71%]
kadi/commands/tests/test_validate.py ...................                                                                                          [ 82%]
kadi/tests/test_events.py ..........                                                                                                              [ 87%]
kadi/tests/test_occweb.py ......................                                                                                                  [100%]

=================================================================== warnings summary ====================================================================
```
Independent check of unit tests by Javier

#### Linux ska3-flight-2025.0rc4
```
(ska3-flight-2025.0rc4) jgonzale kadi $ pytest kadi/commands/tests/test_commands.py::test_get_starcats_each_year
============================================================= test session starts =============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 22 items                                                                                                                            

kadi/commands/tests/test_commands.py ......................                                                                             [100%]

============================================================= 22 passed in 24.78s =============================================================
(ska3-flight-2025.0rc4) jgonzale kadi $ git rev-parse --short HEAD      
02aa65a

```
#### ARM64 ska3-flight-2025.0rc4
```
(ska3-flight-2025.0rc5) ~/SAO/git/kadi fix-starcats-each-year-test $ pytest kadi/commands/tests/test_commands.py::test_get_starcats_each_year
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 22 items                                                                                                                            

kadi/commands/tests/test_commands.py ......................                                                                             [100%]

============================================================= 22 passed in 3.09s ==============================================================                                                                                                                                     
(ska3-flight-2025.0rc5) ~/SAO/git/kadi fix-starcats-each-year-test $ git rev-parse --short HEAD 
02aa65a

```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
