### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -364,7 +364,7 @@ def test_nsm_safe_mode_pitch_offsets_state_constraints(stop_date_2023_203):
         scenario=scenario,
     )
     states["pitch"].info.format = ".1f"
-    out = states["datestart", "pitch", "pcad_mode"].pformat_all()
+    out = states["datestart", "pitch", "pcad_mode"].pformat()
     exp = [
         "      datestart       pitch pcad_mode",
         "--------------------- ----- ---------",
@@ -638,7 +638,7 @@ Definitive,2024:024:09:44:06,NSM,,,,
 
     out = states["datestart", "pitch", "pcad_mode"]
     out["pitch"].format = ".1f"
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
     states = kcs.get_states(
         "2024:024:09:00:00",
@@ -1512,7 +1512,7 @@ def test_hrc_not_run_scenario(stop_date_2023200):  # noqa: ARG001
         state_keys=keys,
         merge_identical=True,
     )
-    states_out = states[["datestart"] + keys].pformat_all()
+    states_out = states[["datestart"] + keys].pformat()
     assert states_out == states_exp
 
     # First make the cmd_events.csv file for the scenario where F_HRC_SAFING is run at
@@ -1555,7 +1555,7 @@ Definitive,2023:184:20:00:00.000,HRC not run,JUL0323A,Tom,Jean,F_HRC_SAFING 2023
         "2023:194:23:13:52.666   OFF   OFF     OFF     OFF",
     ]
 
-    states_out = states[["datestart"] + keys].pformat_all()
+    states_out = states[["datestart"] + keys].pformat()
     assert states_out == states_exp
 
     commands.clear_caches()
@@ -1741,4 +1741,4 @@ def test_read_backstop_with_observations():
         assert obs == obs_flight
 
     for starcat, starcat_flight in zip(starcats, starcats_cmds_flight):
-        assert starcat.pformat_all() == starcat_flight.pformat_all()
+        assert starcat.pformat() == starcat_flight.pformat()

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -468,7 +468,7 @@ def test_fids_state():
         "2023:001:23:10:52.478 2023:001:23:10:52.734    {2, 4}       fids",
         "2023:001:23:10:52.734 2023:002:00:00:00.000 {2, 4, 5}       fids",
     ]
-    out = kstates["datestart", "datestop", "fids", "trans_keys"].pformat_all()
+    out = kstates["datestart", "datestop", "fids", "trans_keys"].pformat()
     assert out == exp
 
 
@@ -1700,7 +1700,7 @@ def test_grating_motion_states():
         "2021:230:00:41:19.002 2021:230:12:00:00.000      RETR      RETR    NONE         letg",
     ]
     # fmt: on
-    assert sts.pformat_all() == exp
+    assert sts.pformat() == exp
 
 
 def test_hrc_states():
@@ -1732,7 +1732,7 @@ def test_hrc_states():
         "2022:263:21:36:06.000 2022:280:00:00:00.000     OFF     OFF   OFF   OFF    hrc_15v"
     ]
     # fmt: on
-    assert sts.pformat_all() == exp
+    assert sts.pformat() == exp
 
 
 def test_hrc_states_with_scs_commanding():
@@ -1771,7 +1771,7 @@ def test_hrc_states_with_scs_commanding():
         "2023:042:04:02:57.978 2023:042:08:35:28.888      ON    hrc_15v",
         "2023:042:08:35:28.888 2023:042:08:35:28.888     OFF    hrc_15v",
     ]
-    assert sts.pformat_all() == exp
+    assert sts.pformat() == exp
 
 
 def test_early_start_exception():
@@ -1833,7 +1833,7 @@ def test_sun_pos_mon_within_eclipse():
         )
 
         names = ["datestart"] + spm_state_keys
-        assert sts[names][-2:].pformat_all() == exp
+        assert sts[names][-2:].pformat() == exp
 
 
 def test_sun_pos_mon_within_eclipse_no_spm_enab(monkeypatch):
@@ -1862,7 +1862,7 @@ def test_sun_pos_mon_within_eclipse_no_spm_enab(monkeypatch):
         "2005:014:16:38:10.000        DISA 2005:014:15:31:36.410              False",
     ]
     names = ["datestart"] + states.SPM_STATE_KEYS
-    assert sts[names].pformat_all() == exp
+    assert sts[names].pformat() == exp
 
 
 def test_get_continuity_acis_cmd_requires_obsid():

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -111,8 +111,8 @@ def test_get_occweb_dir(str_or_Path, cache):
         "       MAR1900E/ 2004-03-18 13:44    -",
         "       MAR2600C/ 2002-04-30 13:38    -",
     ]
-    assert files_path.pformat_all() == exp
-    assert files_url.pformat_all() == exp
+    assert files_path.pformat() == exp
+    assert files_url.pformat() == exp
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
@@ -137,7 +137,7 @@ def test_get_occweb_noodle(lowercase, backslash):
         "       MAR1900E/ 2004-03-18 13:44    -",
         "       MAR2600C/ 2002-04-30 13:38    -",
     ]
-    assert files_path.pformat_all() == exp
+    assert files_path.pformat() == exp
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 182 items                                                                                                                           

kadi/commands/tests/test_commands.py .................................................................................s                 [ 45%]
kadi/commands/tests/test_states.py .......................x.........................                                                    [ 71%]
kadi/commands/tests/test_validate.py ...................                                                                                [ 82%]
kadi/tests/test_events.py ..........                                                                                                    [ 87%]
kadi/tests/test_occweb.py ......................                                                                                        [100%]

============================================================== warnings summary ===============================================================
kadi/kadi/commands/tests/test_commands.py: 84 warnings
kadi/kadi/commands/tests/test_states.py: 2 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /Users/javierg/miniforge3/envs/ska3-flight-2025.0rc5/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================== 180 passed, 1 skipped, 1 xfailed, 114 warnings in 82.01s (0:01:22) ======================================
(ska3-flight-2025.0rc5) ~/SAO/git/kadi pformat $ git rev-parse --short HEAD             
0367897
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
