### PR TITLE
Clip times in interpolate_states

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.7.2
+  rev: v0.9.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -361,7 +361,7 @@ def update_archive_and_get_cmds_recent(
 
     # Update loads table and download/archive backstop files from OCCweb
     loads = update_loads(scenario, cmd_events=cmd_events, lookback=lookback, stop=stop)
-    logger.info(f'Including loads {", ".join(loads["name"])}')
+    logger.info(f"Including loads {', '.join(loads['name'])}")
 
     for load in loads:
         load_name = load["name"]
@@ -437,7 +437,7 @@ def update_archive_and_get_cmds_recent(
         logger.info(f"Processing {cmds_source} with {len(cmds)} commands")
         end_scs = collections.defaultdict(list)
         if date_end := cmds.meta.get("rltt"):
-            source = f'RLTT in {cmds["source"][0]}'
+            source = f"RLTT in {cmds['source'][0]}"
             end_scs[date_end, source].extend([128, 129, 130, 131, 132, 133])
 
         # Explicit END SCS commands. Most commonly these come from command events
@@ -447,7 +447,7 @@ def update_archive_and_get_cmds_recent(
         if np.any(ok):
             for cmd in cmds[ok]:
                 if (scs := cmd["params"]["codisas1"]) >= 128:
-                    source = f'DISABLE SCS in {cmd["source"]} at {cmd["date"]}'
+                    source = f"DISABLE SCS in {cmd['source']} at {cmd['date']}"
                     end_scs[cmd["date"], source].append(scs)
 
         for (date_end, source), scss in end_scs.items():
@@ -465,7 +465,7 @@ def update_archive_and_get_cmds_recent(
                         n_bad = np.count_nonzero(bad)
                         logger.info(
                             f"Removing {n_bad} cmds in SCS slots {scss} from "
-                            f'{prev_cmds["source"][0]} due to {source}'
+                            f"{prev_cmds['source'][0]} due to {source}"
                         )
                     cmds_list[jj] = prev_cmds[~bad]
 
@@ -654,7 +654,7 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
                 npnt_enab = False
             if targ_att is None:
                 # No target attitude is unexpected since we got to a MANVR cmd.
-                logger.warning(f'WARNING: no target attitude for {cmd["date"]}')
+                logger.warning(f"WARNING: no target attitude for {cmd['date']}")
                 log_context_obs(cmds, cmd)
                 continue
             if prev_att is None:
@@ -662,7 +662,7 @@ def get_cmds_obs_from_manvrs(cmds, prev_att=None):
                 # beginning of loads, and normally we just push on to the next
                 # OBS. But if we already have OBS command this is a problem.
                 if cmds_obs:
-                    logger.warning(f'WARNING: No previous attitude for {cmd["date"]}')
+                    logger.warning(f"WARNING: No previous attitude for {cmd['date']}")
                     log_context_obs(cmds, cmd)
                 prev_att = targ_att
                 continue

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -892,7 +892,7 @@ class CommandTable(Table):
                         fmt = "{}={}"
                     fmtvals.append(fmt.format(key, val))
 
-                fmtvals.append(f'scs={cmd["scs"]}')
+                fmtvals.append(f"scs={cmd['scs']}")
 
                 params_str = ", ".join(fmtvals)
             else:

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -2532,6 +2532,9 @@ def get_continuity(
 def interpolate_states(states, times):
     """Interpolate ``states`` table at given times.
 
+    Any ``times`` that are outside the range of the states table are clipped to the
+    first or last state.
+
     Parameters
     ----------
     states
@@ -2554,7 +2557,7 @@ def interpolate_states(states, times):
         tstops = date2secs(states["datestop"])
 
     indexes = np.searchsorted(tstops, times)
-    out = states[indexes]
+    out = states[indexes.clip(0, len(states) - 1)]
     out.add_column(Column(secs2date(times), name="date"), index=0)
 
     return out

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -2532,8 +2532,8 @@ def get_continuity(
 def interpolate_states(states, times):
     """Interpolate ``states`` table at given times.
 
-    Any ``times`` that are outside the range of the states table are clipped to the
-    first or last state.
+    For any ``times`` that are before or after the range of the states table, the
+    output state will be the first or last state, respectively..
 
     Parameters
     ----------

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -1897,3 +1897,12 @@ def test_get_continuity_spm_eclipse():
             "eclipse_enable_spm": "2017:087:07:49:55.838",
         },
     }
+
+
+def test_interpolate_states_extrapolate():
+    """Test that the states are correctly interpolated and extrapolated."""
+    # fmt: off
+    sts =  states.get_states("2024:001:00:01:00", "2024:001:00:05:00", state_keys=["obsid"])
+    times = ["2024:001:00:00:00", "2024:001:00:02:30", "2024:001:00:05:00", "2024:001:00:06:00"]
+    sts_interp = states.interpolate_states(sts, times)
+    assert np.all(sts_interp["obsid"] == [43839] * 4)


### PR DESCRIPTION
## Description

Replan Central `make_timeline.py` had a one-off uncaught exception (see below) related to trying to interpolate states at a time outside of the states intervals. Tracking this down is a little tricky since it was not reproducible, but `interpolate_states` can be fixed.

`interpolate_states` already uses `states[0]` for any `times` that are before the first state. This PR effectively clips the `times` so that it uses `states[-1]` for any `times` after the last state. This matches the default behavior of `np.interpolate()`.

#### Replan Central exception (2025-01-09 at 3am local)
```
WARNING - '/proj/sot/ska3/flight/share/arc3/make_timeline.py --data-dir=/proj/sot/ska3/flight/data/arc3' returned non-zero status: 256
Traceback (most recent call last):
  File "/proj/sot/ska3/flight/share/arc3/make_timeline.py", line 714, in main
    write_states_json(
  File "/proj/sot/ska3/flight/share/arc3/make_timeline.py", line 1163, in write_states_json
    state_vals = kadi_states.interpolate_states(states, times)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/kadi/commands/states.py", line 2557, in interpolate_states
    out = states[indexes]
          ~~~~~~^^^^^^^^^
  ... (astropy internal)
IndexError: index 388 is out of bounds for axis 0 with size 388
```

## Requires

- ska3-flight > 2025.0 (now uses `pformat()` instead of `pformat_all()`)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
`times` beyond the last state will return the last state instead of failing with an exception.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new unit test)
```
(ska3-flight-2025.0rc2) ➜  kadi git:(improve-interpolate-states) git rev-parse --short HEAD                  
d3e76ec
(ska3-flight-2025.0rc2) ➜  kadi git:(improve-interpolate-states) pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 183 items                                                                                                            

kadi/commands/tests/test_commands.py ..................................................................................  [ 44%]
kadi/commands/tests/test_states.py .......................x..........................                                    [ 72%]
kadi/commands/tests/test_validate.py ...................                                                                 [ 82%]
kadi/tests/test_events.py ..........                                                                                     [ 87%]
kadi/tests/test_occweb.py ......................                                                                         [100%]

========================================== 182 passed, 1 xfailed in 73.59s (0:01:13) ===========================================
```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-flight-2025.0rc2) jeanconn-fido> pytest
=============================================================== test session starts ===============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 183 items                                                                                                                               

kadi/commands/tests/test_commands.py ..................................................................................                     [ 44%]
kadi/commands/tests/test_states.py .......................x..........................                                                       [ 72%]
kadi/commands/tests/test_validate.py ...................                                                                                    [ 82%]
kadi/tests/test_events.py ..........                                                                                                        [ 87%]
kadi/tests/test_occweb.py ......................                                                                                            [100%]

================================================================ warnings summary =================================================================
kadi/kadi/commands/tests/test_commands.py: 86 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 182 passed, 1 xfailed, 114 warnings in 221.69s (0:03:41) =============================================
(ska3-flight-2025.0rc2) jeanconn-fido> git rev-parse HEAD
42fecc6293305a1296311b136cec676f859256be
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New unit test added.
