### PR TITLE
Improve robustness of OCCweb utilities and kadi commands

### DIFF
--- a/kadi/commands/commands_v2.py
+++ b/kadi/commands/commands_v2.py
@@ -1201,7 +1201,7 @@ def update_loads(scenario=None, *, lookback=None, stop_loads=None) -> Table:
 
         # Get directory listing for Year/Month
         try:
-            contents = retry_func(occweb.get_occweb_dir)(dir_year_month, timeout=5)
+            contents = occweb.get_occweb_dir(dir_year_month, timeout=5)
         except requests.exceptions.HTTPError as exc:
             if str(exc).startswith("404"):
                 logger.debug(f"No OCCweb directory for {dir_year_month}")
@@ -1300,13 +1300,11 @@ def get_load_cmds_from_occweb_or_local(
             raise ValueError(f"No backstop file found in {ska_dir}")
 
     else:  # use OCCweb
-        load_dir_contents = retry_func(occweb.get_occweb_dir)(
-            dir_year_month / load_name, timeout=5
-        )
+        load_dir_contents = occweb.get_occweb_dir(dir_year_month / load_name, timeout=5)
         for filename in load_dir_contents["Name"]:
             if re.match(r"CR\d{3}.\d{4}\.backstop", filename):
                 # Download the backstop file from OCCweb
-                backstop_text = retry_func(occweb.get_occweb_page)(
+                backstop_text = occweb.get_occweb_page(
                     dir_year_month / load_name / filename,
                     cache=conf.cache_loads_in_astropy_cache,
                     timeout=10,

--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -12,7 +12,6 @@ from chandra_time import DateTime
 from cheta import utils
 from django.db import models
 from Quaternion import Quat
-from ska_helpers.retry import retry_func
 from ska_numpy import interpolate
 
 from .manvr_templates import get_manvr_templates
@@ -2150,7 +2149,7 @@ class IFotEvent(BaseEvent):
         datestop = DateTime(stop).date
 
         # def get_ifot(event_type, start=None, stop=None, props=[], columns=[], timeout=TIMEOUT):
-        ifot_evts = retry_func(occweb.get_ifot)(
+        ifot_evts = occweb.get_ifot(
             cls.ifot_type_desc,
             start=datestart,
             stop=datestop,

--- a/kadi/events/scrape.py
+++ b/kadi/events/scrape.py
@@ -3,7 +3,6 @@ import re
 
 from bs4 import BeautifulSoup as parse_html
 from chandra_time import DateTime
-from ska_helpers.retry import retry_func
 
 from kadi import occweb
 
@@ -68,7 +67,7 @@ def get_fdb_major_events():
     if page in evts_cache:
         return evts_cache[page]
 
-    html = retry_func(occweb.get_url)(page)
+    html = occweb.get_url(page)
     soup = parse_html(html, "lxml")
     table = soup.find("table")
     rows = get_table_rows(table)
@@ -114,7 +113,7 @@ def get_fot_major_events():
     if page in evts_cache:
         return evts_cache[page]
 
-    html = retry_func(occweb.get_url)(page)
+    html = occweb.get_url(page)
     soup = parse_html(html, "lxml")
     major_events_span = soup.find("span", string="Major Events:")
     if major_events_span is None:


### PR DESCRIPTION
## Description

Network access to OCCweb and google sheets fail or timeout with a frequency that causes cron job warnings/errors with some regularity. This PR addresses that in two ways:
- Update all the `occweb` utility functions to retry the internal web access calls 3 times with a delay of 1 sec and backoff of 2 (so: 1 sec then 2 sec delay).
- Update kadi commands to retry the google sheet access with the default retry parameters.

It also reduces the timeout for some "lightweight" network requests from 30 seconds to 5 seconds. In general if these do not succeed in the first second or so they are not going to work.

## Requires

- https://github.com/sot/ska_helpers/pull/64

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Makes all the `kadi.occweb.get_*` functions retry 3 times. There is no convenient way to disable this feature.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(more-retry-for-commands) git rev-parse --short HEAD                                     
b9bb9d1
(ska3) ➜  kadi git:(more-retry-for-commands) env PYTHONPATH=/Users/aldcroft/git/ska_helpers pytest
================================================ test session starts =================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                                  

kadi/commands/tests/test_commands.py ......................................................................... [ 33%]
............                                                                                                   [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                   [ 40%]
kadi/commands/tests/test_states.py ...............................................x..........................  [ 74%]
kadi/commands/tests/test_validate.py ......................                                                    [ 85%]
kadi/tests/test_events.py ..........                                                                           [ 89%]
kadi/tests/test_occweb.py ......................                                                               [100%]

===================================== 214 passed, 1 xfailed in 112.17s (0:01:52) =====================================
```

Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-kady> pytest
=============================================== test session starts ===============================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                               

kadi/commands/tests/test_commands.py ...................................................................... [ 32%]
...............                                                                                             [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                [ 40%]
kadi/commands/tests/test_states.py ...............................................x........................ [ 73%]
..                                                                                                          [ 74%]
kadi/commands/tests/test_validate.py ......................                                                 [ 85%]
kadi/tests/test_events.py ..........                                                                        [ 89%]
kadi/tests/test_occweb.py ......................                                                            [100%]

================================================ warnings summary =================================================
kadi/kadi/commands/tests/test_commands.py: 102 warnings
kadi/kadi/commands/tests/test_filter_events.py: 28 warnings
kadi/kadi/commands/tests/test_states.py: 26 warnings
kadi/kadi/commands/tests/test_validate.py: 9 warnings
kadi/kadi/tests/test_occweb.py: 19 warnings
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================ 214 passed, 1 xfailed, 184 warnings in 250.14s (0:04:10) =============================
ska3-jeanconn-kady> echo $PYTHONPATH
/home/jeanconn/git/ska_helpers
ska3-jeanconn-kady> git rev-parse HEAD
b9bb9d152de87f93aa70436e8a77d680f1ed2f0d
ska3-jeanconn-kady> python -c "import ska_helpers; print(ska_helpers.__version__)"
0.19.1.dev7+g92558a6
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
