### PR TITLE
Add infrastructure to filter command events to get alternate command history

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1022,6 +1022,8 @@ def update_cmd_events(
     this environment variable is set, then events with a date after the value of
     ``CXOTIME_NOW`` are filtered out.
 
+    Finally, events are filtered by `event_filter` if it is provided.
+
     Parameters
     ----------
     scenario : str, None

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -193,7 +193,7 @@ def get_cmds(
     *,
     inclusive_stop=False,
     scenario=None,
-    event_filter=None,
+    event_filter: Callable | list[Callable] | None = None,
     **kwargs,
 ) -> CommandTable:
     """Get Chandra commands that ran on-board or are approved to run.
@@ -237,6 +237,10 @@ def get_cmds(
         Name of commands archive scenario to use instead of default.
     inclusive_stop : bool
         Include commands at exactly ``stop`` if True.
+    event_filter : callable, list of callable, None
+        Callable function or list of callable functions that takes an Event Table as
+        input and returns a boolean mask with same length as Table. This is used to
+        select rows from the Table. If None, no filtering is done.
     **kwargs : dict
         key=val keyword argument pairs for filtering.
 

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -28,6 +28,7 @@ __all__ = [
     "filter_cmd_events_by_event",
     "SCS107_EVENTS",
     "filter_scs107_events",
+    "set_time_now",
 ]
 
 
@@ -1194,3 +1195,31 @@ def filter_cmd_events_state(cmd_events: Table) -> np.ndarray[bool]:
         allowed_states.append("In-work")
     ok = np.isin(cmd_events["State"], allowed_states)
     return ok
+
+
+def set_time_now(date):
+    """Context manager to temporarily set CXOTIME_NOW to ``date``.
+
+    This temporarily sets the CXOTIME_NOW environment variable to ``date`` within the
+    context block. This is a very thin wrapper around ska_helpers.utils.temp_env_var.
+    This effectively makes ``date`` serve as the current time and is useful for testing.
+
+    In this example we get the observation history as if the 2025:012:14:37:04 SCS-107
+    run never happened::
+
+      import kadi.commands as kc
+      start = "2025:012"
+      stop = "2025:018"
+      with kc.set_time_now(stop):
+          obss_as_planned = kc.get_observations(
+              start, stop, event_filter=kc.filter_scs107_events
+          )
+
+    Parameters
+    ----------
+    date : CxoTimeLike
+        Date in CxoTime-compatible format.
+    """
+    from ska_helpers.utils import temp_env_var
+
+    return temp_env_var("CXOTIME_NOW", date)

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -1286,4 +1286,4 @@ def set_time_now(date):
     """
     from ska_helpers.utils import temp_env_var
 
-    return temp_env_var("CXOTIME_NOW", date)
+    return temp_env_var("CXOTIME_NOW", CxoTime(date).date)

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -1110,15 +1110,15 @@ def ska_load_dir(load_name: str) -> Path:
     return load_dir_from_load_name(load_name)
 
 
-def get_default_stop() -> str | None:
-    """Get the default stop date for kadi commands.
+def get_cxotime_now() -> str | None:
+    """Get the value of CXOTIME_NOW env var (or legacy proxy) for kadi commands.
 
     This returns the value of the CXOTIME_NOW environment variable if set,
     otherwise the value of the KADI_COMMANDS_DEFAULT_STOP environment variable,
     otherwise None.
     """
 
-    stop = os.environ.get(
+    cxotime_now = os.environ.get(
         "CXOTIME_NOW", kadi_stop := os.environ.get("KADI_COMMANDS_DEFAULT_STOP")
     )
 
@@ -1129,4 +1129,4 @@ def get_default_stop() -> str | None:
             stacklevel=2,
         )
 
-    return stop
+    return cxotime_now

--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -1144,7 +1144,10 @@ def get_cxotime_now() -> str | None:
 
 def filter_cmd_events_date_stop(date_stop):
     """
-    Returns a function that removes command events with ``Date > date_stop``.
+    Returns an event filter function to remove events with ``Date > date_stop``.
+
+    The returned function can be used as an ``event_filter`` argument to ``get_cmds()``
+    and other related functions.
 
     Parameters
     ----------
@@ -1154,7 +1157,9 @@ def filter_cmd_events_date_stop(date_stop):
     Returns
     -------
     Callable
-        Function that takes a Table of command events and returns a boolean numpy array.
+        Function that takes a Table of command events and returns a boolean numpy array
+        of the same length as the table. The array is a mask and ``True`` entries are
+        kept.
     """
 
     def func(cmd_events):

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -317,6 +317,7 @@ def get_starcats_as_table(
     scenario=None,
     cmds=None,
     starcat_date=None,
+    event_filter=None,
 ):
     """Get a single table of star catalog entries corresponding to input parameters.
 
@@ -360,6 +361,10 @@ def get_starcats_as_table(
         Use this command table instead of querying the archive.
     starcat_date : CxoTime-like, None
         Date of the observation's star catalog
+    event_filter : callable, list of callable, None
+        Callable function or list of callable functions that takes an Event Table as
+        input and returns a boolean mask with same length as Table. If None, no
+        filtering is done.
 
     Returns
     -------
@@ -374,6 +379,7 @@ def get_starcats_as_table(
         cmds=cmds,
         starcat_date=starcat_date,
         as_dict=True,
+        event_filter=event_filter,
     )
     out = defaultdict(list)
     for starcat in starcats:
@@ -404,6 +410,7 @@ def get_starcats(
     as_dict=False,
     starcat_date=None,
     show_progress=False,
+    event_filter=None,
 ):
     """Get a list of star catalogs corresponding to input parameters.
 
@@ -478,6 +485,10 @@ def get_starcats(
         Date of the observation's star catalog
     show_progress : bool
         Show progress bar for long queries (default=False)
+    event_filter : callable, list of callable, None
+        Callable function or list of callable functions that takes an Event Table as
+        input and returns a boolean mask with same length as Table. If None, no
+        filtering is done.
 
     Returns
     -------
@@ -501,6 +512,7 @@ def get_starcats(
         scenario=scenario,
         cmds=cmds,
         starcat_date=starcat_date,
+        event_filter=event_filter,
     )
     starcats = []
     rev_pars_dict = REV_PARS_DICT if cmds is None else cmds.rev_pars_dict()
@@ -571,7 +583,14 @@ def get_starcats(
 
 
 def get_observations(
-    start=None, stop=None, *, obsid=None, scenario=None, cmds=None, starcat_date=None
+    start=None,
+    stop=None,
+    *,
+    obsid=None,
+    scenario=None,
+    cmds=None,
+    starcat_date=None,
+    event_filter=None,
 ):
     """Get observations corresponding to input parameters.
 
@@ -604,8 +623,9 @@ def get_observations(
 
         >>> obs_all = get_observations()  # All observations in commands archive
 
-        # Might be convenient to handle this as a Table >>> from astropy.table
-        import Table >>> obs_all = Table(obs_all)
+        # Might be convenient to handle this as a Table
+        >>> from astropy.table import Table
+        >>> obs_all = Table(obs_all)
 
         >>> from kadi.commands import get_observations
         >>> get_observations(starcat_date='2022:001:17:00:58.521')
@@ -635,6 +655,10 @@ def get_observations(
         Use this command table instead of querying the archive
     starcat_date : CxoTime-like, None
         Date of the observation's star catalog
+    event_filter : callable, list of callable, None
+        Callable function or list of callable functions that takes an Event Table as
+        input and returns a boolean mask with same length as Table. If None, no
+        filtering is done.
 
     Returns
     -------
@@ -651,7 +675,7 @@ def get_observations(
 
     if cmds is None:
         if scenario not in OBSERVATIONS:
-            cmds = get_cmds(scenario=scenario)
+            cmds = get_cmds(scenario=scenario, event_filter=event_filter)
             cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
             obsids = []
             for cmd in cmds_obs:

--- a/kadi/commands/observations.py
+++ b/kadi/commands/observations.py
@@ -665,7 +665,9 @@ def get_observations(
     list of dict
         Observation parameters for matching observations.
     """
+    from kadi.commands import conf
     from kadi.commands.commands_v2 import get_cmds
+    from kadi.commands.core import get_cxotime_now
 
     if starcat_date is not None:
         start = starcat_date if start is None else start
@@ -674,7 +676,8 @@ def get_observations(
     stop = (CxoTime.now() + 1 * u.year) if stop is None else CxoTime(stop)
 
     if cmds is None:
-        if scenario not in OBSERVATIONS:
+        cache_key = scenario, get_cxotime_now(), conf.default_lookback, event_filter
+        if cache_key not in OBSERVATIONS:
             cmds = get_cmds(scenario=scenario, event_filter=event_filter)
             cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
             obsids = []
@@ -686,9 +689,9 @@ def get_observations(
                 obsids.append(_obsid)
 
             cmds_obs["obsid"] = obsids
-            OBSERVATIONS[scenario] = cmds_obs
+            OBSERVATIONS[cache_key] = cmds_obs
         else:
-            cmds_obs = OBSERVATIONS[scenario]
+            cmds_obs = OBSERVATIONS[cache_key]
     else:
         cmds_obs = cmds[cmds["tlmsid"] == "OBS"]
 

--- a/kadi/commands/tests/conftest.py
+++ b/kadi/commands/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import ska_sun
 
-import kadi.commands
+import kadi.commands as kc
 
 
 @pytest.fixture()
@@ -11,4 +11,13 @@ def fast_sun_position_method(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture()
 def disable_hrc_scs107_commanding(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(kadi.commands.conf, "disable_hrc_scs107_commanding", True)
+    monkeypatch.setattr(kc.conf, "disable_hrc_scs107_commanding", True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cmds_dir(tmp_path_factory):
+    with kc.conf.set_temp("cache_loads_in_astropy_cache", True):
+        with kc.conf.set_temp("clean_loads_dir", False):
+            cmds_dir = tmp_path_factory.mktemp("cmds_dir")
+            with kc.conf.set_temp("commands_dir", str(cmds_dir)):
+                yield

--- a/kadi/commands/tests/conftest.py
+++ b/kadi/commands/tests/conftest.py
@@ -21,3 +21,10 @@ def cmds_dir(tmp_path_factory):
             cmds_dir = tmp_path_factory.mktemp("cmds_dir")
             with kc.conf.set_temp("commands_dir", str(cmds_dir)):
                 yield
+
+
+@pytest.fixture()
+def clear_caches():
+    kc.clear_caches()
+    yield
+    kc.clear_caches()

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -553,6 +553,7 @@ def test_cmds_scenario(stop_date_2020_12_03):  # noqa: ARG001
     cmds_dir = Path(commands.conf.commands_dir) / scenario
     cmds_dir.mkdir(exist_ok=True, parents=True)
     # Note variation in format of date, since this comes from humans.
+    # This also does not have a State column, which tests code to put that in.
     cmd_evts_text = """\
 Date,Event,Params,Author,Comment
 2020-12-01T00:08:30,Command,ACISPKT | TLMSID=WSPOW00000",Tom Aldcroft,

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -42,15 +42,6 @@ except FileNotFoundError:
     HAS_AGASC_1P8 = False
 
 
-@pytest.fixture(scope="module", autouse=True)
-def cmds_dir(tmp_path_factory):
-    with commands.conf.set_temp("cache_loads_in_astropy_cache", True):
-        with commands.conf.set_temp("clean_loads_dir", False):
-            cmds_dir = tmp_path_factory.mktemp("cmds_dir")
-            with commands.conf.set_temp("commands_dir", str(cmds_dir)):
-                yield
-
-
 def test_find():
     idx_cmds = commands_v2.IDX_CMDS
     pars_dict = commands_v2.PARS_DICT

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1313,7 +1313,7 @@ def test_scenario_with_rts(monkeypatch, fast_sun_position_method):
     # Make a new custom scenario from the flight version
     events_flight = Table.read(path_flight)
     cti_event = {
-        "State": "definitive",
+        "State": "Definitive",
         "Date": "2021:297:13:00:00",
         "Event": "RTS",
         "Params": "RTSLOAD,1_CTI06,NUM_HOURS=12:00:00,SCS_NUM=135",

--- a/kadi/commands/tests/test_filter_events.py
+++ b/kadi/commands/tests/test_filter_events.py
@@ -8,27 +8,169 @@ from testr.test_helper import has_internet
 import kadi.commands as kc
 import kadi.commands.commands_v2 as kcc2
 import kadi.commands.observations as kco
+import kadi.commands.states as kcs
 
 HAS_INTERNET = has_internet()
 
+# Expected observation outputs for two test cases
+exp_2024366 = [
+    "obsid_1 obsid_2 simpos_1 simpos_2 source_1      starcat_date    ",
+    "------- ------- -------- -------- -------- ---------------------",
+    "  42814   42814   -99616   -99616 DEC2324B 2024:365:23:24:58.901",
+    "  42813   42813   -99616   -99616 DEC2324B 2024:366:01:17:07.965",
+    "  42812   42812   -99616   -99616 DEC2324B 2024:366:02:58:28.076",
+    "  42810   42810   -99616   -99616 DEC2324B 2024:366:05:08:36.000",
+    "  42809   42809   -99616   -99616 DEC2324B 2024:366:05:48:15.632",
+    "  30700   30700    92560    92560 DEC2324B 2024:366:08:26:39.076",
+    "  30690   30690    92904    92904 DEC2324B 2024:366:11:55:08.999",
+    "  30550   30550   -99616   -99616 DEC2324B 2024:366:15:21:03.938",  # SCS-107
+    "  30550   28803   -99616    92904 DEC2324B 2024:366:18:05:04.938",
+    "  30550   28365   -99616    75624 DEC2324B 2024:366:21:21:07.538",
+    "  30550   29835   -99616    92560 DEC2324B 2025:001:08:44:07.810",
+    "  65518   25501   -99616   -50504 DEC2324B 2025:001:13:08:09.384",  # Obsid update
+    "  65518   26975   -99616    92904 DEC2324B 2025:001:16:38:50.384",
+    "  65518   30500   -99616    75624 DEC2324B 2025:001:20:54:41.492",
+    "  65518   25505   -99616   -50504 DEC2324B 2025:002:01:35:29.276",
+    "  65518   29904   -99616    92904 DEC2324B 2025:002:03:07:54.276",
+    "  65518   30688   -99616    92904 DEC2324B 2025:002:04:53:45.276",
+    "  65518   30082   -99616    92904 DEC2324B 2025:002:08:11:25.231",
+    "  65518   42808   -99616   -99616 DEC2324B 2025:002:12:59:42.571",
+    "  65518   42807   -99616   -99616 DEC2324B 2025:002:14:17:07.525",
+    "  65518   42806   -99616   -99616 DEC2324B 2025:002:17:17:25.479",
+    "  65518   42805   -99616   -99616 DEC2324B 2025:002:18:36:19.655",
+    "  65518   42803   -99616   -99616 DEC2324B 2025:002:20:37:36.000",
+    "  65518   42802   -99616   -99616 DEC2324B 2025:002:21:24:48.840",
+    "  65518   42801   -99616   -99616 DEC2324B 2025:002:23:18:02.848",
+    "  65518   30692   -99616    75624 DEC2324B 2025:003:01:18:38.220",
+    "  30707   30707    92904    92904 JAN0325A 2025:003:03:30:50.971",  # Replan
+    "  42808   42808    92904    92904 JAN0325A 2025:003:07:11:30.932",
+    "  30552   30552   -99616   -99616 JAN0325A 2025:003:08:20:57.635",
+    "  29750   29750    75624    75624 JAN0325A 2025:003:11:33:42.635",
+    "  30708   30708    92904    92904 JAN0325A 2025:003:12:45:37.779",
+    "  30689   30689    92904    92904 JAN0325A 2025:003:16:51:59.824",
+    "  30083   30083    92904    92904 JAN0325A 2025:003:20:10:55.729",
+]
+
+exp_2025012 = [
+    "obsid_1 obsid_2 simpos_1 simpos_2 source_1      starcat_date    ",
+    "------- ------- -------- -------- -------- ---------------------",
+    "  28808   28808    92904    92904 JAN0325A 2025:011:21:57:32.070",
+    "  30727   30727   -99616   -99616 JAN0325A 2025:012:00:16:58.622",
+    "  30375   30375    75624    75624 JAN0325A 2025:012:03:46:03.622",
+    "  28203   28203    75624    75624 JAN0325A 2025:012:09:12:20.647",  # SCS-107
+    "  28203   30713   -99616    75624 JAN0325A 2025:012:16:32:24.171",
+    "  28203   28777   -99616   -50504 JAN0325A 2025:012:19:57:10.011",
+    "  28203   30720   -99616    75624 JAN0325A 2025:012:23:49:31.011",
+    "  28203   42779   -99616   -99616 JAN0325A 2025:013:03:02:14.487",
+    "  28203   42778   -99616   -99616 JAN1325A 2025:013:04:44:06.000",  # Observing not run
+    "  28203   42777   -99616   -99616 JAN1325A 2025:013:05:57:09.907",
+    "  28203   42776   -99616   -99616 JAN1325A 2025:013:07:07:46.860",
+    "  28203   42775   -99616   -99616 JAN1325A 2025:013:07:44:32.626",
+    "  28203   42774   -99616   -99616 JAN1325A 2025:013:09:01:57.271",
+    "  28203   42772   -99616   -99616 JAN1325A 2025:013:10:28:47.000",
+    "  28203   42771   -99616   -99616 JAN1325A 2025:013:10:52:58.000",
+    "  28203   42770   -99616   -99616 JAN1325A 2025:013:12:13:46.779",
+    "  28203   28538   -99616    75624 JAN1325A 2025:013:13:10:11.281",
+    "  28203   29875   -99616    75624 JAN1325A 2025:013:22:22:50.269",
+    "  28203   29836   -99616    92560 JAN1325A 2025:014:03:09:59.659",
+    "  28203   29623   -99616    91576 JAN1325A 2025:014:07:27:04.516",
+    "  28203   30730   -99616    75624 JAN1325A 2025:014:13:35:28.530",
+    "  28203   30729   -99616    92560 JAN1325A 2025:014:20:15:34.620",
+    "  28203   30373   -99616    75624 JAN1325A 2025:015:01:13:39.560",
+    "  28565   28565    75624    75624 JAN1525A 2025:015:06:34:03.769",  # Replan
+    "  29963   29963    75624    75624 JAN1525A 2025:015:15:17:21.528",
+    "  42779   42779   -99616   -99616 JAN1525A 2025:015:18:31:28.826",
+    "  42778   42778   -99616   -99616 JAN1525A 2025:015:19:52:46.485",
+]
+
+# SCS-107 filter + "Command" filter removes all CMT_EVT commands.
+# There are a number of "Command" event related to the HRC shutoff due to SCS-107
+# during an HRC-S observation.
+cmd_evt_params_2024366 = []
+
+# SCS-107 filter leaves in two source="CMD_EVT" commands. These get checked in the test.
+cmd_evt_params_2025012 = [
+    {"event": "Command", "event_date": "2025:013:15:14:38"},
+    {
+        "event": "Load_not_run",
+        "event_date": "2025:014:02:55:00",
+        "event_type": "LOAD_NOT_RUN",
+        "load": "JAN1425A",
+    },
+]
+
+cases = [
+    # Includes a manual "Obsid" update event
+    {
+        "start": "2024:366",
+        "stop": "2025:004",
+        "exp_lines": exp_2024366,
+        "len_as_run": 36,  # One extra observation due to the manual obsid update
+        "len_planned": 35,
+        "default_stop": 20,
+        "event_filter": (
+            kc.filter_scs107_events,
+            kc.filter_cmd_events_by_event("Command"),  # Remove all HRC turnoff commands
+        ),
+        "cmd_evt_params": cmd_evt_params_2024366,
+    },
+    # Includes an "Observing not run" JAN1325A event
+    {
+        "start": "2025:012",
+        "stop": "2025:016",
+        "exp_lines": exp_2025012,
+        "len_as_run": 29,
+        "len_planned": 29,
+        "default_stop": 60,
+        "event_filter": kc.filter_scs107_events,
+        "cmd_evt_params": cmd_evt_params_2025012,
+    },
+]
+
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
-def test_filter_scs107_2024366(cmds_dir):
-    """Filter the command events associated with SCS-107 on 2024:366"""
-    start = "2024:365"
-    stop = "2025:003"
+@pytest.mark.parametrize("case", cases)
+def test_filter_scs107_events(
+    clear_caches,
+    cmds_dir,
+    case,
+):
+    """Filter the command events associated with SCS-107 events.
+
+    Test that get_observations(), get_states(), and get_cmds() are working as expected
+    when the event_filter is applied to the planned observations.
+    """
+    start = case["start"]
+    stop = case["stop"]
+    exp_lines = case["exp_lines"]
+    len_as_run = case["len_as_run"]
+    len_planned = case["len_planned"]
+    default_lookback = case["default_stop"]
+    event_filter = case["event_filter"]
+    cmd_evt_params = case["cmd_evt_params"]
 
     obss_as_run = apt.Table(kc.get_observations(start, stop))
 
-    with kc.set_time_now(stop), kc.conf.set_temp("default_lookback", 20):
+    with kc.set_time_now(stop), kc.conf.set_temp("default_lookback", default_lookback):
         obss_planned = apt.Table(
-            kc.get_observations(start, stop, event_filter=kc.filter_scs107_events)
+            kc.get_observations(start, stop, event_filter=event_filter)
         )
+        states_planned = kcs.get_states(
+            start, stop, event_filter=event_filter, state_keys=["obsid"]
+        )
+        cmds_planned = kc.get_cmds(start, stop, event_filter=event_filter)
+
+    # get_states() is working as expected
+    assert np.all(states_planned["obsid"] == obss_planned["obsid"])
+
+    # get_cmds() is working as expected - no CMD_EVT in the planned observations
+    ok = cmds_planned["source"] == "CMD_EVT"
+    assert np.all(cmds_planned[ok]["params"] == cmd_evt_params)
 
     # As-run gets an extra observation because the manual obsid update at
     # 2025:001:12:48:34.040 breaks the observation into two.
-    assert len(obss_as_run) == 34
-    assert len(obss_planned) == 33
+    assert len(obss_as_run) == len_as_run
+    assert len(obss_planned) == len_planned
 
     # Now get rid of the 2nd of the observation that was split into two. The source of
     # CMD_EVT is from the Obsid command event at 2025:001:12:48:34.040.
@@ -50,48 +192,20 @@ def test_filter_scs107_2024366(cmds_dir):
 
     obss_run_planned = apt.join(obss_as_run, obss_planned, keys="starcat_date")
     lines = obss_run_planned[
-        "obsid_1", "obsid_2", "simpos_1", "simpos_2", "starcat_date"
+        "obsid_1",
+        "obsid_2",
+        "simpos_1",
+        "simpos_2",
+        "source_1",
+        "starcat_date",
     ].pformat()
 
-    assert lines == [
-        "obsid_1 obsid_2 simpos_1 simpos_2      starcat_date    ",
-        "------- ------- -------- -------- ---------------------",
-        "  30693   30693    92904    92904 2024:364:21:02:54.559",
-        "  30699   30699    92560    92560 2024:365:00:21:34.399",
-        "  28631   28631    92904    92904 2024:365:03:49:22.699",
-        "  30486   30486   -50504   -50504 2024:365:12:13:55.474",
-        "  30497   30497    75624    75624 2024:365:16:49:40.474",
-        "  42815   42815   -99616   -99616 2024:365:21:32:34.599",
-        "  42814   42814   -99616   -99616 2024:365:23:24:58.901",
-        "  42813   42813   -99616   -99616 2024:366:01:17:07.965",
-        "  42812   42812   -99616   -99616 2024:366:02:58:28.076",
-        "  42810   42810   -99616   -99616 2024:366:05:08:36.000",
-        "  42809   42809   -99616   -99616 2024:366:05:48:15.632",
-        "  30700   30700    92560    92560 2024:366:08:26:39.076",
-        "  30690   30690    92904    92904 2024:366:11:55:08.999",
-        "  30550   30550   -99616   -99616 2024:366:15:21:03.938",
-        "  30550   28803   -99616    92904 2024:366:18:05:04.938",
-        "  30550   28365   -99616    75624 2024:366:21:21:07.538",
-        "  30550   29835   -99616    92560 2025:001:08:44:07.810",
-        "  65518   25501   -99616   -50504 2025:001:13:08:09.384",
-        "  65518   26975   -99616    92904 2025:001:16:38:50.384",
-        "  65518   30500   -99616    75624 2025:001:20:54:41.492",
-        "  65518   25505   -99616   -50504 2025:002:01:35:29.276",
-        "  65518   29904   -99616    92904 2025:002:03:07:54.276",
-        "  65518   30688   -99616    92904 2025:002:04:53:45.276",
-        "  65518   30082   -99616    92904 2025:002:08:11:25.231",
-        "  65518   42808   -99616   -99616 2025:002:12:59:42.571",
-        "  65518   42807   -99616   -99616 2025:002:14:17:07.525",
-        "  65518   42806   -99616   -99616 2025:002:17:17:25.479",
-        "  65518   42805   -99616   -99616 2025:002:18:36:19.655",
-        "  65518   42803   -99616   -99616 2025:002:20:37:36.000",
-        "  65518   42802   -99616   -99616 2025:002:21:24:48.840",
-        "  65518   42801   -99616   -99616 2025:002:23:18:02.848",
-    ]
+    assert lines == exp_lines
 
     keys = [
+        # scenario, stop, default_lookback, event_filter
         (None, None, 30, None),
-        (None, "2025:003", 20, kc.filter_scs107_events),
+        (None, stop, default_lookback, event_filter),
     ]
     assert list(kcc2.CMDS_RECENT) == keys
     assert list(kco.OBSERVATIONS) == keys

--- a/kadi/commands/tests/test_filter_events.py
+++ b/kadi/commands/tests/test_filter_events.py
@@ -166,9 +166,6 @@ def test_filter_scs107_events(
     # get_cmds() is working as expected - no CMD_EVT in the planned observations
     ok = cmds_planned["source"] == "CMD_EVT"
     assert np.all(cmds_planned[ok]["params"] == cmd_evt_params)
-
-    # As-run gets an extra observation because the manual obsid update at
-    # 2025:001:12:48:34.040 breaks the observation into two.
     assert len(obss_as_run) == len_as_run
     assert len(obss_planned) == len_planned
 

--- a/kadi/commands/tests/test_filter_events.py
+++ b/kadi/commands/tests/test_filter_events.py
@@ -1,0 +1,97 @@
+# Use data file from parse_cm.test for get_cmds_from_backstop test.
+# This package is a dependency
+import astropy.table as apt
+import numpy as np
+import pytest
+from testr.test_helper import has_internet
+
+import kadi.commands as kc
+import kadi.commands.commands_v2 as kcc2
+import kadi.commands.observations as kco
+
+HAS_INTERNET = has_internet()
+
+
+@pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
+def test_filter_scs107_2024366(cmds_dir):
+    """Filter the command events associated with SCS-107 on 2024:366"""
+    start = "2024:365"
+    stop = "2025:003"
+
+    obss_as_run = apt.Table(kc.get_observations(start, stop))
+
+    with kc.set_time_now(stop), kc.conf.set_temp("default_lookback", 20):
+        obss_planned = apt.Table(
+            kc.get_observations(start, stop, event_filter=kc.filter_scs107_events)
+        )
+
+    # As-run gets an extra observation because the manual obsid update at
+    # 2025:001:12:48:34.040 breaks the observation into two.
+    assert len(obss_as_run) == 34
+    assert len(obss_planned) == 33
+
+    # Now get rid of the 2nd of the observation that was split into two. The source of
+    # CMD_EVT is from the Obsid command event at 2025:001:12:48:34.040.
+    ok = obss_as_run["source"] != "CMD_EVT"
+    obss_as_run = obss_as_run[ok]
+
+    # Make sure that the source and starcat_date are the same.
+    assert set(obss_as_run.colnames) == set(obss_planned.colnames)
+    for name in obss_as_run.colnames:
+        if name in ["obsid", "simpos"]:
+            continue
+    assert np.all(obss_as_run[name] == obss_planned[name])
+
+    # Now filter out the two observations that have no star catalog. These are both
+    # the gyro hold in the high-IR zone.
+    ok = ~obss_as_run["starcat_date"].mask
+    obss_as_run = obss_as_run[ok]
+    obss_planned = obss_planned[ok]
+
+    obss_run_planned = apt.join(obss_as_run, obss_planned, keys="starcat_date")
+    lines = obss_run_planned[
+        "obsid_1", "obsid_2", "simpos_1", "simpos_2", "starcat_date"
+    ].pformat()
+
+    assert lines == [
+        "obsid_1 obsid_2 simpos_1 simpos_2      starcat_date    ",
+        "------- ------- -------- -------- ---------------------",
+        "  30693   30693    92904    92904 2024:364:21:02:54.559",
+        "  30699   30699    92560    92560 2024:365:00:21:34.399",
+        "  28631   28631    92904    92904 2024:365:03:49:22.699",
+        "  30486   30486   -50504   -50504 2024:365:12:13:55.474",
+        "  30497   30497    75624    75624 2024:365:16:49:40.474",
+        "  42815   42815   -99616   -99616 2024:365:21:32:34.599",
+        "  42814   42814   -99616   -99616 2024:365:23:24:58.901",
+        "  42813   42813   -99616   -99616 2024:366:01:17:07.965",
+        "  42812   42812   -99616   -99616 2024:366:02:58:28.076",
+        "  42810   42810   -99616   -99616 2024:366:05:08:36.000",
+        "  42809   42809   -99616   -99616 2024:366:05:48:15.632",
+        "  30700   30700    92560    92560 2024:366:08:26:39.076",
+        "  30690   30690    92904    92904 2024:366:11:55:08.999",
+        "  30550   30550   -99616   -99616 2024:366:15:21:03.938",
+        "  30550   28803   -99616    92904 2024:366:18:05:04.938",
+        "  30550   28365   -99616    75624 2024:366:21:21:07.538",
+        "  30550   29835   -99616    92560 2025:001:08:44:07.810",
+        "  65518   25501   -99616   -50504 2025:001:13:08:09.384",
+        "  65518   26975   -99616    92904 2025:001:16:38:50.384",
+        "  65518   30500   -99616    75624 2025:001:20:54:41.492",
+        "  65518   25505   -99616   -50504 2025:002:01:35:29.276",
+        "  65518   29904   -99616    92904 2025:002:03:07:54.276",
+        "  65518   30688   -99616    92904 2025:002:04:53:45.276",
+        "  65518   30082   -99616    92904 2025:002:08:11:25.231",
+        "  65518   42808   -99616   -99616 2025:002:12:59:42.571",
+        "  65518   42807   -99616   -99616 2025:002:14:17:07.525",
+        "  65518   42806   -99616   -99616 2025:002:17:17:25.479",
+        "  65518   42805   -99616   -99616 2025:002:18:36:19.655",
+        "  65518   42803   -99616   -99616 2025:002:20:37:36.000",
+        "  65518   42802   -99616   -99616 2025:002:21:24:48.840",
+        "  65518   42801   -99616   -99616 2025:002:23:18:02.848",
+    ]
+
+    keys = [
+        (None, None, 30, None),
+        (None, "2025:003", 20, kc.filter_scs107_events),
+    ]
+    assert list(kcc2.CMDS_RECENT) == keys
+    assert list(kco.OBSERVATIONS) == keys

--- a/kadi/commands/tests/test_filter_events.py
+++ b/kadi/commands/tests/test_filter_events.py
@@ -102,8 +102,8 @@ cmd_evt_params_2025012 = [
 cases = [
     # Includes a manual "Obsid" update event
     {
-        "start": "2024:366",
-        "stop": "2025:004",
+        "start": "2024:366:00:00:00.000",
+        "stop": "2025:004:00:00:00.000",
         "exp_lines": exp_2024366,
         "len_as_run": 36,  # One extra observation due to the manual obsid update
         "len_planned": 35,
@@ -116,8 +116,8 @@ cases = [
     },
     # Includes an "Observing not run" JAN1325A event
     {
-        "start": "2025:012",
-        "stop": "2025:016",
+        "start": "2025:012:00:00:00.000",
+        "stop": "2025:016:00:00:00.000",
         "exp_lines": exp_2025012,
         "len_as_run": 29,
         "len_planned": 29,

--- a/kadi/config.py
+++ b/kadi/config.py
@@ -21,7 +21,7 @@ class Conf(ConfigNamespace):
     """
 
     default_lookback = ConfigItem(
-        30, "Default lookback for previous approved loads (days)."
+        30.0, "Default lookback for previous approved loads (days)."
     )
     cache_loads_in_astropy_cache = ConfigItem(
         False,


### PR DESCRIPTION
## Description

This PR adds infrastructure to filter command events to get alternate command history:
- New `event_filter` kwarg in `get_cmds`, `get_states`, `get_continuity`, `get_observations`, 
  `get_starcats`, `get_starcats_as_table` functions.
- `event_filter` is a function that takes a command events table (e.g. from the google sheet) and 
    returns a boolean mask that selects events to keep.
- Event filtering functions to facilitate the process, most notably `filter_scs107_events` that removes
   events normally associated with an SCS-107 run.

Adding this event filtering was not initially compatible with the caching mechanism for recent commands (within the last 30 days). Previously the cache key was just the `scenario`, but this did not account for changes to:
- `CXOTIME_NOW` current time mocking
- Change in lookback time (`conf.default_lookback`).

So the cache key was changed to include those along with the `event_filter`.

These changes ended up challenging my ability to keep straight the flow and dependencies in the core commands code, so I ended up improving the code:
- Make some dependencies explicit rather than implicit (e.g. dependence on CXOTIME_NOW).
- Renaming variables to be more clear (e.g. `get_default_stop` -> `get_cxotime_now`).
- Adding type annotations in places.
- Factoring out code where possible.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- Previously the `State` column in a local scenario command events file was being ignored. Now it behaves like the google sheet and (if that column is present), events are filtered accordingly. I.e. only `Predictive` and `Definitive` are allowed.
- Added `event_filter` kwarg to  `get_cmds`, `get_states`, `get_continuity`, `get_observations`, 
  `get_starcats`, `get_starcats_as_table` functions.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new unit tests)
```
(ska3) ➜  kadi git:(ignore-scs107s-arg) git rev-parse --short HEAD
fb97db3

(ska3) ➜  kadi git:(ignore-scs107s-arg) pytest                    
======================================================== test session starts ========================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: hypothesis-6.125.2, doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 185 items                                                                                                                 

kadi/commands/tests/test_commands.py ..................................................................................       [ 44%]
kadi/commands/tests/test_filter_events.py ..                                                                                  [ 45%]
kadi/commands/tests/test_states.py .......................x..........................                                         [ 72%]
kadi/commands/tests/test_validate.py ...................                                                                      [ 82%]
kadi/tests/test_events.py ..........                                                                                          [ 88%]
kadi/tests/test_occweb.py ......................                                                                              [100%]

============================================= 184 passed, 1 xfailed in 94.34s (0:01:34) =============================================
```

Independent check of unit tests by Jean
- [x] Linux 
```
ska3-jeanconn-fido> git rev-parse HEAD
2bce4cfd3b80fe775ba5bacd6573c1d54ddbfc6f
ska3-jeanconn-fido> pytest
==================================================== test session starts ====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 185 items                                                                                                         

kadi/commands/tests/test_commands.py ................................................................................ [ 43%]
..                                                                                                                    [ 44%]
kadi/commands/tests/test_filter_events.py ..                                                                          [ 45%]
kadi/commands/tests/test_states.py .......................x..........................                                 [ 72%]
kadi/commands/tests/test_validate.py ...................                                                              [ 82%]
kadi/tests/test_events.py ..........                                                                                  [ 88%]
kadi/tests/test_occweb.py ......................                                                                      [100%]

===================================================== warnings summary ======================================================
kadi/kadi/commands/tests/test_commands.py: 88 warnings
kadi/kadi/commands/tests/test_filter_events.py: 26 warnings
kadi/kadi/commands/tests/test_states.py: 7 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================= 184 passed, 1 xfailed, 149 warnings in 222.18s (0:03:42
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
