### PR TITLE
Add ACIS DPA power state and refactor validation using that state

### DIFF
--- a/docs/commands_states/index.rst
+++ b/docs/commands_states/index.rst
@@ -654,6 +654,9 @@ classes which affect the keys.
 ``dither_phase_pitch``, ``dither_phase_yaw``, ``dither_ampl_pitch``, ``dither_ampl_yaw``, ``dither_period_pitch``, ``dither_period_yaw``
   - :class:`~kadi.commands.states.DitherParamsTransition`
 
+``dpa_power``
+  - :class:`~kadi.commands.states.ACISDpaPowerState`
+
 ``eclipse``
   - :class:`~kadi.commands.states.EclipsePenumbraEntryTransition`
   - :class:`~kadi.commands.states.EclipsePenumbraExitTransition`


### PR DESCRIPTION
## Description

With #350, it is straightforward to add a DPA power computed state (`dpa_power`) by moving the calculation defined in #357 into a computed state. After that, the validation class becomes trivial since it depends only on an MSID and a single state value.

## Requires
- #350 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds `dpa_power` commanded state.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(dpa-power-state) git rev-parse --short HEAD                              
3d8e363
(ska3) ➜  kadi git:(dpa-power-state) pytest
================================================== test session starts ==================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 210 items                                                                                                     

kadi/commands/tests/test_commands.py ............................................................................ [ 36%]
......                                                                                                            [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                      [ 40%]
kadi/commands/tests/test_states.py .............................................x..........................       [ 74%]
kadi/commands/tests/test_validate.py ......................                                                       [ 84%]
kadi/tests/test_events.py ..........                                                                              [ 89%]
kadi/tests/test_occweb.py ......................                                                                  [100%]

====================================== 209 passed, 1 xfailed in 182.34s (0:03:02) =======================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This gives the expected result.
```
python -m kadi.scripts.validate_states --state dpa_power
```