### PR TITLE
Parse major events html from 23-Apr-2025

### DIFF
--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -124,7 +124,7 @@ def get_fot_major_events():
 
     for i, row_vals in enumerate(rows[1:]):
         # If the row_vals[0] doesn't look like a date, skip the row
-        if not re.match(r"^\d{4}\:\d{3}", row_vals[0]):
+        if not re.match(r"^\d{4}:\d{3}", row_vals[0]):
             continue
         start = DateTime(row_vals[0])
         caldate = start.caldate

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -114,7 +114,10 @@ def get_fot_major_events():
 
     html = occweb.get_url(page)
     soup = parse_html(html, "lxml")
-    table = soup.find("table", attrs={"class": "MsoNormalTable"})
+    major_events_span = soup.find("span", string="Major Events:")
+    if major_events_span is None:
+        raise ValueError("No 'Major Events:' span found on page")
+    table = major_events_span.find_next("table", attrs={"class": "MsoNormalTable"})
     rows = get_table_rows(table)
     evts = []
 

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -10,6 +10,7 @@ REPLACES = (
     (r"&#150", "-"),
     (r"&amp;", "&"),
     (r"&nbsp;", " "),
+    (r"&#160;", " "),
     (r"&quot;", '"'),
     (r"&gt;", ">"),
     (r"&lt;", "<"),
@@ -122,6 +123,9 @@ def get_fot_major_events():
     evts = []
 
     for i, row_vals in enumerate(rows[1:]):
+        # If the row_vals[0] doesn't look like a date, skip the row
+        if not re.match(r"^\d{4}\:\d{3}", row_vals[0]):
+            continue
         start = DateTime(row_vals[0])
         caldate = start.caldate
         evt = dict(

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import re
 import uuid
 from pathlib import Path
 
@@ -90,7 +91,7 @@ def test_get_fdb_major_events():
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 def test_get_fot_major_events():
     page = occweb.get_url("fot_major_events")
-    assert "ACA Dark Current Calibration" in page
+    assert re.search("ACA\W*Dark\W*Current\W*Calibration", page, re.DOTALL) is not None
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")

--- a/kadi/tests/test_occweb.py
+++ b/kadi/tests/test_occweb.py
@@ -91,7 +91,7 @@ def test_get_fdb_major_events():
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
 def test_get_fot_major_events():
     page = occweb.get_url("fot_major_events")
-    assert re.search("ACA\W*Dark\W*Current\W*Calibration", page, re.DOTALL) is not None
+    assert re.search(r"ACA\W*Dark\W*Current\W*Calibration", page, re.DOTALL) is not None
 
 
 @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")


### PR DESCRIPTION
## Description

Parse major events html from 23-Apr-2025.

I'm not sure what changes were introduced last week, but today it looks like the parser was reading a containing layout table instead of the major events table, and then also failing on the last row (which is empty).  This PR uses the "Major Events:" span label to find the major event html table and skips rows that don't have YYYY:DOY values in the first column.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Parser in master is doing this today:
```
In [1]: import kadi.events.scrape

In [2]: evts = kadi.events.scrape.get_fot_major_events()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/chandra_time/Time.py:644, in convert(time_in, sys_in, fmt_in, sys_out, fmt_out)
    643 if str(time_in) == time_in:
--> 644     raise TypeError
    645 return [_convert(x, sys_in, fmt_in, sys_out, fmt_out) for x in time_in]

TypeError: 

During handling of the above exception, another exception occurred:

ChandraTimeError                          Traceback (most recent call last)
Cell In[2], line 1
----> 1 evts = kadi.events.scrape.get_fot_major_events()

File ~/git/kadi/kadi/events/scrape.py:123, in get_fot_major_events()
    121 for i, row_vals in enumerate(rows[1:]):
    122     start = DateTime(row_vals[0])
--> 123     caldate = start.caldate
    124     evt = dict(
    125         start=start.date[:8],
    126         date="{}-{}-{}".format(caldate[:4], caldate[4:7], caldate[7:9]),
   (...)
    130         source="FOT",
    131     )
    132     evts.append(evt)

File ~/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/chandra_time/Time.py:814, in DateTime.__getattr__(self, fmt_out)
    811 if fmt_out.startswith('_'):
    812     return self.__getattribute__(fmt_out)
--> 814 return convert(self.time_in,
    815                fmt_in=self.format,
    816                fmt_out=fmt_out,
    817                )

File ~/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/chandra_time/Time.py:647, in convert(time_in, sys_in, fmt_in, sys_out, fmt_out)
    645     return [_convert(x, sys_in, fmt_in, sys_out, fmt_out) for x in time_in]
    646 except TypeError:
--> 647     return _convert(time_in, sys_in, fmt_in, sys_out, fmt_out)

File ~/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/chandra_time/Time.py:674, in _convert(time_in, sys_in, fmt_in, sys_out, fmt_out)
    672         break
    673 else:
--> 674     raise ChandraTimeError("Invalid input format '%s'" % fmt_in)
    676 if sys_in:
    677     if sys_in in time_system:

ChandraTimeError: Invalid input format 'None'
```
Additionally, a unit test was failing as it looks like the strint ACA Dark Current calibration wraps and is now ""ACA Dark Current\r\n    Calibration":
```
__________________________________________________________________ test_get_fot_major_events __________________________________________________________________

    @pytest.mark.skipif(not HAS_OCCWEB, reason="No access to OCCweb")
    def test_get_fot_major_events():
        page = occweb.get_url("fot_major_events")
>       assert "ACA Dark Current Calibration" in page
E       assert 'ACA Dark Current Calibration' in '<html xmlns:v="urn:schemas-microsoft-com:vml"\r\nxmlns:o="urn:schemas-microsoft-com:office:office"\r\nxmlns:w="urn:sc...\r\n </tr>\r\n</table>\r\n\r\n<p class=MsoNormal><o:p>&nbsp;</o:p></p>\r\n\r\n</div>\r\n\r\n</body>\r\n\r\n</html>\r\n'

kadi/tests/test_occweb.py:93: AssertionError
```


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-latest) jeanconn-fido> pytest -v
=================================================================== test session starts ====================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0 -- /fido.real/miniforge3/envs/ska3-latest/bin/python3.12
cachedir: .pytest_cache
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 185 items                                                                                                                                        

kadi/commands/tests/test_commands.py::test_find PASSED                                                                                               [  0%]
kadi/commands/tests/test_commands.py::test_get_cmds PASSED                                                                                           [  1%]
kadi/commands/tests/test_commands.py::test_get_cmds_zero_length_result PASSED                                                                        [  1%]
kadi/commands/tests/test_commands.py::test_get_cmds_inclusive_stop PASSED                                                                            [  2%]
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict PASSED                                                                               [  2%]
kadi/commands/tests/test_commands.py::test_cmds_as_list_of_dict_ska_parsecm PASSED                                                                   [  3%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_backstop_and_add_cmds PASSED                                                                [  3%]
kadi/commands/tests/test_commands.py::test_commands_create_archive_regress PASSED                                                                    [  4%]
kadi/commands/tests/test_commands.py::test_nsm_safe_mode_pitch_offsets_state_constraints PASSED                                                      [  4%]
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_only PASSED                                                                              [  5%]
kadi/commands/tests/test_commands.py::test_get_cmds_v2_arch_recent PASSED                                                                            [  5%]
kadi/commands/tests/test_commands.py::test_get_cmds_v2_recent_only PASSED                                                                            [  6%]
kadi/commands/tests/test_commands.py::test_get_cmds_nsm_2021 PASSED                                                                                  [  7%]
kadi/commands/tests/test_commands.py::test_cmds_scenario PASSED                                                                                      [  7%]
kadi/commands/tests/test_commands.py::test_nsm_offset_pitch_rasl_command_events PASSED                                                               [  8%]
kadi/commands/tests/test_commands.py::test_command_set_bsh PASSED                                                                                    [  8%]
kadi/commands/tests/test_commands.py::test_command_set_safe_mode PASSED                                                                              [  9%]
kadi/commands/tests/test_commands.py::test_bright_star_hold_event PASSED                                                                             [  9%]
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_single PASSED                                                                   [ 10%]
kadi/commands/tests/test_commands.py::test_get_observations_by_obsid_multi PASSED                                                                    [ 10%]
kadi/commands/tests/test_commands.py::test_get_observations_by_start_date PASSED                                                                     [ 11%]
kadi/commands/tests/test_commands.py::test_get_observations_by_start_stop_date_with_scenario PASSED                                                  [ 11%]
kadi/commands/tests/test_commands.py::test_get_observations_no_match PASSED                                                                          [ 12%]
kadi/commands/tests/test_commands.py::test_get_observations_start_stop_inclusion PASSED                                                              [ 12%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year0] PASSED                                                                      [ 13%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year1] PASSED                                                                      [ 14%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year2] PASSED                                                                      [ 14%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year3] PASSED                                                                      [ 15%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year4] PASSED                                                                      [ 15%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year5] PASSED                                                                      [ 16%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year6] PASSED                                                                      [ 16%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year7] PASSED                                                                      [ 17%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year8] PASSED                                                                      [ 17%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year9] PASSED                                                                      [ 18%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year10] PASSED                                                                     [ 18%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year11] PASSED                                                                     [ 19%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year12] PASSED                                                                     [ 20%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year13] PASSED                                                                     [ 20%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year14] PASSED                                                                     [ 21%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year15] PASSED                                                                     [ 21%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year16] PASSED                                                                     [ 22%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year17] PASSED                                                                     [ 22%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year18] PASSED                                                                     [ 23%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year19] PASSED                                                                     [ 23%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year20] PASSED                                                                     [ 24%]
kadi/commands/tests/test_commands.py::test_get_starcats_each_year[year21] PASSED                                                                     [ 24%]
kadi/commands/tests/test_commands.py::test_get_starcat_only_agasc1p7 PASSED                                                                          [ 25%]
kadi/commands/tests/test_commands.py::test_get_starcat_only_agasc1p8 PASSED                                                                          [ 25%]
kadi/commands/tests/test_commands.py::test_get_starcats_with_cmds PASSED                                                                             [ 26%]
kadi/commands/tests/test_commands.py::test_get_starcats_obsid PASSED                                                                                 [ 27%]
kadi/commands/tests/test_commands.py::test_get_starcats_date PASSED                                                                                  [ 27%]
kadi/commands/tests/test_commands.py::test_get_starcats_by_date PASSED                                                                               [ 28%]
kadi/commands/tests/test_commands.py::test_get_starcats_as_table PASSED                                                                              [ 28%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID= aa0000000, par1 = 1 ,   par2=-1.0] PASSED                      [ 29%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[AcisPKT|TLmSID=AA0000000 ,par1=1, par2=-1.0] PASSED                              [ 29%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_case[ACISPKT|  TLmSID = aa0000000 , par1  =1,    par2 =  -1.0] PASSED                 [ 30%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[0] PASSED                                                                         [ 30%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[1] PASSED                                                                         [ 31%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[2] PASSED                                                                         [ 31%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[3] PASSED                                                                         [ 32%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[4] PASSED                                                                         [ 32%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[5] PASSED                                                                         [ 33%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[6] PASSED                                                                         [ 34%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[7] PASSED                                                                         [ 34%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[8] PASSED                                                                         [ 35%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[9] PASSED                                                                         [ 35%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[10] PASSED                                                                        [ 36%]
kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[11] PASSED                                                                        [ 36%]
kadi/commands/tests/test_commands.py::test_scenario_with_rts PASSED                                                                                  [ 37%]
kadi/commands/tests/test_commands.py::test_no_rltt_for_not_run_load PASSED                                                                           [ 37%]
kadi/commands/tests/test_commands.py::test_30_day_lookback_issue PASSED                                                                              [ 38%]
kadi/commands/tests/test_commands.py::test_fill_gaps PASSED                                                                                          [ 38%]
kadi/commands/tests/test_commands.py::test_get_rltt_scheduled_stop_time PASSED                                                                       [ 39%]
kadi/commands/tests/test_commands.py::test_hrc_not_run_scenario PASSED                                                                               [ 40%]
kadi/commands/tests/test_commands.py::test_command_not_run[case0] PASSED                                                                             [ 40%]
kadi/commands/tests/test_commands.py::test_command_not_run[case1] PASSED                                                                             [ 41%]
kadi/commands/tests/test_commands.py::test_command_not_run[case2] PASSED                                                                             [ 41%]
kadi/commands/tests/test_commands.py::test_command_not_run[case3] PASSED                                                                             [ 42%]
kadi/commands/tests/test_commands.py::test_command_not_run[case4] PASSED                                                                             [ 42%]
kadi/commands/tests/test_commands.py::test_command_not_run[case5] PASSED                                                                             [ 43%]
kadi/commands/tests/test_commands.py::test_add_cmds PASSED                                                                                           [ 43%]
kadi/commands/tests/test_commands.py::test_read_backstop_with_observations PASSED                                                                    [ 44%]
kadi/commands/tests/test_filter_events.py::test_filter_scs107_events[case0] PASSED                                                                   [ 44%]
kadi/commands/tests/test_filter_events.py::test_filter_scs107_events[case1] PASSED                                                                   [ 45%]
kadi/commands/tests/test_states.py::test_acis_vidboard PASSED                                                                                        [ 45%]
kadi/commands/tests/test_states.py::test_acis_simode PASSED                                                                                          [ 46%]
kadi/commands/tests/test_states.py::test_cmd_line_interface PASSED                                                                                   [ 47%]
kadi/commands/tests/test_states.py::test_quick PASSED                                                                                                [ 47%]
kadi/commands/tests/test_states.py::test_states_2017 PASSED                                                                                          [ 48%]
kadi/commands/tests/test_states.py::test_pitch_2017 PASSED                                                                                           [ 48%]
kadi/commands/tests/test_states.py::test_sun_vec_versus_telemetry PASSED                                                                             [ 49%]
kadi/commands/tests/test_states.py::test_dither PASSED                                                                                               [ 49%]
kadi/commands/tests/test_states.py::test_fids_state PASSED                                                                                           [ 50%]
kadi/commands/tests/test_states.py::test_get_continuity_regress PASSED                                                                               [ 50%]
kadi/commands/tests/test_states.py::test_get_continuity_vs_states PASSED                                                                             [ 51%]
kadi/commands/tests/test_states.py::test_get_states_with_cmds_and_start_stop PASSED                                                                  [ 51%]
kadi/commands/tests/test_states.py::test_get_continuity_keys PASSED                                                                                  [ 52%]
kadi/commands/tests/test_states.py::test_get_continuity_fail PASSED                                                                                  [ 52%]
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[True] PASSED                                                                  [ 53%]
kadi/commands/tests/test_states.py::test_reduce_states_merge_identical[False] PASSED                                                                 [ 54%]
kadi/commands/tests/test_states.py::test_reduce_states_cmd_states PASSED                                                                             [ 54%]
kadi/commands/tests/test_states.py::test_backstop_format PASSED                                                                                      [ 55%]
kadi/commands/tests/test_states.py::test_backstop_subformat PASSED                                                                                   [ 55%]
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon PASSED                                                                                 [ 56%]
kadi/commands/tests/test_states.py::test_backstop_sun_pos_mon_lunar PASSED                                                                           [ 56%]
kadi/commands/tests/test_states.py::test_backstop_ephem_update PASSED                                                                                [ 57%]
kadi/commands/tests/test_states.py::test_backstop_radmon_no_scs107 PASSED                                                                            [ 57%]
kadi/commands/tests/test_states.py::test_backstop_radmon_with_scs107 XFAIL                                                                           [ 58%]
kadi/commands/tests/test_states.py::test_backstop_scs98 PASSED                                                                                       [ 58%]
kadi/commands/tests/test_states.py::test_backstop_scs84 PASSED                                                                                       [ 59%]
kadi/commands/tests/test_states.py::test_backstop_simpos PASSED                                                                                      [ 60%]
kadi/commands/tests/test_states.py::test_backstop_simfa_pos PASSED                                                                                   [ 60%]
kadi/commands/tests/test_states.py::test_backstop_grating PASSED                                                                                     [ 61%]
kadi/commands/tests/test_states.py::test_backstop_eclipse_entry PASSED                                                                               [ 61%]
kadi/commands/tests/test_states.py::test_regress_eclipse PASSED                                                                                      [ 62%]
kadi/commands/tests/test_states.py::test_continuity_just_after_command PASSED                                                                        [ 62%]
kadi/commands/tests/test_states.py::test_continuity_far_future PASSED                                                                                [ 63%]
kadi/commands/tests/test_states.py::test_acis_power_cmds PASSED                                                                                      [ 63%]
kadi/commands/tests/test_states.py::test_continuity_with_transitions_SPM PASSED                                                                      [ 64%]
kadi/commands/tests/test_states.py::test_continuity_with_no_transitions_SPM PASSED                                                                   [ 64%]
kadi/commands/tests/test_states.py::test_get_pitch_from_mid_maneuver PASSED                                                                          [ 65%]
kadi/commands/tests/test_states.py::test_get_states_start_between_aouptarg_aomanuvr_cmds PASSED                                                      [ 65%]
kadi/commands/tests/test_states.py::test_get_continuity_and_pitch_from_mid_maneuver PASSED                                                           [ 66%]
kadi/commands/tests/test_states.py::test_acisfp_setpoint_state PASSED                                                                                [ 67%]
kadi/commands/tests/test_states.py::test_grating_motion_states PASSED                                                                                [ 67%]
kadi/commands/tests/test_states.py::test_hrc_states PASSED                                                                                           [ 68%]
kadi/commands/tests/test_states.py::test_hrc_states_with_scs_commanding PASSED                                                                       [ 68%]
kadi/commands/tests/test_states.py::test_early_start_exception PASSED                                                                                [ 69%]
kadi/commands/tests/test_states.py::test_nsm_continuity PASSED                                                                                       [ 69%]
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse PASSED                                                                           [ 70%]
kadi/commands/tests/test_states.py::test_sun_pos_mon_within_eclipse_no_spm_enab PASSED                                                               [ 70%]
kadi/commands/tests/test_states.py::test_get_continuity_acis_cmd_requires_obsid PASSED                                                               [ 71%]
kadi/commands/tests/test_states.py::test_get_continuity_spm_eclipse PASSED                                                                           [ 71%]
kadi/commands/tests/test_states.py::test_interpolate_states_extrapolate PASSED                                                                       [ 72%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePitch] PASSED                                                           [ 72%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateRoll] PASSED                                                            [ 73%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateDither] PASSED                                                          [ 74%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidatePcadMode] PASSED                                                        [ 74%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSimpos] PASSED                                                          [ 75%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateObsid] PASSED                                                           [ 75%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateLETG] PASSED                                                            [ 76%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateHETG] PASSED                                                            [ 76%]
kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateSunPosMon] PASSED                                                       [ 77%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePitch] PASSED                                                            [ 77%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateRoll] PASSED                                                             [ 78%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateDither] PASSED                                                           [ 78%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidatePcadMode] PASSED                                                         [ 79%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSimpos] PASSED                                                           [ 80%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateObsid] PASSED                                                            [ 80%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateLETG] PASSED                                                             [ 81%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateHETG] PASSED                                                             [ 81%]
kadi/commands/tests/test_validate.py::test_validate_regression[True-ValidateSunPosMon] PASSED                                                        [ 82%]
kadi/commands/tests/test_validate.py::test_off_nominal_roll_violations PASSED                                                                        [ 82%]
kadi/tests/test_events.py::test_xdg_config_home_env_var PASSED                                                                                       [ 83%]
kadi/tests/test_events.py::test_overlapping_intervals PASSED                                                                                         [ 83%]
kadi/tests/test_events.py::test_interval_pads PASSED                                                                                                 [ 84%]
kadi/tests/test_events.py::test_query_event_intervals PASSED                                                                                         [ 84%]
kadi/tests/test_events.py::test_basic_query PASSED                                                                                                   [ 85%]
kadi/tests/test_events.py::test_short_query PASSED                                                                                                   [ 85%]
kadi/tests/test_events.py::test_get_obsid PASSED                                                                                                     [ 86%]
kadi/tests/test_events.py::test_intervals_filter PASSED                                                                                              [ 87%]
kadi/tests/test_events.py::test_get_overlaps PASSED                                                                                                  [ 87%]
kadi/tests/test_events.py::test_select_overlapping PASSED                                                                                            [ 88%]
kadi/tests/test_occweb.py::test_put_get_user_none PASSED                                                                                             [ 88%]
kadi/tests/test_occweb.py::test_ifot_fetch PASSED                                                                                                    [ 89%]
kadi/tests/test_occweb.py::test_get_fdb_major_events PASSED                                                                                          [ 89%]
kadi/tests/test_occweb.py::test_get_fot_major_events PASSED                                                                                          [ 90%]
kadi/tests/test_occweb.py::test_get_occweb_dir[False-str] PASSED                                                                                     [ 90%]
kadi/tests/test_occweb.py::test_get_occweb_dir[False-Path] PASSED                                                                                    [ 91%]
kadi/tests/test_occweb.py::test_get_occweb_dir[update-str] PASSED                                                                                    [ 91%]
kadi/tests/test_occweb.py::test_get_occweb_dir[update-Path] PASSED                                                                                   [ 92%]
kadi/tests/test_occweb.py::test_get_occweb_dir[True-str] PASSED                                                                                      [ 92%]
kadi/tests/test_occweb.py::test_get_occweb_dir[True-Path] PASSED                                                                                     [ 93%]
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-False] PASSED                                                                                 [ 94%]
kadi/tests/test_occweb.py::test_get_occweb_noodle[True-True] PASSED                                                                                  [ 94%]
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-False] PASSED                                                                                [ 95%]
kadi/tests/test_occweb.py::test_get_occweb_noodle[False-True] PASSED                                                                                 [ 95%]
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[FOT] PASSED                                                                                    [ 96%]
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[GRETA/mission/Backstop] PASSED                                                                 [ 96%]
kadi/tests/test_occweb.py::test_all_get_occweb_noodle[vweb] PASSED                                                                                   [ 97%]
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[False] PASSED                                                                                    [ 97%]
kadi/tests/test_occweb.py::test_get_occweb_dir_fail[True] PASSED                                                                                     [ 98%]
kadi/tests/test_occweb.py::test_get_occweb_page_binary[False] PASSED                                                                                 [ 98%]
kadi/tests/test_occweb.py::test_get_occweb_page_binary[update] PASSED                                                                                [ 99%]
kadi/tests/test_occweb.py::test_get_occweb_page_binary[True] PASSED                                                                                  [100%]

===================================================================== warnings summary =====================================================================
kadi/kadi/commands/tests/test_commands.py: 87 warnings
kadi/kadi/commands/tests/test_filter_events.py: 25 warnings
kadi/kadi/commands/tests/test_states.py: 6 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /fido.real/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 184 passed, 1 xfailed, 146 warnings in 218.62s (0:03:38) =================================================
(ska3-latest) jeanconn-fido> git rev-parse HEAD
5f4daaea89dcee70a2aef03baa957156627e06fe
```


Independent check of unit tests by Tom
- [x] osx - test_occweb run according to comment

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New parser gives this output
```
In [2]: import kadi.events.scrape

In [3]: evts = kadi.events.scrape.get_fot_major_events()

In [4]: evts[-1]
Out[4]: 
{'start': '2025:115',
 'date': '2025-Apr-25',
 'tstart': 861927220.184,
 'descr': 'IRU calibration and default gyro bias updates patch uplink',
 'note': 'PR-629 uplinked successfully.',
 'source': 'FOT'}
```
