### PR TITLE
Support HRC 15V On from SCS-85 activation

### DIFF
--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -448,6 +448,10 @@ class FixedTransition(BaseTransition):
     :param transition_val: single transition value or list of values
     """
 
+    # If specified set the time delta for actual transition relative to command time.
+    # This should be an astropy time Quantity like 10 * u.s.
+    time_delta = None
+
     @classmethod
     def set_transitions(cls, transitions_list: list[Transition], cmds, start, stop):
         """
@@ -478,7 +482,10 @@ class FixedTransition(BaseTransition):
             attrs = [attrs]
 
         for cmd in state_cmds:
-            transitions_list.append(Transition(cmd["date"], zip(attrs, vals)))  # noqa: PERF401
+            date = cmd["date"]
+            if cls.time_delta is not None:
+                date = (CxoTime(date) + cls.time_delta).date
+            transitions_list.append(Transition(date, zip(attrs, vals)))  # noqa: PERF401
 
 
 class ParamTransition(BaseTransition):

--- a/kadi/commands/states.py
+++ b/kadi/commands/states.py
@@ -803,6 +803,23 @@ class Hrc15vOn_SCS134_Transition(FixedTransition):
     default_value = "ON"
 
 
+class Hrc15vOn_SCS85_Transition(FixedTransition):
+    """HRC 15V ON from SCS-85
+
+    This is the default in operations following release of MATLAB 2026_020
+    and supercedes commanding of SCS-134.
+    """
+
+    command_attributes = {"tlmsid": "COACTSX", "coacts1": 85}
+    state_keys = ["hrc_15v"]
+    transition_key = "hrc_15v"
+    transition_val = "ON"
+    default_value = "ON"
+    # Actual 15V on is 22.166 s after SCS-85 activation. Source: K. Gage communication
+    # 2026-03-31.
+    time_delta = 22.166 * u.s
+
+
 class Hrc15vOff_Transition(FixedTransition):
     """HRC 15V OFF"""
 


### PR DESCRIPTION
## Description

With the release of MATLAB tools 2026_020, load commanding is updated so that the HRC 15V power supply is turned on via activation of SCS-85. Previously this was done via SCS-134.

This PR adds support for setting the `hrc_15v` state to `ON` at a time 22.166 seconds after the SCS-85 activation command. The time delay was provided by K. Gage.

To support the time delay, a new `time_delay` class attribute was added to the `FixedTransition` class. The code for this is straightforward.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None. 

This is back-compatible with older loads that use SCS-134 since the state-changing class that watches for SCS-134 has not been removed. There are currently no plans to repurpose SCS-134 since that SCS is quite small. If that did happen it would be possible to have the state transition depend on the date of the command.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  kadi git:(hrc-scs-85-commanding) git rev-parse --short HEAD
b630b31
(ska3) ➜  kadi git:(hrc-scs-85-commanding) pytest 
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 313 items                                                                                                                                               

kadi/commands/tests/test_commands.py ...............................................................s..............................                         [ 30%]
kadi/commands/tests/test_commands_v2.py ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss                            [ 58%]
kadi/commands/tests/test_filter_events.py ..                                                                                        [ 58%]
kadi/commands/tests/test_states.py ...............................................x..........................                       [ 82%]
kadi/commands/tests/test_validate.py ......................                                                                         [ 89%]
kadi/tests/test_events.py ..........                                                                                                [ 92%]
kadi/tests/test_occweb.py .......................                                                                                   [100%]

========================================= 223 passed, 89 skipped, 1 xfailed in 109.54s (0:01:49) ==========================================
```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-matlab-2026.4rc1) jeanconn-kady> pytest
==================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.1
collected 313 items                                                                                                                                                                                                         

kadi/commands/tests/test_commands.py ...............................................................s..............................                                                                                   [ 30%]
kadi/commands/tests/test_commands_v2.py ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss                                                                                      [ 58%]
kadi/commands/tests/test_filter_events.py ..                                                                                                                                                                          [ 58%]
kadi/commands/tests/test_states.py ...............................................x..........................                                                                                                         [ 82%]
kadi/commands/tests/test_validate.py ......................                                                                                                                                                           [ 89%]
kadi/tests/test_events.py ..........                                                                                                                                                                                  [ 92%]
kadi/tests/test_occweb.py .......................                                                                                                                                                                     [100%]

================================================================================== 223 passed, 89 skipped, 1 xfailed in 326.94s (0:05:26) ===================================================================================
(ska3-matlab-2026.4rc1) jeanconn-kady> git rev-parse HEAD
b630b319017b3b15292b011c651408a2e6e875e3
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The following script (run in this repo directory) provides the following output.
#### Script
```
import kadi.commands as kc
import kadi.commands.states as kcs

# Read the backstop file for the FEB1626T test loads and get the HRC states
cmds = kc.read_backstop("FEB1626T.backstop")
states = kcs.get_states(cmds=cmds, state_keys=["hrc_s", "hrc_i", "hrc_15v", "hrc_24v"])

states.pprint_exclude_names = ["tstart", "tstop"]
states.pprint_all()
```
#### Output
The SCS-85 activation times are listed below:
- `2026:048:18:51:11.027`
- `2026:049:13:09:34.924`
 
The `hrc_15v` `ON` times are 22 seconds afterward.
```
      datestart              datestop       hrc_s hrc_i hrc_15v hrc_24v trans_keys
--------------------- --------------------- ----- ----- ------- ------- ----------
2026:046:22:04:13.413 2026:048:18:51:33.193   OFF   OFF     OFF     OFF           
2026:048:18:51:33.193 2026:048:18:52:37.027   OFF   OFF      ON     OFF    hrc_15v
2026:048:18:52:37.027 2026:048:20:07:44.027   OFF    ON      ON     OFF      hrc_i
2026:048:20:07:44.027 2026:048:20:07:45.027   OFF    ON      ON     OFF      hrc_s
2026:048:20:07:45.027 2026:048:20:07:57.027   OFF   OFF      ON     OFF      hrc_i
2026:048:20:07:57.027 2026:049:13:09:57.090   OFF   OFF     OFF     OFF    hrc_15v
2026:049:13:09:57.090 2026:049:13:11:00.924   OFF   OFF      ON     OFF    hrc_15v
2026:049:13:11:00.924 2026:049:14:37:47.924   OFF    ON      ON     OFF      hrc_i
2026:049:14:37:47.924 2026:049:14:37:48.924   OFF    ON      ON     OFF      hrc_s
2026:049:14:37:48.924 2026:049:14:38:00.924   OFF   OFF      ON     OFF      hrc_i
2026:049:14:38:00.924 2026:054:01:55:44.837   OFF   OFF     OFF     OFF    hrc_15v
```

I also confirmed that without this patch, the states show `hrc_15v` in the `OFF` state for the entire load.