### PR TITLE
Skip custom scenario test and new flight scenario test if no internet

### DIFF
--- a/kadi/commands/tests/test_commands.py
+++ b/kadi/commands/tests/test_commands.py
@@ -1213,6 +1213,7 @@ def patched_read_cmd_events_from_sheet(doc_id):
     return evts
 
 
+@pytest.mark.skipif(not HAS_INTERNET, reason="No internet connection")
 def test_flight_scenario_sheet_access():
     """Test that flight scenario does not access the google command events sheet"""
     with kadi.commands.conf.set_temp("cmd_events_flight_id", "id-does-not-exist"):


### PR DESCRIPTION
## Description

Skip custom scenario test and flight scenario check if no internet.  The tests need internet access to the google sheet.

The more complete issue is fixed in #375, but these tests can safely be skipped in advance of that PR.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2026.1rc5) flame:kadi jean$ git checkout skip-custom-test-no-internet
Switched to branch 'skip-custom-test-no-internet'
(ska3-flight-2026.1rc5) flame:kadi jean$ pytest 
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 220 items                                                                                                                                                                            

kadi/commands/tests/test_commands.py .......................................................................................                                                             [ 39%]
kadi/commands/tests/test_filter_events.py ..                                                                                                                                             [ 40%]
kadi/commands/tests/test_states.py .................................................x..........................                                                                          [ 75%]
kadi/commands/tests/test_validate.py ......................                                                                                                                              [ 85%]
kadi/tests/test_events.py ..........                                                                                                                                                     [ 89%]
kadi/tests/test_occweb.py .......................                                                                                                                                        [100%]

========================================================================== 219 passed, 1 xfailed in 180.06s (0:03:00) ==========================================================================
(ska3-flight-2026.1rc5) flame:kadi jean$ pytest
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 220 items                                                                                                                                                                            

kadi/commands/tests/test_commands.py .......sssssssssss..ss..................................ss..............ssss..s........                                                             [ 39%]
kadi/commands/tests/test_filter_events.py ss                                                                                                                                             [ 40%]
kadi/commands/tests/test_states.py sssssssssssssssssssssssssssss....................x..........................                                                                          [ 75%]
kadi/commands/tests/test_validate.py ssssssssssssssssssssss                                                                                                                              [ 85%]
kadi/tests/test_events.py ..........                                                                                                                                                     [ 89%]
kadi/tests/test_occweb.py sssssssssssssssssssssss                                                                                                                                        [100%]

========================================================================== 123 passed, 96 skipped, 1 xfailed in 9.93s ==========================================================================
(ska3-flight-2026.1rc5) flame:kadi jean$ git rev-parse HEAD
a4b8dea84a4180803b61ad47745f0cfee37d5c66
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
