### PR TITLE
Fix the absolute path handling to work on Windows

### DIFF
--- a/kadi/occweb.py
+++ b/kadi/occweb.py
@@ -303,11 +303,11 @@ def get_occweb_page(
     if isinstance(path, str) and path.startswith("https://occweb"):
         url = path
     else:
-        path = Path(path)
         # Handle the case of providing an absolute path into the OCCweb tree, e.g.
-        # /FOT/mission_planning/Backstop instead of FOT/mission_planning/Backstop.
-        if path.is_absolute():
-            path = path.relative_to(path.anchor)
+        # "/FOT/mission_planning/Backstop" instead of "FOT/mission_planning/Backstop".
+        # At this point `path` can (in theory) be a Path, so handle that in a platform
+        # independent way.
+        path = Path(path).as_posix().lstrip("/")
         url = ROOTURL + (Path("/occweb") / path).as_posix()
 
     logger.info(f"Getting OCCweb {path} with {cache=}")


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #377 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Windows - (this ska is a little older and I didn't try to figure out why it does all this printing, but the tests passed.
```
(ska3-matlab-2026.2rc2)
jean@FLICKER CLANGARM64 ~/git/kadi (fix-windows-absolute-path-bug)
$ pytest
==================================================== test session starts ====================================================
platform win32 -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: C:\Users\jean\git\kadi
plugins: anyio-4.12.1, timeout-2.4.0
collected 219 items

kadi\commands\tests\test_commands.py .......2026-02-26 08:46:39,087 read_cmd_events_from_sheet: Getting cmd_events from https://docs.google.com/spreadsheets/d/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ/export?format=csv
2026-02-26 08:46:39,649 get_cmd_events_from_sheet: Writing 168 cmd_events to C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\cmd_events.csv
2026-02-26 08:46:39,665 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT with cache=False
2026-02-26 08:46:40,031 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT1821A with cache=False
2026-02-26 08:46:41,250 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT1821A/CR290_2101.backstop with cache=True
2026-02-26 08:46:41,324 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\OCT1821A.pkl.gz
2026-02-26 08:46:41,337 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521A with cache=False
2026-02-26 08:46:41,550 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521A/CR297_1402.backstop with cache=True
2026-02-26 08:46:41,631 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\OCT2521A.pkl.gz
2026-02-26 08:46:41,646 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521B with cache=False
2026-02-26 08:46:41,841 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2521B/CR298_0204.backstop with cache=True
2026-02-26 08:46:41,913 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\OCT2521B.pkl.gz
2026-02-26 08:46:41,927 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2821A with cache=False
2026-02-26 08:46:42,127 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT2821A/CR301_2101.backstop with cache=True
2026-02-26 08:46:42,253 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\OCT2821A.pkl.gz
2026-02-26 08:46:42,261 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT3021A with cache=False
2026-02-26 08:46:42,446 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/OCT/OCT3021A/CR303_2205.backstop with cache=True
2026-02-26 08:46:42,549 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\OCT3021A.pkl.gz
2026-02-26 08:46:42,570 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV with cache=False
2026-02-26 08:46:42,726 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV0821A with cache=False
2026-02-26 08:46:42,917 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV0821A/CR312_0801.backstop with cache=True
2026-02-26 08:46:43,019 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\NOV0821A.pkl.gz
2026-02-26 08:46:43,037 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV1521A with cache=False
2026-02-26 08:46:43,266 get_occweb_page: Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2021/NOV/NOV1521A/CR318_2001.backstop with cache=True
2026-02-26 08:46:43,349 write_backstop: Saving C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\loads\NOV1521A.pkl.gz
2026-02-26 08:46:43,368 update_cmd_events_and_loads_and_get_cmds_recent: Including loads OCT1821A, OCT2521A, OCT2521B, OCT2821A, OCT3021A, NOV0821A, NOV1521A
2026-02-26 08:46:43,382 update_cmd_events_and_loads_and_get_cmds_recent: Load OCT1821A has 1362 commands with RLTT=2021:290:21:37:46.377
2026-02-26 08:46:43,396 update_cmd_events_and_loads_and_get_cmds_recent: Load OCT2521A has 72 commands with RLTT=None
2026-02-26 08:46:43,407 update_cmd_events_and_loads_and_get_cmds_recent: Load OCT2521B has 1375 commands with RLTT=2021:298:01:57:00.000
2026-02-26 08:46:43,418 update_cmd_events_and_loads_and_get_cmds_recent: Load OCT2821A has 357 commands with RLTT=2021:301:21:38:28.115
2026-02-26 08:46:43,431 update_cmd_events_and_loads_and_get_cmds_recent: Load OCT3021A has 2158 commands with RLTT=2021:303:22:31:59.642
2026-02-26 08:46:43,442 update_cmd_events_and_loads_and_get_cmds_recent: Load NOV0821A has 1608 commands with RLTT=2021:312:08:17:31.883
2026-02-26 08:46:43,454 update_cmd_events_and_loads_and_get_cmds_recent: Load NOV1521A has 1587 commands with RLTT=2021:318:20:10:00.000
2026-02-26 08:46:43,504 update_cmd_events_and_loads_and_get_cmds_recent: Including cmd_events:
  Obsid at 2021:301:23:42:01
  Observing not run at 2021:301:18:00:00
  SCS-107 at 2021:301:16:35:54
  Maneuver at 2021:297:01:41:01
  Load not run at 2021:296:10:41:57
  Obsid at 2021:296:10:42:20
  NSM at 2021:296:10:41:57
2026-02-26 08:46:43,540 update_cmd_events_and_loads_and_get_cmds_recent: Processing OCT1821A with 1362 commands
2026-02-26 08:46:43,541 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1362 commands from OCT1821A
2026-02-26 08:46:43,542 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT Load_not_run at 2021:296:10:41:57.000 with 1 commands
2026-02-26 08:46:43,542 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1 commands from CMD_EVT Load_not_run at 2021:296:10:41:57.000
2026-02-26 08:46:43,542 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT NSM at 2021:296:10:41:57.000 with 14 commands
2026-02-26 08:46:43,543 update_cmd_events_and_loads_and_get_cmds_recent: Removing 207 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT1821A due to DISABLE SCS in CMD_EVT at 2021:296:10:41:57.000
2026-02-26 08:46:43,544 update_cmd_events_and_loads_and_get_cmds_recent: Adding 14 commands from CMD_EVT NSM at 2021:296:10:41:57.000
2026-02-26 08:46:43,544 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT Obsid at 2021:296:10:42:20.000 with 1 commands
2026-02-26 08:46:43,544 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1 commands from CMD_EVT Obsid at 2021:296:10:42:20.000
2026-02-26 08:46:43,544 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT Maneuver at 2021:297:01:41:01.000 with 4 commands
2026-02-26 08:46:43,545 update_cmd_events_and_loads_and_get_cmds_recent: Adding 4 commands from CMD_EVT Maneuver at 2021:297:01:41:01.000
2026-02-26 08:46:43,545 update_cmd_events_and_loads_and_get_cmds_recent: Processing OCT2521A with 72 commands
2026-02-26 08:46:43,545 update_cmd_events_and_loads_and_get_cmds_recent: Adding 72 commands from OCT2521A
2026-02-26 08:46:43,545 update_cmd_events_and_loads_and_get_cmds_recent: Processing OCT2521B with 1375 commands
2026-02-26 08:46:43,547 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1375 commands from OCT2521B
2026-02-26 08:46:43,547 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT SCS-107 at 2021:301:16:35:54.000 with 9 commands
2026-02-26 08:46:43,548 update_cmd_events_and_loads_and_get_cmds_recent: Removing 231 cmds in SCS slots [131, 132, 133] from OCT2521B due to DISABLE SCS in CMD_EVT at 2021:301:16:35:54.000
2026-02-26 08:46:43,549 update_cmd_events_and_loads_and_get_cmds_recent: Adding 9 commands from CMD_EVT SCS-107 at 2021:301:16:35:54.000
2026-02-26 08:46:43,549 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT Observing_not_run at 2021:301:18:00:00.000 with 1 commands
2026-02-26 08:46:43,549 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1 commands from CMD_EVT Observing_not_run at 2021:301:18:00:00.000
2026-02-26 08:46:43,549 update_cmd_events_and_loads_and_get_cmds_recent: Processing OCT2821A with 357 commands
2026-02-26 08:46:43,550 update_cmd_events_and_loads_and_get_cmds_recent: Removing 332 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT2521B due to RLTT in OCT2821A
2026-02-26 08:46:43,552 update_cmd_events_and_loads_and_get_cmds_recent: Adding 357 commands from OCT2821A
2026-02-26 08:46:43,552 update_cmd_events_and_loads_and_get_cmds_recent: Processing CMD_EVT Obsid at 2021:301:23:42:01.000 with 1 commands
2026-02-26 08:46:43,553 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1 commands from CMD_EVT Obsid at 2021:301:23:42:01.000
2026-02-26 08:46:43,553 update_cmd_events_and_loads_and_get_cmds_recent: Processing OCT3021A with 2158 commands
2026-02-26 08:46:43,554 update_cmd_events_and_loads_and_get_cmds_recent: Removing 84 cmds in SCS slots [128, 129, 130, 131, 132, 133] from OCT2821A due to RLTT in OCT3021A
2026-02-26 08:46:43,556 update_cmd_events_and_loads_and_get_cmds_recent: Adding 2158 commands from OCT3021A
2026-02-26 08:46:43,557 update_cmd_events_and_loads_and_get_cmds_recent: Processing NOV0821A with 1608 commands
2026-02-26 08:46:43,557 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1608 commands from NOV0821A
2026-02-26 08:46:43,557 update_cmd_events_and_loads_and_get_cmds_recent: Processing NOV1521A with 1587 commands
2026-02-26 08:46:43,558 update_cmd_events_and_loads_and_get_cmds_recent: Adding 1587 commands from NOV1521A
2026-02-26 08:46:44,006 get_cmds_obs_final: No starcat for obsid 0 at 2021:297:02:05:11.042 even though npnt_enab is True
2026-02-26 08:46:44,140 _update_cmds_archive: Appending 7814 new commands after removing 0 from existing archive
2026-02-26 08:46:44,140 _update_cmds_archive:  starting with cmds_arch[:0] and adding cmds_recent[0:7814]
2026-02-26 08:46:44,145 _update_cmds_archive: Writing 7814 commands to C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\cmds2.h5
2026-02-26 08:46:44,210 _update_cmds_archive: Writing updated pars_dict to C:\Users\jean\AppData\Local\Temp\pytest-of-jean\pytest-3\test_commands_create_archive_r0\cmds2.pkl
..................................................s....................... [ 36%]
.......                                                                                                                [ 40%]
kadi\commands\tests\test_filter_events.py ..                                                                           [ 41%]
kadi\commands\tests\test_states.py ...............................................x..........................          [ 74%]
kadi\commands\tests\test_validate.py ......................                                                            [ 84%]
kadi\tests\test_events.py ..........                                                                                   [ 89%]
kadi\tests\test_occweb.py .......................                                                                      [100%]

=================================== 217 passed, 1 skipped, 1 xfailed in 252.28s (0:04:12) 
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
