### PR TITLE
Add ecsv regress files to installed test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     package_data={
         "kadi.commands": ["templates/*.html", "data/*.joblib"],
-        "kadi.commands.tests": ["data/*.gz", "data/*.yaml"],
+        "kadi.commands.tests": ["data/*.yaml", "data/regression/*.ecsv"],
     },
     tests_require=["pytest"],
     data_files=data_files,


### PR DESCRIPTION
## Description

Add ecsv regress files to installed test data


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:kadi jean$ pytest
=============================================== test session starts ================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 214 items                                                                                                

kadi/commands/tests/test_commands.py ....................................................................... [ 33%]
.............                                                                                                [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                 [ 40%]
kadi/commands/tests/test_states.py ...............................................x......................... [ 74%]
.                                                                                                            [ 74%]
kadi/commands/tests/test_validate.py ......................                                                  [ 85%]
kadi/tests/test_events.py ..........                                                                         [ 89%]
kadi/tests/test_occweb.py ......................                                                             [100%]

================================================= warnings summary =================================================
kadi/kadi/commands/tests/test_commands.py: 93 warnings
kadi/kadi/commands/tests/test_filter_events.py: 27 warnings
kadi/kadi/commands/tests/test_states.py: 25 warnings
kadi/kadi/commands/tests/test_validate.py: 17 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= 213 passed, 1 xfailed, 183 warnings in 123.32s (0:02:03)
(ska3-latest) flame:kadi jean$ git rev-parse HEAD
710f4e47df6c87a4ce46f4219272356383077645
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Confirmed missing regression files in conda env:
```
(ska3-latest) flame:kadi jean$ conda list kadi
# packages in environment at /Users/jean/miniforge3/envs/ska3-latest:
#
# Name                    Version                   Build  Channel
kadi                      7.17.0                  py312_0    https://icxc.cfa.harvard.edu/aspect/ska3-conda/test
(ska3-latest) flame:kadi jean$ ls /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/kadi/commands/tests/data/regression
```
Pip installed this PR 
```
(ska3-latest) flame:kadi jean$ ls /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/kadi/commands/tests/data/regression
acisfp_setpoint-2024360-2025030.ecsv
aoephem1-aoephem2-aoratio-aoargper-aoeccent-ao1minus-ao1plus-aomotion-aoiterat-aoorbang-aoperige-aoascend-aosini-aoslr-aosqrtmu-2024360-2025030.ecsv
clocking-power_cmd-vid_board-fep_count-si_mode-ccd_count-obsid-2024360-2025030.ecsv
dither-2024360-2025030.ecsv
dither_phase_pitch-dither_phase_yaw-dither_ampl_pitch-dither_ampl_yaw-dither_period_pitch-dither_period_yaw-2024360-2025030.ecsv
eclipse-2024360-2025030.ecsv
eclipse_timer-2024360-2025030.ecsv
ephem_update-2024360-2025030.ecsv
fids-2024360-2025030.ecsv
format-2024360-2025030.ecsv
hrc_15v-2024360-2025030.ecsv
hrc_24v-2024360-2025030.ecsv
hrc_i-2024360-2025030.ecsv
hrc_s-2024360-2025030.ecsv
letg-hetg-grating-2024360-2025030.ecsv
obsid-2024360-2025030.ecsv
orbit_point-2024360-2025030.ecsv
pitch-rasl-off_nom_roll-sun_ra-sun_dec-2023030-2023060.ecsv
q1-q2-q3-q4-targ_q1-targ_q2-targ_q3-targ_q4-auto_npnt-pcad_mode-sun_vector_update-2023030-2023060.ecsv
ra-dec-roll-2023030-2023060.ecsv
radmon-2024360-2025030.ecsv
scs84-2024360-2025030.ecsv
scs98-2024360-2025030.ecsv
simfa_pos-2024360-2025030.ecsv
simpos-2024360-2025030.ecsv
subformat-2024360-2025030.ecsv
sun_pos_mon-battery_connect-eclipse_enable_spm-2024360-2025030.ecsv
```
And confirmed "installed" test changed from 
```
kadi/commands/tests/test_states.py::test_regression[filename0] SKIPPED (got empty parameter set ['filena...) [  2%]
```
to 
```
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/dither-2024360-2025030.ecsv] PASSED [  1%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/scs84-2024360-2025030.ecsv] PASSED [  2%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/pitch-rasl-off_nom_roll-sun_ra-sun_dec-2023030-2023060.ecsv] PASSED [  4%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_i-2024360-2025030.ecsv] PASSED [  5%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/fids-2024360-2025030.ecsv] PASSED [  6%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/orbit_point-2024360-2025030.ecsv] PASSED [  8%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/radmon-2024360-2025030.ecsv] PASSED [  9%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/ephem_update-2024360-2025030.ecsv] PASSED [ 10%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/sun_pos_mon-battery_connect-eclipse_enable_spm-2024360-2025030.ecsv] PASSED [ 12%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/acisfp_setpoint-2024360-2025030.ecsv] PASSED [ 13%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/simpos-2024360-2025030.ecsv] PASSED [ 14%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_24v-2024360-2025030.ecsv] PASSED [ 16%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_s-2024360-2025030.ecsv] PASSED [ 17%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/scs98-2024360-2025030.ecsv] PASSED [ 18%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/ra-dec-roll-2023030-2023060.ecsv] PASSED [ 20%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/subformat-2024360-2025030.ecsv] PASSED [ 21%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/format-2024360-2025030.ecsv] PASSED [ 22%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/letg-hetg-grating-2024360-2025030.ecsv] PASSED [ 24%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/q1-q2-q3-q4-targ_q1-targ_q2-targ_q3-targ_q4-auto_npnt-pcad_mode-sun_vector_update-2023030-2023060.ecsv] PASSED [ 25%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/clocking-power_cmd-vid_board-fep_count-si_mode-ccd_count-obsid-2024360-2025030.ecsv] PASSED [ 27%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_15v-2024360-2025030.ecsv] PASSED [ 28%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/eclipse_timer-2024360-2025030.ecsv] PASSED [ 29%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/dither_phase_pitch-dither_phase_yaw-dither_ampl_pitch-dither_ampl_yaw-dither_period_pitch-dither_period_yaw-2024360-2025030.ecsv] PASSED [ 31%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/eclipse-2024360-2025030.ecsv] PASSED                   [ 32%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/simfa_pos-2024360-2025030.ecsv] PASSED                    [ 33%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/obsid-2024360-2025030.ecsv] PASSED                               [ 35%]
kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/aoephem1-aoephem2-aoratio-aoargper-aoeccent-ao1minus-ao1plus-aomotion-aoiterat-aoorbang-aoperige-aoascend-aosini-aoslr-aosqrtmu-2024360-2025030.ecsv] PASSED [ 36%]
```

