### PR TITLE
Set Orbit event dict with Python native types not numpy types

### DIFF
--- a/kadi/events/models.py
+++ b/kadi/events/models.py
@@ -2552,7 +2552,7 @@ class Orbit(BaseEvent):
         events = []
         for orbit in orbits:
             ok = orbit_points["orbit_num"] == orbit["orbit_num"]
-            event = {key: orbit[key] for key in orbit.dtype.names}
+            event = {key: orbit[key].item() for key in orbit.dtype.names}
             event["foreign"] = {
                 "OrbitPoint": orbit_points[ok],
                 "RadZone": [orbit_funcs.get_radzone_from_orbit(orbit)],


### PR DESCRIPTION
## Description

This fixes a latent issue where the `Orbit` model event dict (used to create the model instance) was being populated with numpy scalars like `np.int32(3264)` instead of the expected Python scalars like `3264` (int). This was previously working because of a deprecated numpy behavior where comparing `np.int32(3264)` to an empty list was returning False. In numpy > 2.0 this now raises an exception.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2026.0rc4) ➜  kadi git:(use-python-types-for-orbit-event) git rev-parse --short HEAD   
586cbad
(ska3-flight-2026.0rc4) ➜  kadi git:(use-python-types-for-orbit-event) pytest
======================================= test session starts =======================================
platform darwin -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 215 items                                                                               

kadi/commands/tests/test_commands.py ...................................................... [ 25%]
...............................                                                             [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                [ 40%]
kadi/commands/tests/test_states.py ...............................................x........ [ 66%]
..................                                                                          [ 74%]
kadi/commands/tests/test_validate.py ......................                                 [ 85%]
kadi/tests/test_events.py ..........                                                        [ 89%]
kadi/tests/test_occweb.py ......................                                            [100%]

======================================== warnings summary =========================================
```

Independent check of unit tests by Javier
- [ ] Linux
```
(ska3-flight) jgonzale kadi $ git rev-parse HEAD
586cbad2bb1784dc098e944399467b0c0fdf5c8a
(ska3-flight) jgonzale kadi $ pytest kadi
==================================================================== test session starts =====================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 215 items                                                                                                                                          

kadi/commands/tests/test_commands.py .....................................................................................                             [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                                                           [ 40%]
kadi/commands/tests/test_states.py ...............................................x..........................                                          [ 74%]
kadi/commands/tests/test_validate.py ......................                                                                                            [ 85%]
kadi/tests/test_events.py ..........                                                                                                                   [ 89%]
kadi/tests/test_occweb.py ......................                                                                                                       [100%]

========================================================= 214 passed, 1 xfailed in 268.89s (0:04:28) =========================================================

```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Confirmed that the original issue seen in `ska_testr` testing is resolved.
```
# In the repo directory
$ cp $SKA/data/kadi/events3.db3 ./

# Without this PR, running this fails in the same way noted on Slack. WITH the PR
# it runs successfully.
$ python -m kadi.scripts.update_events --model Orbit --start 2025:300 --delete-from-start
```
