### PR TITLE
Fix issue setting the lookback default after it gets used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.0
+  rev: v0.11.4
   hooks:
     # Run the linter.
     - id: ruff

--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1138,6 +1138,9 @@ def get_cmd_events_from_local(scenario=None):
 
 def update_loads(scenario=None, *, lookback=None, stop_loads=None) -> Table:
     """Update local copy of approved command loads though ``lookback`` days."""
+    if lookback is None:
+        lookback = conf.default_lookback
+
     dt = 21 * u.day
     cxotime_now = get_cxotime_now()
     # This is either the true current time or else the mock time from CXOTIME_NOW.
@@ -1147,9 +1150,6 @@ def update_loads(scenario=None, *, lookback=None, stop_loads=None) -> Table:
     # stop is the current time).
     if stop_loads is None and cxotime_now is None:
         stop += dt
-
-    if lookback is None:
-        lookback = conf.default_lookback
 
     # Ensure the scenario directory exists
     paths.SCENARIO_DIR(scenario).mkdir(parents=True, exist_ok=True)

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -2222,7 +2222,7 @@ def get_states(
 
     # List of dict to hold state values.  Datestarts is the corresponding list of
     # start dates for each state.
-    states = [StateDict({key: None for key in state_keys})]
+    states = [StateDict({key: None for key in state_keys})]  # noqa: C420
     datestarts = [start]
 
     # Apply initial ``continuity`` values.  Clear the trans_keys set after setting

--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -246,7 +246,6 @@ def test_commands_create_archive_regress(
             os.environ["KADI"] = str(tmpdir)
             update_cmds_v2.main(
                 (
-                    "--lookback=30",
                     f"--stop={stop.date}",
                     f"--data-root={tmpdir}",
                 )


### PR DESCRIPTION
## Description

PR #351 introduced a problem in kadi commands update processing where the lookback value (None by default) was being used in a computation prior to being set to the `conf.default_lookback` value. This was temporarily fixed in production by adding the `--lookback=30` flag to the script command.

This PR does two things:
- Move the `lookback` update to the top of the function before it gets used.
- Change the test of the command archive update process to not supply the `--lookback` argument. This matches the way the script is called in production.

This PR also includes an unrelated fix for ruff 11.0. There are no code changes so I did not re-run unit tests.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

With only the 1st commit, the `test_commands_create_archive_regress` test fails with the same exception seen in production processing.

With both commits:
```
(ska3) ➜  kadi git:(fix-lookback-default) git rev-parse --short HEAD    
636f61e
(ska3) ➜  kadi git:(fix-lookback-default) pytest
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 185 items                                                                                                                                                

kadi/commands/tests/test_commands.py ..................................................................................                                      [ 44%]
kadi/commands/tests/test_filter_events.py ..                                                                                                                 [ 45%]
kadi/commands/tests/test_states.py .......................x..........................                                                                        [ 72%]
kadi/commands/tests/test_validate.py ...................                                                                                                     [ 82%]
kadi/tests/test_events.py ..........                                                                                                                         [ 88%]
kadi/tests/test_occweb.py ......................                                                                                                             [100%]

============================================================ 184 passed, 1 xfailed in 92.99s (0:01:32) =============================================================
```

Independent check of unit tests by Javier (also ran test after reverting 76c85518ebab1dfeb3a1ae4f16d0d86184ae5e37 to make sure the test would have caught the issue).
- [x] [OSX]:
```
(ska3-flight) ~/SAO/git/kadi fix-lookback-default $ git rev-parse --short HEAD    
c651a42
(ska3-flight) ~/SAO/git/kadi fix-lookback-default $ pytest kadi   
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git/kadi
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 185 items                                                                                                                           

kadi/commands/tests/test_commands.py ..................................................................................                 [ 44%]
kadi/commands/tests/test_filter_events.py ..                                                                                            [ 45%]
kadi/commands/tests/test_states.py .......................x..........................                                                   [ 72%]
kadi/commands/tests/test_validate.py ...................                                                                                [ 82%]
kadi/tests/test_events.py ..........                                                                                                    [ 88%]
kadi/tests/test_occweb.py ......................                                                                                        [100%]

================================================== 184 passed, 1 xfailed in 79.25s (0:01:19) ==================================================
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
