### PR TITLE
Add django 5.x compat for abstract class detection

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -138,9 +138,12 @@ def get_event_models(baseclass=None):
             # Make an instance of event class to discover if it is an abstact base class.
             try:
                 event = var()
-            except TypeError:
+            except TypeError as err:
                 # Probably an abstract base class that can't be instantiated
-                continue
+                if "Abstract models cannot be instantiated" in str(err):
+                    continue
+                else:
+                    raise
             else:
                 # Compatibility with Django < 1.8-ish
                 if not event._meta.abstract:


### PR DESCRIPTION
## Description

This provides compatibility for django 5.x in ska3-hope.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(django-5-compat) git rev-parse --short HEAD
56b8454
(ska3) ➜  kadi git:(django-5-compat) pytest  
========================================= test session starts ==========================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                    

kadi/commands/tests/test_commands.py ........................................................... [ 27%]
..........................                                                                       [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                     [ 40%]
kadi/commands/tests/test_states.py ...............................................x............. [ 68%]
.............                                                                                    [ 74%]
kadi/commands/tests/test_validate.py ......................                                      [ 85%]
kadi/tests/test_events.py ..........                                                             [ 89%]
kadi/tests/test_occweb.py ......................                                                 [100%]

============================== 214 passed, 1 xfailed in 100.70s (0:01:40) ==============================
(ska3) ➜  kadi git:(django-5-compat) conda activate ska3-hope  
(ska3-hope) ➜  kadi git:(django-5-compat) pytest
========================================= test session starts ==========================================
platform darwin -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 215 items                                                                                    

kadi/commands/tests/test_commands.py ........................................................... [ 27%]
..........................                                                                       [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                     [ 40%]
kadi/commands/tests/test_states.py ...............................................x............. [ 68%]
.............                                                                                    [ 74%]
kadi/commands/tests/test_validate.py ......................                                      [ 85%]
kadi/tests/test_events.py ..........                                                             [ 89%]
kadi/tests/test_occweb.py ......................                                                 [100%]

=========================================== warnings summary ===========================================
```

Independent check of unit tests by Jean
Tested on ska3 flight
- [x] Linux
```
Switched to a new branch 'django-5-compat'
ska3-jeanconn-kady> git rev-parse HEAD
56b84546b33cd8512ea8bf1cd242e7a34a04e64f
ska3-jeanconn-kady> pytest
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                                                                       

kadi/commands/tests/test_commands.py .....................................................................................                          [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                                                        [ 40%]
kadi/commands/tests/test_states.py ...............................................x..........................                                       [ 74%]
kadi/commands/tests/test_validate.py ......................                                                                                         [ 85%]
kadi/tests/test_events.py ..........                                                                                                                [ 89%]
kadi/tests/test_occweb.py ......................                                                                                                    [100%]

==================================================================== warnings summary =====================================================================
kadi/kadi/commands/tests/test_commands.py: 100 warnings
kadi/kadi/commands/tests/test_filter_events.py: 26 warnings
kadi/kadi/commands/tests/test_states.py: 24 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 214 passed, 1 xfailed, 178 warnings in 264.90s (0:04:24) =
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
