### PR TITLE
Make small change to get rid of deprecation warning

### DIFF
--- a/kadi/scripts/validate_states.py
+++ b/kadi/scripts/validate_states.py
@@ -170,7 +170,7 @@ def get_violations_text(violations: list[dict]) -> str:
         Text for alert
     """
     lines = ["kadi validate_states processing found state violation(s):", ""]
-    lines.extend(Table(violations).pformat(max_lines=-1, max_width=-1))
+    lines.extend(Table(violations).pformat())
     lines.extend(["", "See:https://cxc.harvard.edu/mta/ASPECT/validate_states/", ""])
     text = "\n".join(lines)
     return text


### PR DESCRIPTION
This PR replaces a call to Table.pformat_all with Table.pformat(max_lines=-1, max_width=-1).

Currently, this issues a warning:
```
WARNING: AstropyDeprecationWarning: The pformat_all function is deprecated and may be removed in a future version.
```

The only question is whether if you are ok with `max_lines=-1, max_width=-1`

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
