### PR TITLE
Update to conditionally skip some tests that fail without internet

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1154,7 +1154,6 @@ cmd_events_all_text = """\
     Load not run,OCT2521A
     Command,"ACISPKT | TLMSID= AA00000000, CMDS= 3, WORDS= 3, PACKET(40)= D80000300030603001300"
     Command not run,"COMMAND_SW | TLMSID=4OHETGIN, HEX= 8050300, MSID= 4OHETGIN"
-    RTS,"RTSLOAD,1_4_CTI,NUM_HOURS=39:00:00,SCS_NUM=135"
     Obsid,65527
     Maneuver,0.70546907 0.32988307 0.53440901 0.32847766
     Safe mode,
@@ -1178,44 +1177,6 @@ cmd_events_all_exps = [
     ],
     [
         "2020:001:00:00:00.000 | NOT_RUN          | 4OHETGIN   | CMD_EVT  | event=Command_not_run, event_date=2020:001:00:00:00, hex=8050300, msid=4OHETGIN, __type__=COMMAND_SW, scs=0"
-    ],
-    [
-        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, msid=OORMPEN, scs=135",
-        "2020:001:00:00:01.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:001:00:00:02.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",
-        "2020:001:00:00:03.000 | COMMAND_HW       | 2S2HVON    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, msid=2S2HVON, scs=135",
-        "2020:001:00:00:13.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, 2s2sthv2=4 , msid=2S2STHV, scs=135",
-        "2020:001:00:00:23.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, 2s2sthv2=8 , msid=2S2STHV, scs=135",
-        "2020:001:00:00:24.000 | ACISPKT          | WSPOW08E1E | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:001:00:01:27.000 | ACISPKT          | WT00C62014 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:001:00:01:31.000 | ACISPKT          | XTZ0000005 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:001:00:01:35.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:001:00:01:39.000 | ACISPKT          | RH_0000001 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:002:15:01:39.000 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, msid=2S2HVOF, scs=135",
-        "2020:002:15:01:39.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, msid=OORMPDS, scs=135",
-        "2020:002:15:01:40.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",
-        "2020:002:17:40:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:002:17:40:10.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:002:17:40:14.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
-        "2020:002:17:40:18.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS,"
-        " event_date=2020:001:00:00:00, scs=135",
     ],
     [
         "2020:001:00:00:00.000 | MP_OBSID         | COAOSQID   | CMD_EVT  | event=Obsid, event_date=2020:001:00:00:00, id=65527, scs=0"
@@ -1365,6 +1326,67 @@ def test_get_cmds_from_event_all(idx, disable_hrc_scs107_commanding):
     """Test getting commands from every event type in the Command Events sheet"""
     cevt = cmd_events_all[idx]
     exp = cmd_events_all_exps[idx]
+    cmds = get_cmds_from_event("2020:001:00:00:00", cevt["Event"], cevt["Params"])
+    if cmds is not None:
+        cmds = cmds.pformat_like_backstop(max_params_width=None)
+    assert cmds == exp
+
+
+cmd_events_rts_text = """\
+    Event,Params
+    RTS,"RTSLOAD,1_4_CTI,NUM_HOURS=39:00:00,SCS_NUM=135"
+    """
+cmd_events_rts = Table.read(
+    cmd_events_rts_text, format="ascii.csv", fill_values=[], converters={"Params": str}
+)
+cmd_events_rts_exps = [
+    [
+        "2020:001:00:00:00.000 | COMMAND_SW       | OORMPEN    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, msid=OORMPEN, scs=135",
+        "2020:001:00:00:01.000 | ACISPKT          | WSVIDALLDN | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:001:00:00:02.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",
+        "2020:001:00:00:03.000 | COMMAND_HW       | 2S2HVON    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, msid=2S2HVON, scs=135",
+        "2020:001:00:00:13.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, 2s2sthv2=4 , msid=2S2STHV, scs=135",
+        "2020:001:00:00:23.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, 2s2sthv2=8 , msid=2S2STHV, scs=135",
+        "2020:001:00:00:24.000 | ACISPKT          | WSPOW08E1E | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:001:00:01:27.000 | ACISPKT          | WT00C62014 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:001:00:01:31.000 | ACISPKT          | XTZ0000005 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:001:00:01:35.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:001:00:01:39.000 | ACISPKT          | RH_0000001 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:002:15:01:39.000 | COMMAND_HW       | 2S2HVOF    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, msid=2S2HVOF, scs=135",
+        "2020:002:15:01:39.000 | COMMAND_SW       | OORMPDS    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, msid=OORMPDS, scs=135",
+        "2020:002:15:01:40.000 | COMMAND_HW       | 2S2STHV    | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, 2s2sthv2=0 , msid=2S2STHV, scs=135",
+        "2020:002:17:40:00.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:002:17:40:10.000 | ACISPKT          | AA00000000 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:002:17:40:14.000 | ACISPKT          | WSPOW00000 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+        "2020:002:17:40:18.000 | ACISPKT          | RS_0000001 | CMD_EVT  | event=RTS,"
+        " event_date=2020:001:00:00:00, scs=135",
+    ],
+]
+
+
+@pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
+@pytest.mark.parametrize("idx", range(len(cmd_events_rts_exps)))
+def test_get_cmds_from_event_rts(idx, disable_hrc_scs107_commanding):
+    """Test getting commands from every event type in the Command Events sheet"""
+    cevt = cmd_events_rts[idx]
+    exp = cmd_events_rts_exps[idx]
     cmds = get_cmds_from_event("2020:001:00:00:00", cevt["Event"], cevt["Params"])
     if cmds is not None:
         cmds = cmds.pformat_like_backstop(max_params_width=None)

--- a/kadi/commands/tests/test_states.py
+++ b/kadi/commands/tests/test_states.py
@@ -11,10 +11,13 @@ from astropy.table import Table
 from chandra_time import DateTime
 from cheta import fetch
 from cxotime import CxoTime, CxoTimeLike
+from testr.test_helper import has_internet
 
 from kadi import commands  # noqa: E402
 from kadi.commands import states  # noqa: E402
 from kadi.commands.tests.test_commands import get_cmds_from_cmd_evts_text
+
+HAS_INTERNET = has_internet()
 
 try:
     fetch.get_time_range("dp_pitch")
@@ -225,6 +228,7 @@ def get_regression_filenames():
         yield str(path.relative_to(Path.cwd()))
 
 
+@pytest.mark.skipif(not HAS_INTERNET, reason="Command sheet not available")
 @pytest.mark.parametrize("filename", list(get_regression_filenames()))
 def test_regression(filename, monkeypatch):
     """Test current code vs. regression data in tests/data/regression"""

--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,5 +1,4 @@
-# Copied originally from pandas. This config requires ruff >= 0.2.
-target-version = "py311"
+target-version = "py312"
 
 # fix = true
 lint.unfixable = []
@@ -42,10 +41,12 @@ lint.ignore = [
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
+  "PLC0415", # `import` should be at the top-level of a file
 ]
 
 extend-exclude = [
   "docs",
+  "build",
 ]
 
 [lint.pycodestyle]

--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -42,6 +42,7 @@ lint.ignore = [
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
   "PLC0415", # `import` should be at the top-level of a file
+  "PLW1641", # Class implements `__hash__` if `__eq__` is implemented
 ]
 
 extend-exclude = [


### PR DESCRIPTION
## Description
Update to conditionally skip some tests that fail without internet.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes
```
FAILED kadi/commands/tests/test_commands.py::test_get_cmds_from_event_all[4] - requests.exceptions.ConnectionError: HTTPSConnectionPool(host='occweb.cfa.harvard.edu', port=443): Max retries exceeded with url: /occweb/FOT...
FAILED kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_i-2024360-2025030.ecsv] - AssertionError: State tables have different lengths
FAILED kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_s-2024360-2025030.ecsv] - AssertionError: State tables have different lengths
FAILED kadi/commands/tests/test_states.py::test_regression[kadi/commands/tests/data/regression/hrc_15v-2024360-2025030.ecsv] - AssertionError: State tables have different lengths
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
Without internet run
```
(ska3-latest) flame:kadi jean$ pytest
============================================================== test session starts ===============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 216 items                                                                                                                              

kadi/commands/tests/test_commands.py .......ssssssssss..ss................................................ssss..s........                  [ 38%]
kadi/commands/tests/test_filter_events.py ss                                                                                               [ 39%]
kadi/commands/tests/test_states.py sssssssssssssssssssssssssssss....................x..........................                            [ 75%]
kadi/commands/tests/test_validate.py ssssssssssssssssssssss                                                                                [ 85%]
kadi/tests/test_events.py ..........                                                                                                       [ 89%]
kadi/tests/test_occweb.py ssssssssssssssssssssss                                                                                           [100%]

================================================================ warnings summary ================================================================
kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 123 passed, 92 skipped, 1 xfailed, 2 warnings in 8.47s =============================================
(
```
With internet run:
```
(ska3-latest) flame:kadi jean$ pytest
============================================================== test session starts ===============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 216 items                                                                                                                              

kadi/commands/tests/test_commands.py ....................................................................................                  [ 38%]
kadi/commands/tests/test_filter_events.py ..                                                                                               [ 39%]
kadi/commands/tests/test_states.py .................................................x..........................                            [ 75%]
kadi/commands/tests/test_validate.py ......................                                                                                [ 85%]
kadi/tests/test_events.py ..........                                                                                                       [ 89%]
kadi/tests/test_occweb.py ......................                                                                                           [100%]

================================================================ warnings summary ================================================================
kadi/kadi/commands/tests/test_commands.py: 88 warnings
kadi/kadi/commands/tests/test_filter_events.py: 23 warnings
kadi/kadi/commands/tests/test_states.py: 22 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

kadi/kadi/tests/test_events.py::test_overlapping_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 215 passed, 1 xfailed, 163 warnings in 155.05s (0:02:35)
```

```
ska3-latest) flame:kadi jean$ git rev-parse HEAD
6ade6d5aaa99f87b5b406a1c64448decde01a92c
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
