### PR TITLE
Change from deprecated np.chararray to np.char for encode

### DIFF
--- a/kadi/commands/core.py
+++ b/kadi/commands/core.py
@@ -326,9 +326,9 @@ def get_cmds_from_backstop(backstop, remove_starcat=False):
     out = {}
     # Set idx to -1 so it does not match any real idx
     out["idx"] = np.full(n_bs, fill_value=-1, dtype=np.int32)
-    out["date"] = np.chararray.encode(bs["date"])
-    out["type"] = np.chararray.encode(bs["type"])
-    out["tlmsid"] = np.chararray.encode(bs["tlmsid"])
+    out["date"] = np.char.encode(bs["date"])
+    out["type"] = np.char.encode(bs["type"])
+    out["tlmsid"] = np.char.encode(bs["tlmsid"])
     out["scs"] = bs["scs"].astype(np.uint8)
     out["step"] = bs["step"].astype(np.uint16)
     out["time"] = CxoTime(bs["date"], format="date").secs


### PR DESCRIPTION
## Description

This fixes an easy deprecation warning `np.chararray.encode` => `np.char.encode`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(use-np-char-not-chararray) git rev-parse --short HEAD
7da8085
```
#### ska3-flight
```
(ska3) ➜  kadi git:(use-np-char-not-chararray) pytest
========================================= test session starts ==========================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                    

kadi/commands/tests/test_commands.py ........................................................... [ 27%]
..........................                                                                       [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                     [ 40%]
kadi/commands/tests/test_states.py ...............................................x............. [ 68%]
.............                                                                                    [ 74%]
kadi/commands/tests/test_validate.py ......................                                      [ 85%]
kadi/tests/test_events.py ..........                                                             [ 89%]
kadi/tests/test_occweb.py ......................                                                 [100%]

============================== 214 passed, 1 xfailed in 100.32s (0:01:40) ==============================
```
### ska3-hope
```
(ska3-hope) ➜  kadi git:(use-np-char-not-chararray) pytest                  
========================================= test session starts ==========================================
platform darwin -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 215 items                                                                                    

kadi/commands/tests/test_commands.py ........................................................... [ 27%]
..........................                                                                       [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                     [ 40%]
kadi/commands/tests/test_states.py ...............................................x............. [ 68%]
.............                                                                                    [ 74%]
kadi/commands/tests/test_validate.py ......................                                      [ 85%]
kadi/tests/test_events.py ..........                                                             [ 89%]
kadi/tests/test_occweb.py ......................                                                 [100%]

=========================================== warnings summary ===========================================
kadi/commands/tests/test_states.py:12
  /Users/aldcroft/git/kadi/kadi/commands/tests/test_states.py:12: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguious
  and fails to parse leap day. The default behavior will change in Python 3.15
  to either always raise an exception or to use a different default year (TBD).
  To avoid trouble, add a specific year to the input & format.
  See https://github.com/python/cpython/issues/70647.
    from cheta import fetch

kadi/kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateACISStatePower]
  /Users/aldcroft/miniconda3-arm/envs/ska3-hope/lib/python3.13/site-packages/sklearn/base.py:442: InconsistentVersionWarning: Trying to unpickle estimator MLPRegressor from version 1.6.0 when using version 1.7.2. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
  https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
    warnings.warn(

kadi/kadi/commands/tests/test_validate.py::test_validate_regression[False-ValidateACISStatePower]
  /Users/aldcroft/miniconda3-arm/envs/ska3-hope/lib/python3.13/site-packages/sklearn/base.py:442: InconsistentVersionWarning: Trying to unpickle estimator MinMaxScaler from version 1.6.0 when using version 1.7.2. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
  https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
    warnings.warn(
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
